### PR TITLE
Model alteration methods and refactor

### DIFF
--- a/deriva/core/__init__.py
+++ b/deriva/core/__init__.py
@@ -5,7 +5,7 @@ from deriva.core.base_cli import BaseCLI, KeyValuePairArgs
 from deriva.core.deriva_binding import DerivaBinding, DerivaPathError, DerivaClientContext
 from deriva.core.deriva_server import DerivaServer
 from deriva.core.ermrest_catalog import ErmrestCatalog, ErmrestSnapshot, ErmrestCatalogMutationError
-from deriva.core.ermrest_config import AttrDict, CatalogConfig
+from deriva.core.ermrest_config import AttrDict, tag
 from deriva.core.polling_ermrest_catalog import PollingErmrestCatalog
 from deriva.core.hatrac_store import HatracStore, HatracHashMismatch, HatracJobPaused, HatracJobAborted, \
     HatracJobTimeout

--- a/deriva/core/ermrest_catalog.py
+++ b/deriva/core/ermrest_catalog.py
@@ -91,7 +91,7 @@ class ErmrestCatalog(DerivaBinding):
         return ermrest_model.Model.fromcatalog(self)
 
     def applyCatalogConfig(self, config):
-        return config.apply(self)
+        return config.apply()
 
     def getCatalogSchema(self):
         path = '/schema'

--- a/deriva/core/ermrest_catalog.py
+++ b/deriva/core/ermrest_catalog.py
@@ -409,8 +409,8 @@ class ErmrestCatalog(DerivaBinding):
                         if cname not in src_columns:
                             raise ValueError("Destination column %s.%s.%s does not exist in source catalog." % (sname, tname, cname))
 
-                    src_keys = { tuple(sorted(key.unique_columns)): key for key in table.keys }
-                    dst_keys = { tuple(sorted(key.unique_columns)): key for key in dst_model.schemas[sname].tables[tname].keys }
+                    src_keys = { tuple(sorted(c.name for c in key.unique_columns)): key for key in table.keys }
+                    dst_keys = { tuple(sorted(c.name for c in key.unique_columns)): key for key in dst_model.schemas[sname].tables[tname].keys }
 
                     for utuple in src_keys:
                         if utuple not in dst_keys:

--- a/deriva/core/ermrest_config.py
+++ b/deriva/core/ermrest_config.py
@@ -631,6 +631,24 @@ class CatalogTable (NodeConfigAclBinding):
         })
         return d
 
+    def key_by_columns(self, unique_columns):
+        """Return key from self.keys with matching unique columns or raise KeyError if no such key is found."""
+        cset = set()
+        for c in unique_columns:
+            if isinstance(c, CatalogTable):
+                if self.column_definitions[c.name] is c:
+                    cset.add(c)
+                else:
+                    raise ValueError('column %s object is not from this table object' % (c,))
+            elif c in self.column_definitions.elements:
+                cset.add(self.column_definitions[c])
+            else:
+                raise ValueError('value %s does not name a defined column in this table' % (c,))
+        for key in self.keys:
+            if cset == { c for c in key.unique_columns }:
+                return key
+        raise KeyError(cset)
+
     @object_annotation(tag.table_alternatives)
     def alternatives(self): pass
 

--- a/deriva/core/ermrest_config.py
+++ b/deriva/core/ermrest_config.py
@@ -18,6 +18,9 @@ class AttrDict (dict):
     def __setattr__(self, a, v):
         self[a] = v
 
+    def update(self, d):
+        dict.update(self, d)
+
 # convenient enumeration of common annotation tags
 tag = AttrDict({
     'generated':          'tag:isrd.isi.edu,2016:generated',
@@ -338,12 +341,12 @@ class CatalogConfig (NodeConfigAcl):
         self._catalog = catalog
         NodeConfigAcl.__init__(self, model_doc)
         self._supports_comment = False
+        self._pseudo_fkeys = {}
         self.schemas = {
             sname: kwargs.get('schema_class', CatalogSchema)(self, sname, sdoc, **kwargs)
             for sname, sdoc in model_doc.get('schemas', {}).items()
         }
         self.digest_fkeys()
-        self._pseudo_fkeys = {}
 
     def digest_fkeys(self):
         """Finish second-pass digestion of foreign key definitions using full model w/ all schemas and tables.

--- a/deriva/core/ermrest_config.py
+++ b/deriva/core/ermrest_config.py
@@ -175,10 +175,13 @@ class NodeConfig (object):
                 else:
                     self.catalog.delete('%s/comment' % self.update_uri_path)
         if existing is None or not equivalent(self.annotations, existing.annotations):
-            self.catalog.put(
-                '%s/%s' % (self.update_uri_path, 'annotation'),
-                json=self.annotations
-            )
+            try:
+                self.catalog.put(
+                    '%s/%s' % (self.update_uri_path, 'annotation'),
+                    json=self.annotations
+                )
+            except TypeError as e:
+                raise TypeError('Bad %s/annotation' % (self.update_uri_path, self.annotations)) from e
 
     def clear(self, clear_comment=False):
         """Clear existing annotations on node, also clearing comment if clear_comment is True.

--- a/deriva/core/ermrest_config.py
+++ b/deriva/core/ermrest_config.py
@@ -412,12 +412,23 @@ class CatalogConfig (NodeConfigAcl):
         return self.table(sname, tname).column_definitions[cname]
 
     def fkey(self, constraint_name_pair):
-        """Return configuration for foreign key with given name pair."""
+        """Return configuration for foreign key with given name pair.
+
+        Accepts (schema_name, constraint_name) pairs as found in many
+        faceting annotations and (schema_obj, constraint_name) pairs
+        as found in fkey.name fields.
+
+        """
         sname, cname = constraint_name_pair
-        if sname != '':
-            return self.schemas[sname]._fkeys[cname]
-        else:
+        if isinstance(sname, CatalogSchema):
+            if self.schemas[sname.name] is sname:
+                return sname._fkeys[cname]
+            else:
+                raise ValueError('schema object %s is not from same model tree' % (sname,))
+        elif sname is None or sname == '':
             return self._pseudo_fkeys[cname]
+        else:
+            return self.schemas[sname]._fkeys[cname]
 
     @object_annotation(tag.bulk_upload)
     def bulk_upload(self): pass

--- a/deriva/core/ermrest_config.py
+++ b/deriva/core/ermrest_config.py
@@ -710,11 +710,7 @@ class CatalogTable (NodeConfigAclBinding):
             elif to_table is not c.table:
                 raise ValueError('to-columns must all be part of same table')
         for fkey in self.foreign_keys:
-            fkey_colmap = {
-                from_col: to_col
-                for from_col, to_col in zip(fkey.foreign_key_columns, fkey.referenced_columns)
-            }
-            if colmap == fkey_colmap:
+            if colmap == fkey.column_map:
                 return fkey
         if raise_nomatch:
             raise KeyError(from_to_map)

--- a/deriva/core/ermrest_model.py
+++ b/deriva/core/ermrest_model.py
@@ -797,6 +797,8 @@ class ForeignKey (_ec.CatalogForeignKey):
     def alter(
             self,
             constraint_name=nochange,
+            on_update=nochange,
+            on_delete=nochange,
             comment=nochange,
             acls=nochange,
             acl_bindings=nochange,
@@ -805,6 +807,8 @@ class ForeignKey (_ec.CatalogForeignKey):
         """Alter existing schema definition.
 
         :param constraint_name: Replacement constraint name string
+        :param on_update: Replacement on-update action string
+        :param on_delete: Replacement on-delete action string
         :param comment: Replacement comment (default nochange)
         :param acls: Replacement ACL configuration (default nochange)
         :param acl_bindings: Replacement ACL bindings (default nochange)
@@ -814,6 +818,8 @@ class ForeignKey (_ec.CatalogForeignKey):
 
         """
         changes = strip_nochange({
+            'on_update': on_update,
+            'on_delete': on_delete,
             'comment': comment,
             'acls': acls,
             'acl_bindings': acl_bindings,
@@ -839,6 +845,12 @@ class ForeignKey (_ec.CatalogForeignKey):
                 self.constraint_schema._fkeys[self.constraint_name] = self
             else:
                 self.table.schema.model._pseudo_fkeys[self.constraint_name] = self
+
+        if 'on_update' in changes:
+            self.on_update = changed['on_update']
+
+        if 'on_delete' in changes:
+            self.on_delete = changed['on_delete']
 
         if 'comment' in changes:
             self._comment = changed['comment']

--- a/deriva/core/ermrest_model.py
+++ b/deriva/core/ermrest_model.py
@@ -881,11 +881,11 @@ class ForeignKey (_ec.CatalogForeignKey):
     def drop(self):
         """Remove this foreign key from the remote database.
         """
-        if self.names[0] not in self.table.foreign_keys.elements:
+        if self.name not in self.table.foreign_keys.elements:
             raise ValueError('Foreign key %s does not appear to belong to table %s.' % (self, self.table))
         self.catalog.delete(self.update_uri_path).raise_for_status()
-        del self.table.foreign_keys[self.names[0]]
-        del self.pk_table.foreign_keys[self.names[0]]
+        del self.table.foreign_keys[self.name]
+        del self.pk_table.referenced_by[self.name]
 
 def make_type(type_doc, **kwargs):
     """Create instance of Type, DomainType, or ArrayType as appropriate for type_doc."""

--- a/deriva/core/ermrest_model.py
+++ b/deriva/core/ermrest_model.py
@@ -102,7 +102,7 @@ class Schema (_ec.CatalogSchema):
             'schema_name': schema_name,
             'comment': comment,
             'acls': acls,
-            'annotations': nochange,
+            'annotations': annotations,
         })
 
         r = self.catalog.put(self.uri_path, json=changes)

--- a/deriva/core/ermrest_model.py
+++ b/deriva/core/ermrest_model.py
@@ -94,14 +94,9 @@ class Schema (_ec.CatalogSchema):
         :param schema_name: Replacement schema name (default nochange)
         :param comment: Replacement comment (default nochange)
         :param acls: Replacement ACL configuration (default nochange)
+        :param annotations: Replacement annotations (default nochange)
 
         Returns self (to allow for optional chained access).
-
-        Partially updates self as side-effect to reflect changes
-        successfully acknowledged by server. For complete
-        synchronization, discard existing client-side model
-        information and retrieve catalog.getCatalogModel() with
-        authoritative copy from server.
 
         """
         changes = strip_nochange({
@@ -456,18 +451,14 @@ class Table (_ec.CatalogTable):
         :param table_name: Replacement table name (default nochange)
         :param comment: Replacement comment (default nochange)
         :param acls: Replacement ACL configuration (default nochange)
+        :param acl_bindings: Replacement ACL bindings (default nochange)
+        :param annotations: Replacement annotations (default nochange)
 
         A change of schema name is a transfer of the existing table to
         an existing destination schema (not a rename of the current
         containing schema).
 
         Returns self (to allow for optional chained access).
-
-        Partially updates self as side-effect to reflect changes
-        successfully acknowledged by server. For complete
-        synchronization, discard existing client-side model
-        information and retrieve catalog.getCatalogModel() with
-        authoritative copy from server.
 
         """
         changes = strip_nochange({
@@ -625,21 +616,24 @@ class Column (_ec.CatalogColumn):
 
         :param catalog: ErmrestCatalog instance
         :param name: Replacement column name (default nochange)
+        :param type: Replacement Type instance (default nochange)
+        :param nullok: Replacement nullok value (default nochange)
+        :param default: Replacement default value (default nochange)
         :param comment: Replacement comment (default nochange)
         :param acls: Replacement ACL configuration (default nochange)
         :param acl_bindings: Replacement ACL bindings (default nochange)
         :param annotations: Replacement annotations (default nochange)
 
-        A change of schema name is a transfer of the existing table to
-        an existing destination schema (not a rename of the current
-        containing schema).
-
         Returns self (to allow for optional chained access).
 
         """
+        if type is not nochange and not isinstance(type, Type):
+            raise TypeError('Parameter "type" %s should be an instance of Type.' % (type,))
         changes = strip_nochange({
-            'schema_name': schema_name,
-            'table_name': table_name,
+            'name': name,
+            'type': type,
+            'nullok': nullok,
+            'default': default,
             'comment': comment,
             'acls': acls,
             'acl_bindings': acl_bindings,

--- a/deriva/core/ermrest_model.py
+++ b/deriva/core/ermrest_model.py
@@ -1,5 +1,6 @@
 
 from . import ermrest_config as _ec
+from .ermrest_config import equivalent
 import re
 
 def _kwargs(**kwargs):
@@ -86,6 +87,28 @@ class Schema (_ec.CatalogSchema):
             'comment': self.comment,
         })
         return d
+
+    def apply(self, existing=None):
+        """Apply configuration to corresponding schema in catalog unless existing already matches.
+
+        :param existing: An instance comparable to self, or None to apply configuration unconditionally.
+
+        The state of self.comment, self.annotations, and self.acls
+        will be applied to the server unless they match their
+        corresponding state in existing.
+        """
+        changes = {}
+        if existing is None or not equivalent(self._comment, existing._comment):
+            changes['comment'] = self._comment
+        if existing is None or not equivalent(self.annotations, existing.annotations):
+            changes['annotations'] = self.annotations
+        if existing is None or not equivalent(self.acls, existing.acls):
+            changes['acls'] = self.acls
+        if changes:
+            # use alter method to reduce number of web requests
+            self.alter(**changes)
+        for tname, table in self.tables.items():
+            table.apply(existing.tables[tname] if existing else None)
 
     def alter(self, schema_name=nochange, comment=nochange, acls=nochange, annotations=nochange):
         """Alter existing schema definition.
@@ -430,6 +453,34 @@ class Table (_ec.CatalogTable):
         })
         return d
 
+    def apply(self, existing=None):
+        """Apply configuration to corresponding table in catalog unless existing already matches.
+
+        :param existing: An instance comparable to self, or None to apply configuration unconditionally.
+
+        The state of self.comment, self.annotations, self.acls, and
+        self.acl_bindings will be applied to the server unless they
+        match their corresponding state in existing.
+        """
+        changes = {}
+        if existing is None or not equivalent(self._comment, existing._comment):
+            changes['comment'] = self._comment
+        if existing is None or not equivalent(self.annotations, existing.annotations):
+            changes['annotations'] = self.annotations
+        if existing is None or not equivalent(self.acls, existing.acls):
+            changes['acls'] = self.acls
+        if existing is None or not equivalent(self.acl_bindings, existing.acl_bindings):
+            changes['acl_bindings'] = self.acl_bindings
+        if changes:
+            # use alter method to reduce number of web requests
+            self.alter(**changes)
+        for col in self.column_definitions:
+            col.apply(existing.column_definitions[col.name] if existing else None)
+        for key in self.keys:
+            key.apply(existing.keys[key.name_in_model(existing.schema.model)] if existing else None)
+        for fkey in self.foreign_keys:
+            fkey.apply(existing.foreign_keys[fkey.name_in_model(existing.schema.model)] if existing else None)
+
     def alter(
             self,
             schema_name=nochange,
@@ -591,6 +642,28 @@ class Column (_ec.CatalogColumn):
             'annotations': annotations,
         }
 
+    def apply(self, existing=None):
+        """Apply configuration to corresponding column in catalog unless existing already matches.
+
+        :param existing: An instance comparable to self, or None to apply configuration unconditionally.
+
+        The state of self.comment, self.annotations, self.acls, and
+        self.acl_bindings will be applied to the server unless they
+        match their corresponding state in existing.
+        """
+        changes = {}
+        if existing is None or not equivalent(self._comment, existing._comment):
+            changes['comment'] = self._comment
+        if existing is None or not equivalent(self.annotations, existing.annotations):
+            changes['annotations'] = self.annotations
+        if existing is None or not equivalent(self.acls, existing.acls):
+            changes['acls'] = self.acls
+        if existing is None or not equivalent(self.acl_bindings, existing.acl_bindings):
+            changes['acl_bindings'] = self.acl_bindings
+        if changes:
+            # use alter method to reduce number of web requests
+            self.alter(**changes)
+
     def alter(
             self,
             name=nochange,
@@ -701,6 +774,24 @@ class Key (_ec.CatalogKey):
             'annotations': annotations,
         }
 
+    def apply(self, existing=None):
+        """Apply configuration to corresponding table in catalog unless existing already matches.
+
+        :param existing: An instance comparable to self, or None to apply configuration unconditionally.
+
+        The state of self.comment and self.annotations will be applied
+        to the server unless they match their corresponding state in
+        existing.
+        """
+        changes = {}
+        if existing is None or not equivalent(self._comment, existing._comment):
+            changes['comment'] = self._comment
+        if existing is None or not equivalent(self.annotations, existing.annotations):
+            changes['annotations'] = self.annotations
+        if changes:
+            # use alter method to reduce number of web requests
+            self.alter(**changes)
+
     def alter(
             self,
             constraint_name=nochange,
@@ -793,6 +884,28 @@ class ForeignKey (_ec.CatalogForeignKey):
             'acl_bindings': acl_bindings,
             'annotations': annotations,
         }
+
+    def apply(self, existing=None):
+        """Apply configuration to corresponding table in catalog unless existing already matches.
+
+        :param existing: An instance comparable to self, or None to apply configuration unconditionally.
+
+        The state of self.comment, self.annotations, self.acls, and
+        self.acl_bindings will be applied to the server unless they
+        match their corresponding state in existing.
+        """
+        changes = {}
+        if existing is None or not equivalent(self._comment, existing._comment):
+            changes['comment'] = self._comment
+        if existing is None or not equivalent(self.annotations, existing.annotations):
+            changes['annotations'] = self.annotations
+        if existing is None or not equivalent(self.acls, existing.acls):
+            changes['acls'] = self.acls
+        if existing is None or not equivalent(self.acl_bindings, existing.acl_bindings):
+            changes['acl_bindings'] = self.acl_bindings
+        if changes:
+            # use alter method to reduce number of web requests
+            self.alter(**changes)
 
     def alter(
             self,

--- a/deriva/core/ermrest_model.py
+++ b/deriva/core/ermrest_model.py
@@ -148,7 +148,7 @@ class Schema (_ec.CatalogSchema):
         self.model.digest_fkeys()
         return newtable
 
-    def delete(self):
+    def drop(self):
         """Remove this schema from the remote database.
         """
         if self.name not in self.model.schemas:
@@ -555,7 +555,7 @@ class Table (_ec.CatalogTable):
             return fkey
         return self._create_table_part('foreignkey', add_fkey, ForeignKey, fkey_def)
 
-    def delete(self):
+    def drop(self):
         """Remove this table from the remote database.
         """
         if self.name not in self.schema.tables:
@@ -674,7 +674,7 @@ class Column (_ec.CatalogColumn):
         })
         return d
         
-    def delete(self):
+    def drop(self):
         """Remove this column from the remote database.
         """
         if self.name not in self.table.column_definitions.elements:
@@ -749,7 +749,7 @@ class Key (_ec.CatalogKey):
         })
         return d
 
-    def delete(self):
+    def drop(self):
         """Remove this key from the remote database.
         """
         if self.names[0] not in self.table.keys.elements:
@@ -866,7 +866,7 @@ class ForeignKey (_ec.CatalogForeignKey):
         })
         return d
 
-    def delete(self):
+    def drop(self):
         """Remove this foreign key from the remote database.
         """
         if self.names[0] not in self.table.foreign_keys.elements:

--- a/deriva/core/polling_ermrest_catalog.py
+++ b/deriva/core/polling_ermrest_catalog.py
@@ -176,13 +176,14 @@ class PollingErmrestCatalog(ErmrestCatalog):
                         # ... and delay for up to coalesce_seconds to combine multiple notices into one wakeup
                         while next(coalesce_gen)[0] is not None:
                             pass
+                        # run once per wakeup
+                        self._run_notice_event(look_for_work)
+                        last_notice_event = time.time()
                 else:
-                    # wait for next poll deadline
+                    # wait for next poll deadline and run once
                     time.sleep(next_poll_time())
-
-                # run once now that we've woken on AMQP or basic poll delay
-                self._run_notice_event(look_for_work)
-                last_notice_event = time.time()
+                    self._run_notice_event(look_for_work)
+                    last_notice_event = time.time()
 
             except pika.exceptions.AMQPConnectionError as e:
                 if amqp_failed_at is None:

--- a/deriva/core/utils/core_utils.py
+++ b/deriva/core/utils/core_utils.py
@@ -305,3 +305,30 @@ def get_transfer_summary(total_bytes, elapsed_time):
     summary = "%.2f %s transferred%s. %s" % \
               (transferred, "KB" if total_bytes < Megabyte else "MB", throughput, elapsed)
     return summary
+
+def topo_sorted(depmap):
+    """Return list of items topologically sorted.
+
+       depmap: { item: [required_item, ...], ... }
+
+    Raises ValueError if a required_item cannot be satisfied in any order.
+
+    The per-item required_item iterables must allow revisiting on
+    multiple iterations.
+
+    """
+    ordered = [ item for item, requires in depmap.items() if not requires ]
+    depmap = { item: set(requires) for item, requires in depmap.items() if requires }
+    satisfied = set(ordered)
+    while depmap:
+        additions = []
+        for item, requires in list(depmap.items()):
+            if requires.issubset(satisfied):
+                additions.append(item)
+                satisfied.add(item)
+                del depmap[item]
+        if not additions:
+            raise ValueError(("unsatisfiable", depmap))
+        ordered.extend(additions)
+        additions = []
+    return ordered

--- a/deriva/transfer/restore/deriva_restore.py
+++ b/deriva/transfer/restore/deriva_restore.py
@@ -151,7 +151,7 @@ class DerivaRestore:
 
     def copy_cdef(self, column):
         """Copy column definition with conditional parts."""
-        return sname, tname, self.prune_parts(column.prejson())
+        return self.prune_parts(column.prejson())
 
     @staticmethod
     def check_column_compatibility(src, dst):
@@ -172,7 +172,7 @@ class DerivaRestore:
             raise error("default", src.default, dst.default)
 
     def copy_kdef(self, key):
-        return sname, tname, self.prune_parts(key.prejson())
+        return self.prune_parts(key.prejson())
 
     def get_table_path(self, sname, tname, is_bag):
         return os.path.abspath(
@@ -269,7 +269,10 @@ class DerivaRestore:
 
         src_schema_file = os.path.abspath(
             os.path.join(self.input_path, "data" if is_bag else "", "catalog-schema.json"))
-        src_model = Model.fromfile(src_schema_file)
+        # the src_catalog_stub created below will never be "connected" in any kind of network sense,
+        # but we need an instance of ErmrestCatalog in order to get a working Model from the schema file.
+        src_catalog_stub = ErmrestCatalog("file", src_schema_file, "1")
+        src_model = Model.fromfile(src_catalog_stub, src_schema_file)
 
         # initialize/connect to destination catalog
         if not self.catalog_id:
@@ -340,7 +343,7 @@ class DerivaRestore:
 
                         for cname in src_columns:
                             if cname not in dst_columns:
-                                new_columns.append(self.copy_cdef(src_columns[cname]))
+                                new_columns.append((sname, tname, self.copy_cdef(src_columns[cname])))
                             else:
                                 self.check_column_compatibility(src_columns[cname], dst_columns[cname])
 
@@ -350,13 +353,13 @@ class DerivaRestore:
                                     "Destination column %s.%s.%s does not exist in source catalog." %
                                     (sname, tname, cname))
 
-                        src_keys = {tuple(sorted(key.unique_columns)): key for key in table.keys}
-                        dst_keys = {tuple(sorted(key.unique_columns)): key for key in
+                        src_keys = {tuple(sorted(c.name for c in key.unique_columns)): key for key in table.keys}
+                        dst_keys = {tuple(sorted(c.name for c in key.unique_columns)): key for key in
                                     dst_model.schemas[sname].tables[tname].keys}
 
                         for utuple in src_keys:
                             if utuple not in dst_keys:
-                                new_keys.append(self.copy_kdef(src_keys[utuple]))
+                                new_keys.append((sname, tname, self.copy_kdef(src_keys[utuple])))
 
                         for utuple in dst_keys:
                             if utuple not in src_keys:

--- a/deriva/transfer/upload/deriva_upload.py
+++ b/deriva/transfer/upload/deriva_upload.py
@@ -9,7 +9,7 @@ import tempfile
 import logging
 import platform
 from collections import OrderedDict, namedtuple
-from deriva.core import ErmrestCatalog, CatalogConfig, HatracStore, HatracJobAborted, HatracJobPaused, \
+from deriva.core import ErmrestCatalog, HatracStore, HatracJobAborted, HatracJobPaused, \
     HatracJobTimeout, urlquote, stob, format_exception, get_credential, read_config, write_config, copy_config, \
     resource_path, make_dirs, lock_file, DEFAULT_CHUNK_SIZE, IS_PY2, __version__ as VERSION
 from deriva.core.utils import hash_utils as hu, mime_utils as mu, version_utils as vu
@@ -343,7 +343,7 @@ class DerivaUpload(object):
                (self.DefaultTransferStateBaseName, self.server.get('host', 'localhost'))
 
     def getRemoteConfig(self):
-        catalog_config = CatalogConfig.fromcatalog(self.catalog)
+        catalog_config = self.catalog.getCatalogModel()
         return catalog_config.bulk_upload
 
     def getUpdatedConfig(self):

--- a/docs/README.md
+++ b/docs/README.md
@@ -258,12 +258,18 @@ foreign keys:
     
     key.alter(constraint_name=new_unqualified_name_str)
     
-    foreign_key.alter(constraint_name=new_unqualified_name_str)
+    foreign_key.alter(
+      constraint_name=new_unqualified_name_str,
+      on_update=new_action_string,
+      on_delete=new_action_string
+    )
 
 The key and foreign key alterations accept only the unqualified
 constraint name string, because it is not possible to change the
 schema qualification other than by relocating the parent table to a
-different schema.
+different schema. The foreign key alteration also supports changes to
+the `on_update` and `on_delete` action, e.g. `NO ACTION`, `SET NULL`,
+or `CASCADE`.
 
 As a convenience, there are also optional `alter()` arguments to
 reconfigure `comment`, `acls`, `acl_bindings` if they exist in the

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,7 +62,7 @@ access layer.
    - Change acls on schema, table, column, and foreign key constraints.
    - Change acl\_bindings on table, column, and foreign key constraints.
    - Change annotations on catalog, schema, table, column, key, or foreign key constraints.
-- Delete model elements
+- Drop model elements
    - Drop schemas.
    - Drop tables.
    - Drop columns.
@@ -210,17 +210,17 @@ be added to a model with `model.create_schema(schema_def)`.
 
 #### Remove a Column from a Table
 
-To delete a column, you invoke the `delete()` method on the
+To remove or "drop" a column, you invoke the `drop()` method on the
 column object itself:
 
     table = model_root.table(schema_name, table_name)
 	column = table.column_definitions[column_name]
-	column.delete()
+	column.drop()
 
 The same pattern can be used to remove a key or foreign key from a
-table via `key.delete()` or `foreign_key.delete()`,
+table via `key.drop()` or `foreign_key.drop()`,
 respectively. Similarly, a schema or table can be removed with
-`schema.delete()` or `table.delete()`, respectively.
+`schema.drop()` or `table.drop()`, respectively.
 
 #### Alter a Table
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,12 +57,23 @@ access layer.
    - Create new columns on existing tables.
    - Create new key constraints over existing columns.
    - Create new foreign key constraints over existing columns and key constraints.
+- Reconfigure model elements
+   - Change comment string on schema, table, column, key, or foreign key constraints.
+   - Change acls on schema, table, column, and foreign key constraints.
+   - Change acl\_bindings on table, column, and foreign key constraints.
+   - Change annotations on catalog, schema, table, column, key, or foreign key constraints.
 - Delete model elements
    - Drop schemas.
    - Drop tables.
    - Drop columns.
    - Drop key constraints.
    - Drop foreign key constraints.
+- Alter model elements
+   - Rename a schema.
+   - Rename a table or move the table between schemas.
+   - Rename a column, or change column storage type, default value, or null-ok status.
+   - Rename a key constraint.
+   - Rename a foreign key constraint.
 
 ### Limitations
 
@@ -72,11 +83,10 @@ the local objects to get out of synchronization with the remote
 catalog and either represent model elements which no longer exist or
 lack model elements recently added.
 
-The provided management methods, when used carefully, can
-incrementally update the local representation with changes made to the
-server by the calling client. However, if other clients make
-concurrent changes, it is likely that the local representation will
-diverge.
+The provided management methods can incrementally update the local
+representation with changes made to the server by the calling
+client. However, if other clients make concurrent changes, it is
+likely that the local representation will diverge.
 
 The only robust solution to this problem is for the caller to discard
 its model representation, reconstruct it to match the latest server
@@ -147,7 +157,7 @@ definition:
       provide_system=True,
     )
     schema = model_root.schemas[schema_name]
-    new_table = schema.create_table(catalog, table_def)
+    new_table = schema.create_table(table_def)
 
 By default, `create_table(...)` will add system columns to the table
 definition, so the caller does not need to reconstruct these standard elements
@@ -161,7 +171,7 @@ science data columns.  A simple vocabulary term table can be
 created with a helper function:
 
     schema = model_root.schemas[schema_name]
-    new_vocab_table = schema.create_table(catalog,
+    new_vocab_table = schema.create_table(
       Table.define_vocabulary(
         "My Vocabulary",
         "MYPROJECT:{RID}",
@@ -169,7 +179,7 @@ created with a helper function:
       )
     )
 
-The `Table.define_vocabular()` method is a convenience wrapper around
+The `Table.define_vocabulary()` method is a convenience wrapper around
 `Table.define()` to automatically generate core vocabulary table
 structures. It accepts other table definition parameters which a
 sophisticated caller can use to override or extend these core
@@ -191,13 +201,12 @@ existing table.
       acl_bindings={},
     )
     table = model_root.table(schema_name, table_name)
-    new_column = table.create_column(catalog, column_def)
+    new_column = table.create_column(column_def)
 
 The same pattern can be used to add a key or foreign key to an
-existing table via `table.create_key(catalog, key_def)` or
-`table.create_fkey(catalog, fkey_def)`, respectively. Similarly, a
-schema can be added to a model with `model.create_schema(catalog,
-schema_def)`.
+existing table via `table.create_key(key_def)` or
+`table.create_fkey(fkey_def)`, respectively. Similarly, a schema can
+be added to a model with `model.create_schema(schema_def)`.
 
 #### Remove a Column from a Table
 
@@ -206,18 +215,64 @@ column object itself:
 
     table = model_root.table(schema_name, table_name)
 	column = table.column_definitions[column_name]
-	column.delete(catalog, table=table)
-
-The optional `table` argument allows the method to prune the stale
-object from the table object to reflect the change made on
-the server. If this is omitted, the server change will be made but the
-local table object will fall out of synchronization.
+	column.delete()
 
 The same pattern can be used to remove a key or foreign key from a
-table via `key.delete(catalog, table)` or `foreign_key.delete(catalog,
-table)`, respectively. Similarly, a schema or table can be removed
-with `schema.delete(catalog, model)` or `table.delete(catalog,
-schema)`, respectively.
+table via `key.delete()` or `foreign_key.delete()`,
+respectively. Similarly, a schema or table can be removed with
+`schema.delete()` or `table.delete()`, respectively.
+
+#### Alter a Table
+
+To alter certain aspects of an existing table, you invoke the
+`alter()` method with optional keyword arguments for the aspects you
+wish to change. The default for omitted keyword arguments is a special
+`nochange` value which means to keep that aspect as it is currently
+defined:
+
+    table = model_root.table(orig_schema_name, orig_table_name)
+    table.alter(
+      schema_name=destination_schema_name,
+      table_name=new_table_name
+    )
+
+The `schema_name` argument allows you to relocate an existing table
+from an original schema to a destination schema, where both named
+schemas already exist in the model. This also relocates key or foreign
+key constraints in the table at the same time. The `table_name`
+argument allows you to revise the name of an existing table in the
+model, while preserving other aspects of the table definition,
+content, and content history.
+
+The same pattern can be used to alter schemas, columns, keys, and
+foreign keys:
+
+    schema.alter(schema_name=new_schema_name)
+    
+    column.alter(
+      name=new_column_name,
+      type=new_column_type_obj,
+      nullok=new_nullok_value,
+      default=new_default_value
+    )
+    
+    key.alter(constraint_name=new_unqualified_name_str)
+    
+    foreign_key.alter(constraint_name=new_unqualified_name_str)
+
+The key and foreign key alterations accept only the unqualified
+constraint name string, because it is not possible to change the
+schema qualification other than by relocating the parent table to a
+different schema.
+
+As a convenience, there are also optional `alter()` arguments to
+reconfigure `comment`, `acls`, `acl_bindings` if they exist in the
+`define()` method for the same class of object. They are omitted from
+the preceding examples for the sake of brevity. These arguments allow
+similar effect to mutating the local configuration fields and then
+invoking the `apply()` method to send them to the server, except that
+configuration changes included in an `alter()` request will happen
+atomically with respect to the other indicated alterations.
 
 ## ErmrestCatalog
 
@@ -286,7 +341,7 @@ factory methods on a catalog or snapshot object:
    - The `config_root` object roots a tree of objects isomorphic to the catalog model, organizing configuration data according to each part of the model.
    - Allows inspection of catalog/snapshot annotations and policies.
    - Allows mutation to draft a new configuration objective.
-   - Draft changes are applied with `catalog.applyCatalogConfig(config_root)`
+   - Draft changes are applied with `config_root.apply()`
 - `model_root = catalog.getCatalogModel()`
    - `deriva.core.ermrest_model.Model` object for catalog (or snapshot)
    - The `model_root` object roots a tree of objects isomorphic to the catalog model, organizing model definitions according to each part of the model.

--- a/tests/deriva/core/test_datapath.py
+++ b/tests/deriva/core/test_datapath.py
@@ -52,9 +52,9 @@ def define_test_schema(catalog):
     An 'isa' schema with an 'experiment' table, with 'type' that references the vocab table.
     """
     model = catalog.getCatalogModel()
-    vocab = model.create_schema(catalog, _em.Schema.define("Vocab"))
-    vocab.create_table(catalog, _em.Table.define_vocabulary("Experiment_Type", "TEST:{RID}"))
-    isa = model.create_schema(catalog, _em.Schema.define("ISA"))
+    vocab = model.create_schema(_em.Schema.define("Vocab"))
+    vocab.create_table(_em.Table.define_vocabulary("Experiment_Type", "TEST:{RID}"))
+    isa = model.create_schema(_em.Schema.define("ISA"))
 
     # create 'Project' table
     table_def = _em.Table.define(
@@ -69,7 +69,7 @@ def define_test_schema(catalog):
             _em.Key.define(['Investigator', 'Num'])
         ]
     )
-    isa.create_table(catalog, table_def)
+    isa.create_table(table_def)
 
     # create 'Experiment' table
     table_def = _em.Table.define(
@@ -92,11 +92,11 @@ def define_test_schema(catalog):
             _em.ForeignKey.define(['Project_Investigator', 'Project_Num'], 'ISA', 'Project', ['Investigator', 'Num'])
         ]
     )
-    isa.create_table(catalog, table_def)
+    isa.create_table(table_def)
 
     # create copy of 'Experiment' table
     table_def['table_name'] = 'Experiment_Copy'
-    isa.create_table(catalog, table_def)
+    isa.create_table(table_def)
 
 
 def _generate_experiment_entities(types, count):
@@ -566,3 +566,7 @@ class DatapathTests (unittest.TestCase):
         ig = itemgetter(*nondefaults)
         for i in range(TEST_EXP_MAX):
             self.assertEqual(ig(results[i]), ig(entities_copy[i]), 'copied values do not match')
+
+
+if __name__ == '__main__':
+    sys.exit(unittest.main())


### PR DESCRIPTION
This is a work-in-progress.  I'm opening the PR early just to make review of the changes easier.

This at its core is adding model alteration methods to do things like schema, table, and column renames and various other things equivalent to SQL `ALTER` statements.

In support of that goal, it also refactors some of the model object hierarchy to provide tighter linkage, so the model-changing methods can also update the client-side object representations to reflect the changes made to the server model.  (This is only for changes performed by the method itself. It does not attempt to detect or reconcile asynchronous changes made to the catalog by other clients.)