### PR TITLE
Datapath for R

### DIFF
--- a/deriva/core/datapath.py
+++ b/deriva/core/datapath.py
@@ -4,11 +4,6 @@ import logging
 import re
 from requests import HTTPError
 
-try:
-    from pandas import DataFrame as _DataFrame
-except ImportError:
-    _DataFrame = None
-
 logger = logging.getLogger(__name__)
 """Logger for this module"""
 
@@ -324,12 +319,14 @@ class EntitySet (object):
 
     @property
     def dataframe(self):
-        """Pandas DataFrame representation of this path."""
+        """Pandas DataFrame representation of this path.
+
+        :return: a pandas dataframe object
+        :raise ImportError: exception if the 'pandas' library is not available
+        """
         if not self._dataframe:
-            if _DataFrame:
-                self._dataframe = _DataFrame(self._results)
-            else:
-                logger.debug("'pandas' package not installed")
+            from pandas import DataFrame
+            self._dataframe = DataFrame(self._results)
         return self._dataframe
 
     def __len__(self):

--- a/deriva/core/datapath.py
+++ b/deriva/core/datapath.py
@@ -79,7 +79,7 @@ class Catalog (object):
         }
 
     def __dir__(self):
-        return list(super(Catalog, self).__dir__()) + [key for key in self.schemas if _isidentifier(key)]
+        return list(dir(super(Catalog, self))) + [key for key in self.schemas if _isidentifier(key)]
 
     def __getattr__(self, a):
         return self.schemas[a]
@@ -101,7 +101,7 @@ class Schema (object):
         }
 
     def __dir__(self):
-        return list(super(Schema, self).__dir__()) + [key for key in self.tables if _isidentifier(key)]
+        return list(dir(super(Schema, self))) + [key for key in self.tables if _isidentifier(key)]
 
     def __getattr__(self, a):
         return self.tables[a]
@@ -128,7 +128,7 @@ class DataPath (object):
         self._bind_table_instance(root)
 
     def __dir__(self):
-        return list(super(DataPath, self).__dir__()) + self._identifiers
+        return list(dir(super(DataPath, self))) + self._identifiers
 
     def __getattr__(self, a):
         return self._table_instances[a]
@@ -362,7 +362,7 @@ class Table (object):
         }
 
     def __dir__(self):
-        return list(super(Table, self).__dir__()) + [key for key in self.column_definitions if _isidentifier(key)]
+        return list(dir(super(Table, self))) + [key for key in self.column_definitions if _isidentifier(key)]
 
     def __getattr__(self, a):
         return self.column_definitions[a]

--- a/deriva/core/datapath.py
+++ b/deriva/core/datapath.py
@@ -57,7 +57,6 @@ class DataPathException (Exception):
     """
     def __init__(self, message, reason=None):
         super(DataPathException, self).__init__(message, reason)
-        assert isinstance(message, str)
         self.message = message
         self.reason = reason
 
@@ -678,7 +677,8 @@ class Column (object):
         :param other: a _string_ literal value.
         :return: a filter predicate object
         """
-        assert isinstance(other, str), "This comparison only supports string literals."
+        if not isinstance(other, str):
+            logger.warning("'regexp' method comparison only supports string literals.")
         return FilterPredicate(self, "::regexp::", other)
 
     def ciregexp(self, other):
@@ -687,7 +687,8 @@ class Column (object):
         :param other: a _string_ literal value.
         :return: a filter predicate object
         """
-        assert isinstance(other, str), "This comparison only supports string literals."
+        if not isinstance(other, str):
+            logger.warning("'ciregexp' method comparison only supports string literals.")
         return FilterPredicate(self, "::ciregexp::", other)
 
     def ts(self, other):
@@ -696,7 +697,8 @@ class Column (object):
         :param other: a _string_ literal value.
         :return: a filter predicate object
         """
-        assert isinstance(other, str), "This comparison only supports string literals."
+        if not isinstance(other, str):
+            logger.warning("'ts' method comparison only supports string literals.")
         return FilterPredicate(self, "::ts::", other)
 
 

--- a/deriva/core/datapath.py
+++ b/deriva/core/datapath.py
@@ -619,33 +619,83 @@ class Column (object):
     def __str__(self):
         return self.name
 
-    def __eq__(self, other):
+    def eq(self, other):
+        """Returns an 'equality' comparison predicate.
+
+        :param other: `None` or any other literal value.
+        :return: a filter predicate object
+        """
         if other is None:
             return FilterPredicate(self, "::null::", '')
         else:
             return FilterPredicate(self, "=", other)
 
-    def __lt__(self, other):
+    __eq__ = eq
+
+    def lt(self, other):
+        """Returns a 'less than' comparison predicate.
+
+        :param other: a literal value.
+        :return: a filter predicate object
+        """
         return FilterPredicate(self, "::lt::", other)
 
-    def __le__(self, other):
+    __lt__ = lt
+
+    def le(self, other):
+        """Returns a 'less than or equal' comparison predicate.
+
+        :param other: a literal value.
+        :return: a filter predicate object
+        """
         return FilterPredicate(self, "::leq::", other)
 
-    def __gt__(self, other):
+    __le__ = le
+
+    def gt(self, other):
+        """Returns a 'greater than' comparison predicate.
+
+        :param other: a literal value.
+        :return: a filter predicate object
+        """
         return FilterPredicate(self, "::gt::", other)
 
-    def __ge__(self, other):
+    __gt__ = gt
+
+    def ge(self, other):
+        """Returns a 'greater than or equal' comparison predicate.
+
+        :param other: a literal value.
+        :return: a filter predicate object
+        """
         return FilterPredicate(self, "::geq::", other)
 
+    __ge__ = ge
+
     def regexp(self, other):
+        """Returns a 'regular expression' comparison predicate.
+
+        :param other: a _string_ literal value.
+        :return: a filter predicate object
+        """
         assert isinstance(other, str), "This comparison only supports string literals."
         return FilterPredicate(self, "::regexp::", other)
 
     def ciregexp(self, other):
+        """Returns a 'case-insensitive regular expression' comparison predicate.
+
+        :param other: a _string_ literal value.
+        :return: a filter predicate object
+        """
         assert isinstance(other, str), "This comparison only supports string literals."
         return FilterPredicate(self, "::ciregexp::", other)
 
     def ts(self, other):
+        """Returns a 'text search' comparison predicate.
+
+        :param other: a _string_ literal value.
+        :return: a filter predicate object
+        """
         assert isinstance(other, str), "This comparison only supports string literals."
         return FilterPredicate(self, "::ts::", other)
 
@@ -783,14 +833,36 @@ class Predicate (object):
     def __init__(self):
         pass
 
-    def __and__(self, other):
+    def and_(self, other):
+        """Returns a conjunction predicate.
+
+        :param other: a predicate object.
+        :return: a junction predicate object.
+        """
         return JunctionPredicate(self, "&", other)
 
-    def __or__(self, other):
+    __and__ = and_
+
+    def or_(self, other):
+        """Returns a disjunction predicate.
+
+        :param other: a predicate object.
+        :return: a junction predicate object.
+        """
         return JunctionPredicate(self, ";", other)
 
-    def __invert__(self):
+    __or__ = or_
+
+    def negate(self):
+        """Returns a negation predicate.
+
+        This predicate is wrapped in a negation predicate which is returned to the caller.
+
+        :return: a negation predicate object.
+        """
         return NegationPredicate(self)
+
+    __invert__ = negate
 
 
 class FilterPredicate (Predicate):

--- a/tests/deriva/core/test_datapath.py
+++ b/tests/deriva/core/test_datapath.py
@@ -1,17 +1,24 @@
+# Tests for the datapath module.
+#
+# Environment variables:
+#  DERIVA_PY_TEST_HOSTNAME: hostname of the test server
+#  DERIVA_PY_TEST_CREDENTIAL: user credential, if none, it will attempt to get credentail for given hostname
+#  DERIVA_PY_TEST_VERBOSE: set for verbose logging output to stdout
+
 import logging
 import os
 import unittest
 from deriva.core import DerivaServer, get_credential, ermrest_model as _em
 
-TEST_HOSTNAME = os.getenv("DERIVA_PY_TEST_HOSTNAME")
-TEST_CREDENTIALS = os.getenv("DERIVA_PY_TEST_CREDENTIALS")
 TEST_EXP_MAX = 100
 TEST_EXPTYPE_MAX = 10
 TEST_EXP_NAME_FORMAT = "experiment-{}"
 
+hostname = os.getenv("DERIVA_PY_TEST_HOSTNAME")
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-logger.addHandler(logging.StreamHandler())
+if os.getenv("DERIVA_PY_TEST_VERBOSE"):
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(logging.StreamHandler())
 
 
 def define_test_schema(catalog):
@@ -64,15 +71,15 @@ def populate_test_catalog(catalog):
     ])
 
 
-@unittest.skipUnless(TEST_HOSTNAME, "Test host not specified")
+@unittest.skipUnless(hostname, "Test host not specified")
 class DatapathTests (unittest.TestCase):
     catalog = None
 
     @classmethod
     def setUpClass(cls):
         logger.debug("setupUpClass begin")
-        credentials = TEST_CREDENTIALS or get_credential(TEST_HOSTNAME)
-        server = DerivaServer('https', TEST_HOSTNAME, credentials)
+        credential = os.getenv("DERIVA_PY_TEST_CREDENTIAL") or get_credential(hostname)
+        server = DerivaServer('https', hostname, credential)
         cls.catalog = server.create_ermrest_catalog()
         try:
             define_test_schema(cls.catalog)

--- a/tests/deriva/core/test_datapath.py
+++ b/tests/deriva/core/test_datapath.py
@@ -101,6 +101,18 @@ class DatapathTests (unittest.TestCase):
         self.experiment = self.paths.schemas['ISA'].tables['Experiment']
         self.experiment_type = self.paths.schemas['Vocab'].tables['Experiment_Type']
 
+    def test_dir_model(self):
+        self.assertIn('ISA', dir(self.paths))
+
+    def test_dir_schema(self):
+        self.assertIn('Experiment', dir(self.paths.ISA))
+
+    def test_dir_table(self):
+        self.assertIn('Name', dir(self.paths.ISA.Experiment))
+
+    def test_dir_path(self):
+        self.assertIn('Experiment', dir(self.paths.ISA.Experiment.path))
+
     def test_unfiltered_fetch(self):
         entities = self.experiment.entities()
         self.assertEquals(len(entities), TEST_EXP_MAX)

--- a/tests/deriva/core/test_datapath.py
+++ b/tests/deriva/core/test_datapath.py
@@ -113,6 +113,15 @@ class DatapathTests (unittest.TestCase):
     def test_dir_path(self):
         self.assertIn('Experiment', dir(self.paths.ISA.Experiment.path))
 
+    def test_describe_schema(self):
+        self.assert_(self.paths.schemas['ISA'].describe())
+
+    def test_describe_table(self):
+        self.assert_(self.paths.schemas['ISA'].tables['Experiment'].describe())
+
+    def test_describe_column(self):
+        self.assert_(self.paths.schemas['ISA'].tables['Experiment'].column_definitions['Name'].describe())
+
     def test_unfiltered_fetch(self):
         entities = self.experiment.entities()
         self.assertEquals(len(entities), TEST_EXP_MAX)

--- a/tests/deriva/core/test_datapath.py
+++ b/tests/deriva/core/test_datapath.py
@@ -10,6 +10,12 @@ import os
 import unittest
 from deriva.core import DerivaServer, get_credential, ermrest_model as _em
 
+try:
+    from pandas import DataFrame
+    HAS_PANDAS = True
+except ImportError:
+    HAS_PANDAS = False
+
 TEST_EXP_MAX = 100
 TEST_EXPTYPE_MAX = 10
 TEST_EXP_NAME_FORMAT = "experiment-{}"
@@ -202,3 +208,9 @@ class DatapathTests (unittest.TestCase):
         self.assertIn('Experiment:Time', entity)
         self.assertIn('URI', entity)
         self.assertIn('exptype', entity)
+
+    @unittest.skipUnless(HAS_PANDAS, "pandas library not available")
+    def test_dataframe(self):
+        entities = self.experiment.entities()
+        df = entities.dataframe
+        self.assertEquals(len(df), TEST_EXP_MAX)


### PR DESCRIPTION
This PR improves the usage of datapath in R via the 'reticulate' R interface to Python. The primary issue was that datapath makes use of operator overloading which didn't translate into R. In addition, there were some Python 2 incompatibilities which are addressed in this PR.

- For all operator overloading methods in the api, methods have been added. For example:
  - `Column` now has `eq(other)`, `le(other)`, etc. methods that return predicate objects,
  - `Predicate` now has `or_(other)`, `and_(other)`, and `negate()` methods that return predicate objects,
  - and pydoc strings for the above.
- The dot-notation support was improved (fixed in some cases!):
  - fixes #54 : don't assume that objects have `__dir__` methods instead use `dir(...)` on them,
  - also include public members and methods in the list returned by `__dir__`,
  - fixed `__getattr__` also so that it if the attribute is not in the model elements that it falls back to the super classes `getattr(obj, a)` results.
- Fixed #20 (actually this was already fixed some time ago) but this PR includes:
  - further relaxing of asserts on `str` type which don't pass on Python 2,
  - in some cases, logs warnings where a non-str objects will not cause an error but also _probably_ won't produce the results that the user would have expected.
- Changed how `__repr__` behaved to conform more like Python and less like IPython:
  - added a `describe()` method to model elements to return the human-readable string that used to be returned by `__repr__`,
  - custom `__repr__` methods are removed so we can revert back to usual Python behavior,
  - for continued IPython integration `_repr_html_` has been added in places where `__repr__` was removed. It is rudimentary in the sense that it just passes through the string returned by the `describe()` method but that's good enough for this PR. It should be improved in the future.
- Added unit tests for all for all of the above.