### PR TITLE
Datapath composite key based linking

### DIFF
--- a/deriva/core/datapath.py
+++ b/deriva/core/datapath.py
@@ -245,7 +245,7 @@ class DataPath (object):
         """
         if not isinstance(right, Table):
             raise ValueError("'right' must be a 'Table' instance")
-        if on and not isinstance(on, FilterPredicate):
+        if on and not isinstance(on, ComparisonPredicate):
             raise ValueError("'on' must be a comparison or conjuctive predicate")
         if join_type and on is None:
             raise ValueError("'on' must be specified for outer joins")
@@ -806,9 +806,9 @@ class Column (object):
         :return: a filter predicate object
         """
         if other is None:
-            return FilterPredicate(self, "::null::", '')
+            return ComparisonPredicate(self, "::null::", '')
         else:
-            return FilterPredicate(self, "=", other)
+            return ComparisonPredicate(self, "=", other)
         # TODO: accept Column in 'other' for join comparison
 
     __eq__ = eq
@@ -819,7 +819,7 @@ class Column (object):
         :param other: a literal value.
         :return: a filter predicate object
         """
-        return FilterPredicate(self, "::lt::", other)
+        return ComparisonPredicate(self, "::lt::", other)
 
     __lt__ = lt
 
@@ -829,7 +829,7 @@ class Column (object):
         :param other: a literal value.
         :return: a filter predicate object
         """
-        return FilterPredicate(self, "::leq::", other)
+        return ComparisonPredicate(self, "::leq::", other)
 
     __le__ = le
 
@@ -839,7 +839,7 @@ class Column (object):
         :param other: a literal value.
         :return: a filter predicate object
         """
-        return FilterPredicate(self, "::gt::", other)
+        return ComparisonPredicate(self, "::gt::", other)
 
     __gt__ = gt
 
@@ -849,7 +849,7 @@ class Column (object):
         :param other: a literal value.
         :return: a filter predicate object
         """
-        return FilterPredicate(self, "::geq::", other)
+        return ComparisonPredicate(self, "::geq::", other)
 
     __ge__ = ge
 
@@ -861,7 +861,7 @@ class Column (object):
         """
         if not isinstance(other, str):
             logger.warning("'regexp' method comparison only supports string literals.")
-        return FilterPredicate(self, "::regexp::", other)
+        return ComparisonPredicate(self, "::regexp::", other)
 
     def ciregexp(self, other):
         """Returns a 'case-insensitive regular expression' comparison predicate.
@@ -871,7 +871,7 @@ class Column (object):
         """
         if not isinstance(other, str):
             logger.warning("'ciregexp' method comparison only supports string literals.")
-        return FilterPredicate(self, "::ciregexp::", other)
+        return ComparisonPredicate(self, "::ciregexp::", other)
 
     def ts(self, other):
         """Returns a 'text search' comparison predicate.
@@ -881,7 +881,7 @@ class Column (object):
         """
         if not isinstance(other, str):
             logger.warning("'ts' method comparison only supports string literals.")
-        return FilterPredicate(self, "::ts::", other)
+        return ComparisonPredicate(self, "::ts::", other)
 
 
 class SortDescending (object):
@@ -1020,9 +1020,9 @@ class Project (PathOperator):
 class Link (PathOperator):
     def __init__(self, r, on, as_=None, join_type=''):
         super(Link, self).__init__(r)
-        assert isinstance(on, FilterPredicate) or isinstance(on, Table)
+        assert isinstance(on, ComparisonPredicate) or isinstance(on, Table)
         assert as_ is None or isinstance(as_, TableAlias)
-        assert join_type == '' or (join_type in ('left', 'right', 'full') and isinstance(on, FilterPredicate))
+        assert join_type == '' or (join_type in ('left', 'right', 'full') and isinstance(on, ComparisonPredicate))
         self._on = on
         self._as = as_
         self._join_type = join_type
@@ -1071,9 +1071,9 @@ class Predicate (object):
     __invert__ = negate
 
 
-class FilterPredicate (Predicate):
+class ComparisonPredicate (Predicate):
     def __init__(self, lop, op, rop):
-        super(FilterPredicate, self).__init__()
+        super(ComparisonPredicate, self).__init__()
         assert isinstance(lop, Column)
         assert isinstance(rop, Column) or isinstance(rop, int) or \
             isinstance(rop, float) or isinstance(rop, str) or \

--- a/deriva/core/datapath.py
+++ b/deriva/core/datapath.py
@@ -166,6 +166,7 @@ class DataPath (object):
 
     def _contextualized_uri(self, context):
         """Returns a path uri for the specified context.
+
         :param context: a table instance that is bound to this path
         :return: string representation of the path uri
         """
@@ -201,6 +202,7 @@ class DataPath (object):
 
     def filter(self, filter_expression):
         """Filters the path based on the specified formula.
+
         :param filter_expression: should be a valid Predicate object
         :return: self
         """
@@ -521,6 +523,7 @@ class Table (object):
     @property
     def _contextualized_path(self):
         """Returns the path as contextualized for this table instance.
+
         Conditionally updates the context of the path to which this table instance is bound.
         """
         return self.path
@@ -536,9 +539,11 @@ class Table (object):
         return TableAlias(self, alias_name)
 
     def filter(self, filter_expression):
+        """See the docs for this method in `DataPath` for more information."""
         return self._contextualized_path.filter(filter_expression)
 
     def link(self, right, on=None, join_type=''):
+        """See the docs for this method in `DataPath` for more information."""
         return self._contextualized_path.link(right, on, join_type)
 
     def _query(self, attributes, renamed_attributes):
@@ -682,6 +687,7 @@ class TableAlias (Table):
     """
     def __init__(self, base_table, alias_name):
         """Initializes the table alias.
+
         :param base_table: the base table to be given an alias name
         :param alias_name: the alias name
         """
@@ -728,6 +734,7 @@ class TableAlias (Table):
     @property
     def _contextualized_path(self):
         """Returns the path as contextualized for this table instance.
+
         Conditionally updates the context of the path to which this table instance is bound.
         """
         path = self.path

--- a/tests/deriva/core/test_datapath.py
+++ b/tests/deriva/core/test_datapath.py
@@ -344,13 +344,16 @@ class DatapathTests (unittest.TestCase):
         ).entities()
         self.assertEqual(TEST_EXPTYPE_MAX, len(results))
 
-    # def test_link_explicit_composite_key(self):
-    #     results = self.experiment.link(
-    #         self.experiment_type,
-    #         on=(self.experiment.Project_Investigator == self.project.Investigator &
-    #             self.experiment.Project_Num == self.project.Num)
-    #     ).entities()
-    #     self.assertEqual(TEST_PROJ_MAX, len(results))
+    def test_link_explicit_composite_key(self):
+        path = self.experiment.link(
+            self.project,
+            on=(
+                    (self.experiment.Project_Investigator == self.project.Investigator) &
+                    (self.experiment.Project_Num == self.project.Num)
+            )
+        )
+        results = path.entities()
+        self.assertEqual(TEST_PROJ_MAX, len(results))
 
     def test_filter_equality(self):
         results = self.experiment.filter(

--- a/tests/deriva/core/test_datapath.py
+++ b/tests/deriva/core/test_datapath.py
@@ -34,6 +34,9 @@ except ImportError:
 TEST_EXP_MAX = 100
 TEST_EXPTYPE_MAX = 10
 TEST_EXP_NAME_FORMAT = "experiment-{}"
+TEST_PROJ_MAX = 1
+TEST_PROJ_INVESTIGATOR = "Smith"
+TEST_PROJ_NUM = 1
 
 hostname = os.getenv("DERIVA_PY_TEST_HOSTNAME")
 logger = logging.getLogger(__name__)
@@ -53,6 +56,21 @@ def define_test_schema(catalog):
     vocab.create_table(catalog, _em.Table.define_vocabulary("Experiment_Type", "TEST:{RID}"))
     isa = model.create_schema(catalog, _em.Schema.define("ISA"))
 
+    # create 'Project' table
+    table_def = _em.Table.define(
+        "Project",
+        column_defs=[
+            _em.Column.define(cname, ctype) for (cname, ctype) in [
+                ('Investigator', _em.builtin_types.text),
+                ('Num', _em.builtin_types.int4)
+            ]
+        ],
+        key_defs=[
+            _em.Key.define(['Investigator', 'Num'])
+        ]
+    )
+    isa.create_table(catalog, table_def)
+
     # create 'Experiment' table
     table_def = _em.Table.define(
         "Experiment",
@@ -61,14 +79,17 @@ def define_test_schema(catalog):
                 ('Name', _em.builtin_types.text),
                 ('Amount', _em.builtin_types.int4),
                 ('Time', _em.builtin_types.timestamptz),
-                ('Type', _em.builtin_types.text)
+                ('Type', _em.builtin_types.text),
+                ('Project_Investigator', _em.builtin_types.text),
+                ('Project_Num', _em.builtin_types.int4)
             ]
         ],
         key_defs=[
             _em.Key.define(['Name'])
         ],
         fkey_defs=[
-            _em.ForeignKey.define(['Type'], 'Vocab', 'Experiment_Type', ['ID'])
+            _em.ForeignKey.define(['Type'], 'Vocab', 'Experiment_Type', ['ID']),
+            _em.ForeignKey.define(['Project_Investigator', 'Project_Num'], 'ISA', 'Project', ['Investigator', 'Num'])
         ]
     )
     isa.create_table(catalog, table_def)
@@ -90,7 +111,9 @@ def _generate_experiment_entities(types, count):
             "Name": TEST_EXP_NAME_FORMAT.format(i),
             "Amount": i,
             "Time": "2018-01-{}T01:00:00.0".format(1 + (i % 31)),
-            "Type": types[i % TEST_EXPTYPE_MAX]['ID']
+            "Type": types[i % TEST_EXPTYPE_MAX]['ID'],
+            "Project_Investigator": TEST_PROJ_INVESTIGATOR,
+            "Project_Num": TEST_PROJ_NUM
         }
         for i in range(count)
     ]
@@ -99,12 +122,17 @@ def _generate_experiment_entities(types, count):
 def populate_test_catalog(catalog):
     """Populate the test catalog."""
     paths = catalog.getPathBuilder()
-    logger.debug("Insert experiment types")
+    logger.debug("Inserting project...")
+    logger.debug("Inserting experiment types...")
+    proj_table = paths.schemas['ISA'].tables['Project']
+    proj_table.insert([
+        {"Investigator": TEST_PROJ_INVESTIGATOR, "Num": TEST_PROJ_NUM}
+    ])
     type_table = paths.schemas['Vocab'].tables['Experiment_Type']
     types = type_table.insert([
         {"Name": "{}".format(name), "Description": "NA"} for name in range(TEST_EXPTYPE_MAX)
     ], defaults=['ID', 'URI'])
-    logger.debug("Inserting experiments")
+    logger.debug("Inserting experiments...")
     exp = paths.schemas['ISA'].tables['Experiment']
     exp.insert(_generate_experiment_entities(types, TEST_EXP_MAX))
 
@@ -136,6 +164,7 @@ class DatapathTests (unittest.TestCase):
 
     def setUp(self):
         self.paths = self.catalog.getPathBuilder()
+        self.project = self.paths.schemas['ISA'].tables['Project']
         self.experiment = self.paths.schemas['ISA'].tables['Experiment']
         self.experiment_type = self.paths.schemas['Vocab'].tables['Experiment_Type']
         self.experiment_copy = self.paths.schemas['ISA'].tables['Experiment_Copy']
@@ -308,12 +337,20 @@ class DatapathTests (unittest.TestCase):
         results = self.experiment.link(self.experiment_type).entities()
         self.assertEqual(TEST_EXPTYPE_MAX, len(results))
 
-    def test_link_explicit_single_column(self):
+    def test_link_explicit_simple_key(self):
         results = self.experiment.link(
             self.experiment_type,
             on=(self.experiment.Type == self.experiment_type.ID)
         ).entities()
         self.assertEqual(TEST_EXPTYPE_MAX, len(results))
+
+    # def test_link_explicit_composite_key(self):
+    #     results = self.experiment.link(
+    #         self.experiment_type,
+    #         on=(self.experiment.Project_Investigator == self.project.Investigator &
+    #             self.experiment.Project_Num == self.project.Num)
+    #     ).entities()
+    #     self.assertEqual(TEST_PROJ_MAX, len(results))
 
     def test_filter_equality(self):
         results = self.experiment.filter(

--- a/tests/deriva/core/test_datapath.py
+++ b/tests/deriva/core/test_datapath.py
@@ -304,9 +304,16 @@ class DatapathTests (unittest.TestCase):
                 self.assertIn(name, result)
                 self.assertEqual(result[name], value)
 
-    def test_link(self):
+    def test_link_implicit(self):
         results = self.experiment.link(self.experiment_type).entities()
-        self.assertEqual(len(results), TEST_EXPTYPE_MAX)
+        self.assertEqual(TEST_EXPTYPE_MAX, len(results))
+
+    def test_link_explicit_single_column(self):
+        results = self.experiment.link(
+            self.experiment_type,
+            on=(self.experiment.Type == self.experiment_type.ID)
+        ).entities()
+        self.assertEqual(TEST_EXPTYPE_MAX, len(results))
 
     def test_filter_equality(self):
         results = self.experiment.filter(


### PR DESCRIPTION
This update adds support for explicit links based on composite key / fkey references. In order to work within the python syntax the form of the join condition is a conjunction of equality comparisons.

```
# let A and B be tables with fkey/key columns (a,b)
path = A.link(B, on=((A.a == B.a) & (A.b == B.b)))
results = path.entities()
```

Tests and docstrings have been updated. Also, several of the 'assert' statements have been improved to being if error-cond / raise ValueError.