### PR TITLE
Add deriva-client-context header support

### DIFF
--- a/deriva/core/__init__.py
+++ b/deriva/core/__init__.py
@@ -42,6 +42,15 @@ def urlquote(s, safe=''):
     """
     return _urlquote(s.encode('utf-8'), safe=safe)
 
+def urlquote_dcctx(s, safe='~{}",:'):
+    """Quote for use with Deriva-Client-Context or other HTTP headers.
+
+       Defaults to allow additional safe characters for less
+       aggressive encoding of JSON content for use in an HTTP header
+       value.
+
+    """
+    return urlquote(s, safe=safe)
 
 DEFAULT_HEADERS = {}
 

--- a/deriva/core/__init__.py
+++ b/deriva/core/__init__.py
@@ -347,7 +347,7 @@ def get_transfer_summary(total_bytes, elapsed_time):
 
 
 from deriva.core.base_cli import BaseCLI, KeyValuePairArgs
-from deriva.core.deriva_binding import DerivaBinding, DerivaPathError
+from deriva.core.deriva_binding import DerivaBinding, DerivaPathError, DerivaClientContext
 from deriva.core.deriva_server import DerivaServer
 from deriva.core.ermrest_catalog import ErmrestCatalog, ErmrestSnapshot, ErmrestCatalogMutationError
 from deriva.core.ermrest_config import AttrDict, CatalogConfig

--- a/deriva/core/__init__.py
+++ b/deriva/core/__init__.py
@@ -15,7 +15,7 @@ from collections import OrderedDict
 from distutils import util as du_util
 from importlib import import_module
 
-__version__ = "0.7.5"
+__version__ = "0.7.6"
 
 IS_PY2 = (sys.version_info[0] == 2)
 IS_PY3 = (sys.version_info[0] == 3)

--- a/deriva/core/deriva_binding.py
+++ b/deriva/core/deriva_binding.py
@@ -66,7 +66,6 @@ class DerivaClientContext (dict):
         self.set_defaults()
         self.prune()
         x = urlquote_dcctx(json.dumps(self, indent=None, separators=(',', ':')))
-        print('Dcctx: %s' % x)
         return x
 
     def merged(self, overrides):
@@ -268,7 +267,6 @@ class DerivaBinding (object):
         if headers is None:
             headers = {}
         url, headers, prev_response = self._pre_get(path, headers)
-        print('Running GET %s %s' % (path, headers))
         r = self._raise_for_status_304(
             self._session.get(url, headers=headers),
             prev_response,

--- a/deriva/core/ermrest_catalog.py
+++ b/deriva/core/ermrest_catalog.py
@@ -32,6 +32,20 @@ class ErmrestCatalog(DerivaBinding):
              credentials: credential secrets, e.g. cookie
              caching: whether to retain a GET response cache
 
+           Deriva Client Context: You MAY mutate self.dcctx to
+           customize the context for this service endpoint prior to
+           invoking web requests.  E.g.:
+
+             self.dcctx['cid'] = 'my application name'
+
+           You MAY also supply custom per-request context by passing a
+           headers dict to web request methods, e.g. 
+
+             self.get(..., headers={'deriva-client-context': {'action': 'myapp/function1'}})
+
+           This custom header will be merged as override values with
+           the default context in self.dcctx in order to form the
+           complete context for the request.
         """
         super(ErmrestCatalog, self).__init__(scheme, server, credentials, caching, session_config)
         self._server_uri = "%s/ermrest/catalog/%s" % (


### PR DESCRIPTION
Adds support for custom header we understand in deriva servers.  This is a lightly URL-encoded JSON blob with a few well-known keys.

The implementation extends a regular Python dict and allows several levels of configurability:

1. `deriva.DerivaClientContext.defaults` holds *mutable* process-wide defaults for context
2. Each `DerivaBinding` instance holds *mutable* `self.dcctx` endpoint-specific context
3. Each `DerivaBinding` web method accepts/adds/augments `deriva-client-context` header values

A basic worker script using this version of the library will automatically start sending minimal context:
- `cid` is set to basename of `sys.argv[0]` when that is a non-empty value
- `wid` is set to a random UUID via `uuid.uuid4()`

Custom applications may augment this context by setting more appropriate values in the mutable containers or passing request-specific context in the optional `headers` argument to our bindings.