### PR TITLE
extend partial-cloning to existing destination tables

### DIFF
--- a/deriva/core/__init__.py
+++ b/deriva/core/__init__.py
@@ -15,7 +15,7 @@ from collections import OrderedDict
 from distutils import util as du_util
 from importlib import import_module
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 
 IS_PY2 = (sys.version_info[0] == 2)
 IS_PY3 = (sys.version_info[0] == 3)


### PR DESCRIPTION
When a source catalog contains a view (or other non-table kind
of relation):
- Skip source relation and log a warning

When an existing destination table is found:
- Abort if destination column mismatches source column definition
- Abort if destination has extra columns or keys
- Add missing source columns
- Add missing source keys

Perform special data merge for magic built-in client/group tables:
- Sync by stable "ID" from authn system
- Do not attempt to sync RIDs
- Add missing rows
- Update existing rows

This is necessary because ERMrest inserts content into the built-in
tables before we are given an opportunity to supply any content.

For safety, also reject source catalogs w/ foreign key references
to RID of magic built-in client/group tables. Since these are
not synchronized, we won't be able to maintain data integrity for
copied rows.

NOTE: we still do not clone data for existing non-magic tables. Content
cloning is not well-defined if the destination table does not start
in a known-empty state.