### PR TITLE
Added a function to Table class to create an asset table 

### DIFF
--- a/deriva/core/ermrest_model.py
+++ b/deriva/core/ermrest_model.py
@@ -293,7 +293,7 @@ class Table (_ec.CatalogTable):
                  elmenents such at {{{MD5}}} or {{{Filename}}}. The default template puts files in
                      /hatrac/schema_name/table_name/filename.md5
                  where the filename and md5 value is computed on upload and the schema_name and table_name are the
-                 values of the provided arguments.
+                 values of the provided arguments.  If value is set to False, no hatrac_template is used.
           :param column_defs: a list of Column.define() results for extra or overridden column definitions
           :param key_defs: a list of Key.define() results for extra or overridden key constraint definitions
           :param fkey_defs: a list of ForeignKey.define() results for foreign key definitions
@@ -323,25 +323,26 @@ class Table (_ec.CatalogTable):
             hatrac_template = '/hatrac/%s/%s/{{#encode}}{{{Filename}}}{{/encode}}.{{{MD5}}}' % (sname, tname)
 
         def add_asset_annotations(custom):
-            annotations = {_ec.tag['table_display']: {'row_name': {'row_markdown_pattern': '{{{Filename}}}'}}}
             annotations.update(custom)
             return annotations
 
         def add_asset_columns(custom):
+            asset_annotation = {
+                _ec.tag.asset: {
+                    'filename_column': 'Filename',
+                    'byte_count_column': 'Length',
+                    'md5': 'MD5',
+                }
+            }
+            if hatrac_template:
+                asset_annotation[_ec.tag.asset]['url_pattern'] = hatrac_template
             return [
                 col_def
                 for col_def in [
                         Column.define(
                             'URL', builtin_types['text'],
                             nullok=False,
-                            annotations={
-                                _ec.tag.asset: {
-                                    'filename_column': 'Filename',
-                                    'byte_count_column': 'Length',
-                                    'url_pattern': hatrac_template,
-                                    'md5': 'MD5',
-                                }
-                            },
+                            annotations=asset_annotation,
                             comment='URL to the asset',
                         ),
                         Column.define('Filename', builtin_types['text'], comment='Filename of the asset that was uploaded'),

--- a/deriva/core/ermrest_model.py
+++ b/deriva/core/ermrest_model.py
@@ -317,7 +317,7 @@ class Table (_ec.CatalogTable):
           """
 
         if not hatrac_template:
-            hatrac_template='/hatrac/%s/%s/{{{_URL.Filename}}}.{{{_URL.MD5}}}' % (sname, tname)
+            hatrac_template='/hatrac/%s/%s/{{#encode}}{{{Filename}}}{{/encode}}.{{{MD5}}}' % (sname, tname)
 
         def add_asset_annotations(custom):
             annotations =  {_ec.tag['table_display']: {'row_name': {'row_markdown_pattern': '{{{Filename}}}'}}}

--- a/deriva/core/ermrest_model.py
+++ b/deriva/core/ermrest_model.py
@@ -325,32 +325,29 @@ class Table (_ec.CatalogTable):
             return annotations
 
         def add_asset_columns(custom):
-            column_annotations = {
-                'URL': {
-                    _ec.tag.asset: {
-                        'filename_column': 'Filename',
-                        'byte_count_column': 'Length',
-                        'url_pattern': hatrac_template,
-                        'md5': 'MD5'
-                    },
-                }
-            }
             return [
-                col_def
-                for col_def in [
+                       col_def
+                       for col_def in [
                     Column.define('URL', builtin_types['text'],
                                   nullok=False,
-                                  annotations=column_annotations['URL'],
+                                  annotations={
+                                      _ec.tag.asset: {
+                                          'filename_column': 'Filename',
+                                          'byte_count_column': 'Length',
+                                          'url_pattern': hatrac_template,
+                                          'md5': 'MD5'
+                                      }
+                                  },
                                   comment='URL to the asset'),
-                    Column.define('Filename', builtin_types['text'], annotations=column_annotations['Filename'],
+                    Column.define('Filename', builtin_types['text'],
                                   comment='Filename of the asset that was uploaded'),
                     Column.define('Description', builtin_types['markdown'],
                                   comment='Description of the asset'),
                     Column.define('Length', builtin_types['int8'], nullok=False, comment='Asset length (bytes)'),
                     Column.define('MD5', builtin_types['text'], nullok=False)
                 ]
-                if col_def['name'] not in {c['name']: c for c in custom}
-            ] + custom
+                       if col_def['name'] not in {c['name']: c for c in custom}
+                   ] + custom
 
         def add_asset_keys(custom):
             def ktup(k):

--- a/deriva/core/ermrest_model.py
+++ b/deriva/core/ermrest_model.py
@@ -282,8 +282,17 @@ class Table (_ec.CatalogTable):
         )
 
     @classmethod
-    def define_asset(cls, sname, tname, hatrac_template=None, column_defs=[], key_defs=[],
-                     fkey_defs=[], comment=None, acls={}, acl_bindings={}, annotations={},
+    def define_asset(cls,
+                     sname,
+                     tname,
+                     hatrac_template=None,
+                     column_defs=[],
+                     key_defs=[],
+                     fkey_defs=[],
+                     comment=None,
+                     acls={},
+                     acl_bindings={},
+                     annotations={},
                      provide_system=True):
         """Build an asset  table definition.
 
@@ -291,7 +300,7 @@ class Table (_ec.CatalogTable):
           :param tname: the name of the newly defined table
           :param hatrac_template: template for the hatrac URL.  Will undergo substitution to template can include
                  elmenents such at {{{MD5}}} or {{{Filename}}}. The default template puts files in
-                     /hatrac/schema_name/table_name/filename.md5
+                     /hatrac/schema_name/table_name/md5.filename
                  where the filename and md5 value is computed on upload and the schema_name and table_name are the
                  values of the provided arguments.  If value is set to False, no hatrac_template is used.
           :param column_defs: a list of Column.define() results for extra or overridden column definitions
@@ -308,7 +317,7 @@ class Table (_ec.CatalogTable):
 
           - Filename: ermrest_curie, unique not null, default curie template "%s:{RID}" % curie_prefix
           - URL: Location of the asset, unique not null.  Default template is:
-                    /hatrac/sname/tname/{{{Filename}}}.{{{MD5}}} where tname is the name of the asset table.
+                    /hatrac/sname/tname/{{{MD5}}}.{{{Filename}}} where tname is the name of the asset table.
           - Length: Length of the asset.
           - MD5: text
           - Description: markdown, not null
@@ -320,7 +329,7 @@ class Table (_ec.CatalogTable):
           """
 
         if hatrac_template is None:
-            hatrac_template = '/hatrac/%s/%s/{{#encode}}{{{Filename}}}{{/encode}}.{{{MD5}}}' % (sname, tname)
+            hatrac_template = '/hatrac/%s/%s/{{{MD5}}}.{{#encode}}{{{Filename}}}{{/encode}}' % (sname, tname)
 
         def add_asset_annotations(custom):
             annotations.update(custom)

--- a/deriva/core/ermrest_model.py
+++ b/deriva/core/ermrest_model.py
@@ -282,11 +282,12 @@ class Table (_ec.CatalogTable):
         )
 
     @classmethod
-    def define_asset(cls, tname, hatrac_template=None, column_defs=[], key_defs=[],
+    def define_asset(cls, sname, tname, hatrac_template=None, column_defs=[], key_defs=[],
                      fkey_defs=[], comment=None, acls={}, acl_bindings={}, annotations={},
                      provide_system=True):
         """Build an asset  table definition.
 
+          :param sname: the name of the schema for the asset table
           :param tname: the name of the newly defined table
           :param hatrac_template: template for the hatrac URL.  Will undergo substitution to template can include
                  elmenents such at {{{MD5}}} or {{{Filename}}}
@@ -316,7 +317,7 @@ class Table (_ec.CatalogTable):
           """
 
         if not hatrac_template:
-            hatrac_template='/hatrac/%s/{{{_URL.Filename}}}.{{{_URL.MD5}}}' % tname
+            hatrac_template='/hatrac/{}/{}/{{{_URL.Filename}}}.{{{_URL.MD5}}}'.format(sname, tname)
 
         def add_asset_annotations(custom):
             annotations =  {_ec.tag['table_display']: {'row_name': {'row_markdown_pattern': '{{{Filename}}}'}}}

--- a/deriva/core/ermrest_model.py
+++ b/deriva/core/ermrest_model.py
@@ -317,7 +317,7 @@ class Table (_ec.CatalogTable):
           """
 
         if not hatrac_template:
-            hatrac_template='/hatrac/{}/{}/{{{_URL.Filename}}}.{{{_URL.MD5}}}'.format(sname, tname)
+            hatrac_template='/hatrac/%s/%s/{{{_URL.Filename}}}.{{{_URL.MD5}}}' % (sname, tname)
 
         def add_asset_annotations(custom):
             annotations =  {_ec.tag['table_display']: {'row_name': {'row_markdown_pattern': '{{{Filename}}}'}}}

--- a/deriva/core/ermrest_model.py
+++ b/deriva/core/ermrest_model.py
@@ -333,10 +333,6 @@ class Table (_ec.CatalogTable):
                         'url_pattern': hatrac_template,
                         'md5': 'MD5'
                     },
-                    _ec.tag.column_display: {'*': {'markdown_pattern': '[**{{URL}}**]({{{URL}}})'}}
-                },
-                'Filename': {
-                    _ec.tag.column_display: {'*': {'markdown_pattern': '[**{{Filename}}**]({{{URL}}})'}}
                 }
             }
             return [

--- a/deriva/core/ermrest_model.py
+++ b/deriva/core/ermrest_model.py
@@ -329,40 +329,40 @@ class Table (_ec.CatalogTable):
 
         def add_asset_columns(custom):
             return [
-                       col_def
-                       for col_def in [Column.define('URL', builtin_types['text'],
-                                                     nullok=False,
-                                                     annotations={
-                                                         _ec.tag.asset: {
-                                                             'filename_column': 'Filename',
-                                                             'byte_count_column': 'Length',
-                                                             'url_pattern': hatrac_template,
-                                                             'md5': 'MD5'
-                                                         }
-                                                     },
-                                                     comment='URL to the asset'),
-                                       Column.define('Filename', builtin_types['text'],
-                                                     comment='Filename of the asset that was uploaded'),
-                                       Column.define('Description', builtin_types['markdown'],
-                                                     comment='Description of the asset'),
-                                       Column.define('Length', builtin_types['int8'], nullok=False,
-                                                     comment='Asset length (bytes)'),
-                                       Column.define('MD5', builtin_types['text'], nullok=False)
-                                       ]
-                       if col_def['name'] not in {c['name']: c for c in custom}
-                   ] + custom
+                col_def
+                for col_def in [
+                        Column.define(
+                            'URL', builtin_types['text'],
+                            nullok=False,
+                            annotations={
+                                _ec.tag.asset: {
+                                    'filename_column': 'Filename',
+                                    'byte_count_column': 'Length',
+                                    'url_pattern': hatrac_template,
+                                    'md5': 'MD5',
+                                }
+                            },
+                            comment='URL to the asset',
+                        ),
+                        Column.define('Filename', builtin_types['text'], comment='Filename of the asset that was uploaded'),
+                        Column.define('Description', builtin_types['markdown'], comment='Description of the asset'),
+                        Column.define('Length', builtin_types['int8'], nullok=False, comment='Asset length (bytes)'),
+                        Column.define('MD5', builtin_types['text'], nullok=False, comment='Asset content MD5 checksum'),
+                ]
+                if col_def['name'] not in {c['name']: c for c in custom}
+            ] + custom
 
         def add_asset_keys(custom):
             def ktup(k):
                 return tuple(k['unique_columns'])
 
             return [
-                       key_def
-                       for key_def in [
+                key_def
+                for key_def in [
                     Key.define(['URL']),
                 ]
-                       if ktup(key_def) not in {ktup(kdef): kdef for kdef in custom}
-                   ] + custom
+                if ktup(key_def) not in {ktup(kdef): kdef for kdef in custom}
+            ] + custom
 
         return cls.define(
             tname,

--- a/deriva/core/ermrest_model.py
+++ b/deriva/core/ermrest_model.py
@@ -319,7 +319,7 @@ class Table (_ec.CatalogTable):
           facilitate use of the table by Chaise.
           """
 
-        if hatrac_template is not None:
+        if hatrac_template is None:
             hatrac_template = '/hatrac/%s/%s/{{#encode}}{{{Filename}}}{{/encode}}.{{{MD5}}}' % (sname, tname)
 
         def add_asset_annotations(custom):

--- a/deriva/core/ermrest_model.py
+++ b/deriva/core/ermrest_model.py
@@ -281,6 +281,103 @@ class Table (_ec.CatalogTable):
             provide_system
         )
 
+    @classmethod
+    def define_asset(cls, tname, hatrac_template=None, column_defs=[], key_defs=[],
+                     fkey_defs=[], comment=None, acls={}, acl_bindings={}, annotations={},
+                     provide_system=True):
+        """Build an asset  table definition.
+
+          :param tname: the name of the newly defined table
+          :param hatrac_template: template for the hatrac URL.  Will undergo substitution to template can include
+                 elmenents such at {{{MD5}}} or {{{Filename}}}
+          :param column_defs: a list of Column.define() results for extra or overridden column definitions
+          :param key_defs: a list of Key.define() results for extra or overridden key constraint definitions
+          :param fkey_defs: a list of ForeignKey.define() results for foreign key definitions
+          :param comment: a comment string for the table
+          :param acls: a dictionary of ACLs for specific access modes
+          :param acl_bindings: a dictionary of dynamic ACL bindings
+          :param annotations: a dictionary of annotations
+          :param provide_system: whether to inject standard system column definitions when missing from column_defs
+
+          These core asset table columns are generated automatically if
+          absent from the input column_defs.
+
+          - Filename: ermrest_curie, unique not null, default curie template "%s:{RID}" % curie_prefix
+          - URL: Location of the asset, unique not null.  Default template is:
+                    /hatrac/tname/{{{_URL.Filename}}}.{{{_URL.MD5}}} where tname is the name of the asset table.
+          - Length: Length of the asset.
+          - MD5: text
+          - Description: markdown, not null
+
+          However, caller-supplied definitions override the default.
+
+          In addition to creating the columns, this function also creates an asset annotation on the URL column to
+          facilitate use of the table by Chaise.
+          """
+
+        if not hatrac_template:
+            hatrac_template='/hatrac/%s/{{{_URL.Filename}}}.{{{_URL.MD5}}}' % tname
+
+        def add_asset_annotations(custom):
+            annotations =  {_ec.tag['table_display']: {'row_name': {'row_markdown_pattern': '{{{Filename}}}'}}}
+            annotations.update(custom)
+            return annotations
+
+        def add_asset_columns(custom):
+            column_annotations = {
+                'URL': {
+                    _ec.tag.asset: {
+                        'filename_column': 'Filename',
+                        'byte_count_column': 'Length',
+                        'url_pattern': hatrac_template,
+                        'md5': 'MD5'
+                    },
+                    _ec.tag.column_display: {'*': {'markdown_pattern': '[**{{URL}}**]({{{URL}}})'}}
+                },
+                'Filename': {
+                    _ec.tag.column_display: {'*': {'markdown_pattern': '[**{{Filename}}**]({{{URL}}})'}}
+                }
+            }
+            return [
+                col_def
+                for col_def in [
+                    Column.define('URL', builtin_types['text'],
+                                  nullok=False,
+                                  annotations=column_annotations['URL'],
+                                  comment='URL to the asset'),
+                    Column.define('Filename', builtin_types['text'], annotations=column_annotations['Filename'],
+                                  comment='Filename of the asset that was uploaded'),
+                    Column.define('Description', builtin_types['markdown'],
+                                  comment='Description of the asset'),
+                    Column.define('Length', builtin_types['int8'], nullok=False, comment='Asset length (bytes)'),
+                    Column.define('MD5', builtin_types['text'], nullok=False)
+                ]
+                if col_def['name'] not in {c['name']: c for c in custom}
+            ] + custom
+
+        def add_asset_keys(custom):
+            def ktup(k):
+                return tuple(k['unique_columns'])
+            return [
+                key_def
+                for key_def in [
+                        Key.define(['URL']),
+                ]
+                if ktup(key_def) not in { ktup(kdef): kdef for kdef in custom }
+            ] + custom
+
+        return cls.define(
+            tname,
+            add_asset_columns(column_defs),
+            add_asset_keys(key_defs),
+            fkey_defs,
+            comment if comment is not None else 'Asset table.',
+            acls,
+            acl_bindings,
+            add_asset_annotations(annotations),
+            provide_system
+        )
+
     def prejson(self, prune=True):
         d = super(Table, self).prejson(prune)
         d.update({


### PR DESCRIPTION
This is a class function, completely self contained.  It creates the table with the minimal set of columns and also adds minimal annotations necessary to make the table function properly in chaise.

By default, files are named: /hatrac/%s/{{#encode}}{{{Filename}}}{{/encode}}.{{{MD5}}}

I wonder if we should include the schema name here as well?  Would require an additional argument in the call.

I am only requiring that the URL be unique and non-null.  All other columns are optional.  