### PR TITLE
rewrite annotation decorators for consistent getter/setter/deleter be…

### DIFF
--- a/deriva/core/__init__.py
+++ b/deriva/core/__init__.py
@@ -15,7 +15,7 @@ from collections import OrderedDict
 from distutils.util import strtobool
 from pkg_resources import parse_version, get_distribution, DistributionNotFound
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 
 IS_PY2 = (sys.version_info[0] == 2)
 IS_PY3 = (sys.version_info[0] == 3)

--- a/deriva/transfer/upload/deriva_upload.py
+++ b/deriva/transfer/upload/deriva_upload.py
@@ -327,7 +327,7 @@ class DerivaUpload(object):
 
     def getRemoteConfig(self):
         catalog_config = CatalogConfig.fromcatalog(self.catalog)
-        return catalog_config.annotation_obj("tag:isrd.isi.edu,2017:bulk-upload")
+        return catalog_config.bulk_upload
 
     def getUpdatedConfig(self):
         # if we are using an overridden config file, skip the update check


### PR DESCRIPTION
…havior

The special annotation interfaces, e.g.:

1. table.table_display
2. table.table_display["x"] = "y"
3. table.table_display = {"x": "y"}
4. del table.table_display
5. column.immutable
6. column.immutable = True
7. column.immutable = False
8. del column.immutable

All work convienently as sugar for generic access, e.g.:

1. table.annotations.get(tag.table_display, {})
2. tmp = table.annotations.get(tag.table_display, {})
   tmp["x"] = "y"
3. table.annotations[tag.table_display] = {"x": "y"}
4. table.annotations.pop(tag.table_display, None)
5. tag.immutable in column.annotations
6. column.annotations[tag.immutable] = None
7. column.annotations.pop(tag.immutable, None)
8. column.annotations.pop(tag.immutable, None)