### PR TITLE
move set_credentails to end of derivabinding init (fixes #69)

### DIFF
--- a/deriva/core/deriva_binding.py
+++ b/deriva/core/deriva_binding.py
@@ -135,14 +135,14 @@ class DerivaBinding (object):
             session_config = DEFAULT_SESSION_CONFIG
         self._get_new_session(session_config)
 
-        self.set_credentials(credentials, server)
-
         self._caching = caching
         self._cache = {}
 
         self._response_raise_for_status = _response_raise_for_status
 
         self.dcctx = DerivaClientContext()
+
+        self.set_credentials(credentials, server)
 
     def get_server_uri(self):
         return self._server_uri


### PR DESCRIPTION
Small change to fix issue #69. I tested with a small client that makes a connection using username/password credentails. To confirm that this change doesn't break the more typical usage with globus auth credentails, I confirmed that datapath tests work.