### PR TITLE
Paged catalog download and some streaming requests.get tweaks.

### DIFF
--- a/deriva/core/__init__.py
+++ b/deriva/core/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.3"
+__version__ = "1.1"
 
 from deriva.core.utils.core_utils import *
 from deriva.core.base_cli import BaseCLI, KeyValuePairArgs

--- a/deriva/core/ermrest_catalog.py
+++ b/deriva/core/ermrest_catalog.py
@@ -160,7 +160,9 @@ class ErmrestCatalog(DerivaBinding):
             return None
         return entity[0], entity[1]
 
-    def getAsFile(self, path, destfilename,
+    def getAsFile(self,
+                  path,
+                  destfilename,
                   headers=DEFAULT_HEADERS,
                   callback=None,
                   delete_if_empty=False,

--- a/deriva/core/ermrest_catalog.py
+++ b/deriva/core/ermrest_catalog.py
@@ -1,4 +1,5 @@
 import os
+import io
 import logging
 import datetime
 import codecs
@@ -16,6 +17,8 @@ class ErmrestCatalogMutationError(Exception):
 
 
 _clone_state_url = "tag:isrd.isi.edu,2018:clone-status"
+
+DEFAULT_PAGE_SIZE = 100000
 
 
 class ErmrestCatalog(DerivaBinding):
@@ -167,7 +170,7 @@ class ErmrestCatalog(DerivaBinding):
                   callback=None,
                   delete_if_empty=False,
                   paged=False,
-                  page_size=100000):
+                  page_size=DEFAULT_PAGE_SIZE):
         """
            Retrieve catalog data streamed to destination file.
            Caller is responsible to clean up file even on error, when the file may or may not be exist.
@@ -178,15 +181,17 @@ class ErmrestCatalog(DerivaBinding):
         """
         self.check_path(path)
 
-        # Only entity API supported with paged mode at this time, otherwise fallback.
-        page_size = page_size if page_size > 0 else 100000
+        # Only entity API supported with paged mode at this time, otherwise fallback. We fallback rather than raise an
+        # exception in the case that the caller might be trying to perform an opportunistic paged request without
+        # knowing a priori if paged support for the given query is available.
+        page_size = page_size if page_size > 0 else DEFAULT_PAGE_SIZE
         if not path.startswith("/entity") and paged:
             logging.debug("Paged data retrieval only supported for entity API queries.")
             paged = False
 
         # Only "application/x-json-stream" or "text/csv" supported with paged mode at this time, otherwise fallback.
         accept = headers.get("accept")
-        if not (accept == "application/x-json-stream" or accept == "text/csv"):
+        if accept not in ("application/x-json-stream", "text/csv"):
             logging.debug("Paged data retrieval not supported for content type: %s" % accept)
             paged = False
 
@@ -213,58 +218,78 @@ class ErmrestCatalog(DerivaBinding):
                                 destfile.close()
                                 return
             else:
-                first = True
-                last = None
-                backoff = 2
+                first_page = True
+                first_line = None
+                last_record = None
                 while True:
                     qualifier = "@sort(RID)%s?limit=%d" % \
-                               (("@after(%s)" % urlquote(last)) if last is not None else "", page_size)
-                    with self._session.get(self._server_uri + path + qualifier, headers=headers, stream=True) as r:
+                               (("@after(%s)" % urlquote(last_record)) if last_record is not None else "", page_size)
+                    # 1. Try to get a page worth of data, back-off page size if query run time errors are encountered
+                    with self._session.get(self._server_uri + path + qualifier, headers=headers) as r:
                         if r.status_code == 400 and "Query run time limit exceeded" in r.text:
                             r.close()
-                            backoff *= 2
-                            page_size //= backoff
+                            page_size //= 2
                             page_size = 1 if page_size < 1 else page_size
                             logging.warning("Query runtime exceeded while attempting to transfer rows from %s to file "
                                             "[%s]. The page size is being reduced to %s and the query will be retried."
                                             % (self._server_uri + path, destfilename, page_size))
                             continue
-                        logging.debug("Transferring file %s to %s" % (self._server_uri + path, destfilename))
-                        content_type = r.headers.get("Content-Type")
+
+                        # 2. Write the page to disk and determine the last RID processed in order to get the next page
                         last_line = None
-                        lines = r.iter_lines()
+                        content_type = r.headers.get("Content-Type")
+                        logging.debug("Transferring file %s to %s" % (self._server_uri + path, destfilename))
+                        # CSV processing iterates over lines in the response, skipping the header line(s) in all but
+                        # the first page, and captures the last line of each page to determine the last record processed
                         if content_type == "text/csv":
-                            try:
-                                first_line = next(lines)
-                            except StopIteration:
-                                break
-                            if first:
-                                tline = first_line + b"\n"
+                            skip = 1
+                            line_num = 0
+                            if first_page:
+                                lines = r.iter_lines(decode_unicode=True)
+                                reader = csv.reader(lines)
+                                first_line = next(reader)
+                                skip = reader.line_num
+                            for line in r.iter_lines():
+                                if not first_page:
+                                    line_num += 1
+                                    if line_num <= skip:
+                                        continue
+                                tline = line + b"\n"
                                 destfile.write(tline)
                                 total += len(tline)
                                 last_line = tline
-                                first = False
-                        for line in lines:
-                            tline = line + b"\n"
-                            destfile.write(tline)
-                            total += len(tline)
-                            last_line = tline
+                            if last_line and last_line != first_line:
+                                reader = csv.DictReader([last_line.decode('utf-8')], first_line)
+                                last_line = next(reader)
+                            first_page = False
+                        # JSON-Stream processing writes the entire buffer to the destination file. The last line is
+                        # captured by reverse seeking in the buffer from right before the last b'\n' newline to the next
+                        # newline or buf[0], then calling readline from the current position
+                        elif content_type == "application/x-json-stream":
+                            buf = r.content
+                            if not buf:
+                                break
+                            destfile.write(buf)
+                            total += len(buf)
+                            b = io.BytesIO(buf)
+                            b.seek(-2, os.SEEK_END)
+                            while b.read(1) != b'\n':
+                                b.seek(-2, os.SEEK_CUR)
+                                if b.tell() == os.SEEK_SET:
+                                    break
+                            last_line = json.loads(b.readline().decode('utf-8'))
+
+                        # 3. Save the last record RID and flush the destination file buffers to disk.
+                        if not last_line:
+                            break
                         destfile.flush()
                         os.fsync(destfile.fileno())
+                        last_record = last_line['RID']
                         if callback:
                             if not callback(progress="Downloading: %.2f MB transferred" %
                                                      (float(total) / float(Megabyte))):
                                 destfile.close()
                                 return
-                        if not last_line:
-                            break
-                        if content_type == "application/x-json-stream":
-                            last_line = json.loads(last_line.decode('utf-8'))
-                        elif content_type == "text/csv" and last_line != first_line:
-                            reader = csv.DictReader([last_line.decode('utf-8')],
-                                                    first_line.decode('utf-8').split(","))
-                            last_line = next(reader)
-                        last = last_line['RID']
 
             elapsed = datetime.datetime.now() - start
             summary = get_transfer_summary(total, elapsed)

--- a/deriva/core/ermrest_catalog.py
+++ b/deriva/core/ermrest_catalog.py
@@ -210,13 +210,13 @@ class ErmrestCatalog(DerivaBinding):
                     for buf in r.iter_content(chunk_size=DEFAULT_CHUNK_SIZE):
                         destfile.write(buf)
                         total += len(buf)
-                        destfile.flush()
-                        os.fsync(destfile.fileno())
                         if callback:
                             if not callback(progress="Downloading: %.2f MB transferred" %
                                                      (float(total) / float(Megabyte))):
                                 destfile.close()
                                 return
+                destfile.flush()
+                os.fsync(destfile.fileno())
             else:
                 first_page = True
                 first_line = None

--- a/deriva/core/ermrest_catalog.py
+++ b/deriva/core/ermrest_catalog.py
@@ -3,16 +3,20 @@ import logging
 import datetime
 import codecs
 import csv
+import json
 
 from . import urlquote, datapath, DEFAULT_HEADERS, DEFAULT_CHUNK_SIZE, Megabyte, Kilobyte, get_transfer_summary, IS_PY2
 from .deriva_binding import DerivaBinding
 from .ermrest_config import CatalogConfig
 from . import ermrest_model
 
+
 class ErmrestCatalogMutationError(Exception):
     pass
 
+
 _clone_state_url = "tag:isrd.isi.edu,2018:clone-status"
+
 
 class ErmrestCatalog(DerivaBinding):
     """Persistent handle for an ERMrest catalog.
@@ -156,37 +160,110 @@ class ErmrestCatalog(DerivaBinding):
             return None
         return entity[0], entity[1]
 
-    def getAsFile(self, path, destfilename, headers=DEFAULT_HEADERS, callback=None, delete_if_empty=False):
+    def getAsFile(self, path, destfilename,
+                  headers=DEFAULT_HEADERS,
+                  callback=None,
+                  delete_if_empty=False,
+                  paged=False,
+                  page_size=100000):
         """
            Retrieve catalog data streamed to destination file.
            Caller is responsible to clean up file even on error, when the file may or may not be exist.
            If "delete_if_empty" is True, the file will be inspected for "empty" content. In the case of
            json/json-stream content, the presence of a single empty JSON object will be tested for. In the case of
-           CSV content, the file will be parsed with CSV reader to determine that only a single header line and now row
+           CSV content, the file will be parsed with CSV reader to determine that only a single header line and no row
            data is present.
         """
         self.check_path(path)
+
+        # Only entity API supported with paged mode at this time, otherwise fallback.
+        page_size = page_size if page_size > 0 else 100000
+        if not path.startswith("/entity") and paged:
+            logging.debug("Paged data retrieval only supported for entity API queries.")
+            paged = False
+
+        # Only "application/x-json-stream" or "text/csv" supported with paged mode at this time, otherwise fallback.
+        accept = headers.get("accept")
+        if not (accept == "application/x-json-stream" or accept == "text/csv"):
+            logging.debug("Paged data retrieval not supported for content type: %s" % accept)
+            paged = False
 
         headers = headers.copy()
 
         destfile = open(destfilename, 'w+b')
 
         try:
-            r = self._session.get(self._server_uri + path, headers=headers, stream=True)
-            self._response_raise_for_status(r)
-            content_type = r.headers.get("Content-Type")
-
             total = 0
             start = datetime.datetime.now()
-            logging.debug("Transferring file %s to %s" % (self._server_uri + path, destfilename))
-            for buf in r.iter_content(chunk_size=DEFAULT_CHUNK_SIZE):
-                destfile.write(buf)
-                total += len(buf)
-                if callback:
-                    if not callback(progress="Downloading: %.2f MB transferred" % (float(total) / float(Megabyte))):
-                        destfile.close()
-                        return None
-            destfile.flush()
+            if not paged:
+                with self._session.get(self._server_uri + path, headers=headers, stream=True) as r:
+                    self._response_raise_for_status(r)
+                    content_type = r.headers.get("Content-Type")
+                    logging.debug("Transferring file %s to %s" % (self._server_uri + path, destfilename))
+                    for buf in r.iter_content(chunk_size=DEFAULT_CHUNK_SIZE):
+                        destfile.write(buf)
+                        total += len(buf)
+                        destfile.flush()
+                        os.fsync(destfile.fileno())
+                        if callback:
+                            if not callback(progress="Downloading: %.2f MB transferred" %
+                                                     (float(total) / float(Megabyte))):
+                                destfile.close()
+                                return
+            else:
+                first = True
+                last = None
+                backoff = 2
+                while True:
+                    qualifier = "@sort(RID)%s?limit=%d" % \
+                               (("@after(%s)" % urlquote(last)) if last is not None else "", page_size)
+                    with self._session.get(self._server_uri + path + qualifier, headers=headers, stream=True) as r:
+                        if r.status_code == 400 and "Query run time limit exceeded" in r.text:
+                            r.close()
+                            backoff *= 2
+                            page_size //= backoff
+                            page_size = 1 if page_size < 1 else page_size
+                            logging.warning("Query runtime exceeded while attempting to transfer rows from %s to file "
+                                            "[%s]. The page size is being reduced to %s and the query will be retried."
+                                            % (self._server_uri + path, destfilename, page_size))
+                            continue
+                        logging.debug("Transferring file %s to %s" % (self._server_uri + path, destfilename))
+                        content_type = r.headers.get("Content-Type")
+                        last_line = None
+                        lines = r.iter_lines()
+                        if content_type == "text/csv":
+                            try:
+                                first_line = next(lines)
+                            except StopIteration:
+                                break
+                            if first:
+                                tline = first_line + b"\n"
+                                destfile.write(tline)
+                                total += len(tline)
+                                last_line = tline
+                                first = False
+                        for line in lines:
+                            tline = line + b"\n"
+                            destfile.write(tline)
+                            total += len(tline)
+                            last_line = tline
+                        destfile.flush()
+                        os.fsync(destfile.fileno())
+                        if callback:
+                            if not callback(progress="Downloading: %.2f MB transferred" %
+                                                     (float(total) / float(Megabyte))):
+                                destfile.close()
+                                return
+                        if not last_line:
+                            break
+                        if content_type == "application/x-json-stream":
+                            last_line = json.loads(last_line.decode('utf-8'))
+                        elif content_type == "text/csv" and last_line != first_line:
+                            reader = csv.DictReader([last_line.decode('utf-8')],
+                                                    first_line.decode('utf-8').split(","))
+                            last_line = next(reader)
+                        last = last_line['RID']
+
             elapsed = datetime.datetime.now() - start
             summary = get_transfer_summary(total, elapsed)
 
@@ -221,7 +298,6 @@ class ErmrestCatalog(DerivaBinding):
             if callback:
                 callback(summary=log_msg, file_path=destfilename)
 
-            return r
         finally:
             if destfile:
                 destfile.close()

--- a/deriva/core/hatrac_store.py
+++ b/deriva/core/hatrac_store.py
@@ -109,15 +109,17 @@ class HatracStore(DerivaBinding):
                 total = 0
                 start = datetime.datetime.now()
                 logging.debug("Transferring file %s to %s" % (self._server_uri + path, destfilename))
-                for buf in r.iter_content(chunk_size=Megabyte):
+                for buf in r.iter_content(chunk_size=DEFAULT_CHUNK_SIZE):
                     destfile.write(buf)
                     total += len(buf)
+                    destfile.flush()
+                    os.fsync(destfile.fileno())
                     if callback:
                         if not callback(progress="Downloading: %.2f MB transferred" % (total / Megabyte)):
                             destfile.close()
+                            r.close()
                             os.remove(destfilename)
                             return None
-                destfile.flush()
                 elapsed = datetime.datetime.now() - start
                 summary = get_transfer_summary(total, elapsed)
                 logging.info("File [%s] transfer successful. %s" % (destfilename, summary))

--- a/deriva/core/hatrac_store.py
+++ b/deriva/core/hatrac_store.py
@@ -112,8 +112,6 @@ class HatracStore(DerivaBinding):
                 for buf in r.iter_content(chunk_size=DEFAULT_CHUNK_SIZE):
                     destfile.write(buf)
                     total += len(buf)
-                    destfile.flush()
-                    os.fsync(destfile.fileno())
                     if callback:
                         if not callback(progress="Downloading: %.2f MB transferred" % (total / Megabyte)):
                             destfile.close()
@@ -122,6 +120,8 @@ class HatracStore(DerivaBinding):
                             return None
                 elapsed = datetime.datetime.now() - start
                 summary = get_transfer_summary(total, elapsed)
+                destfile.flush()
+                os.fsync(destfile.fileno())
                 logging.info("File [%s] transfer successful. %s" % (destfilename, summary))
                 if callback:
                     callback(summary=summary, file_path=destfilename)

--- a/deriva/core/utils/core_utils.py
+++ b/deriva/core/utils/core_utils.py
@@ -224,6 +224,7 @@ def write_credential(credential_file=DEFAULT_CREDENTIAL_FILE, credential=DEFAULT
             credential_data = unicode(credential_data, 'utf-8')
         cf.write(credential_data)
         cf.flush()
+        os.fsync(cf.fileno())
 
 
 def read_credential(credential_file=DEFAULT_CREDENTIAL_FILE, create_default=False, default=DEFAULT_CREDENTIAL):

--- a/deriva/transfer/backup/deriva_backup.py
+++ b/deriva/transfer/backup/deriva_backup.py
@@ -23,8 +23,8 @@ class DerivaBackup(DerivaDownload):
             "output_path": "catalog-schema"
         }
     }
-    BASE_DATA_QUERY_PATH = "/entity/{}:{}?limit=none"
-    BASE_DATA_OUTPUT_PATH = "records/{}/{}.json"
+    BASE_DATA_QUERY_PATH = "/entity/{}:{}"
+    BASE_DATA_OUTPUT_PATH = "records/{}/{}"
     BASE_ASSET_OUTPUT_PATH = "assets"
 
     def __init__(self, *args, **kwargs):
@@ -89,7 +89,10 @@ class DerivaBackup(DerivaDownload):
                     query_path = self.BASE_DATA_QUERY_PATH.format(q_sname, q_tname)
                     query_proc = dict()
                     query_proc["processor"] = data_format
-                    query_proc["processor_params"] = {"query_path": query_path, "output_path": output_path}
+                    query_proc_params = {"query_path": query_path, "output_path": output_path}
+                    if data_format == "json-stream":
+                        query_proc_params.update({"paged_query": True, "paged_query_size": 100000})
+                    query_proc["processor_params"] = query_proc_params
                     self.config["catalog"]["query_processors"].append(query_proc)
 
         self.generate_asset_configs()

--- a/deriva/transfer/backup/deriva_backup.py
+++ b/deriva/transfer/backup/deriva_backup.py
@@ -90,7 +90,7 @@ class DerivaBackup(DerivaDownload):
                     query_proc = dict()
                     query_proc["processor"] = data_format
                     query_proc_params = {"query_path": query_path, "output_path": output_path}
-                    if data_format == "json-stream":
+                    if data_format in ("json-stream", "csv"):
                         query_proc_params.update({"paged_query": True, "paged_query_size": 100000})
                     query_proc["processor_params"] = query_proc_params
                     self.config["catalog"]["query_processors"].append(query_proc)

--- a/deriva/transfer/download/processors/query/base_query_processor.py
+++ b/deriva/transfer/download/processors/query/base_query_processor.py
@@ -39,6 +39,8 @@ class BaseQueryProcessor(BaseProcessor):
         self.ro_author_orcid = self.kwargs.get("ro_author_orcid")
         self.output_relpath = None
         self.output_abspath = None
+        self.paged_query = self.parameters.get("paged_query", False)
+        self.paged_query_size = self.parameters.get("paged_query_size", 100000)
 
     def process(self):
         resp = self.catalogQuery(headers={'accept': self.content_type})
@@ -68,7 +70,11 @@ class BaseQueryProcessor(BaseProcessor):
             make_dirs(output_dir)
         try:
             if as_file:
-                return self.catalog.getAsFile(self.query, self.output_abspath, headers=headers, delete_if_empty=True)
+                return self.catalog.getAsFile(self.query, self.output_abspath,
+                                              headers=headers,
+                                              delete_if_empty=True,
+                                              paged=self.paged_query,
+                                              page_size=self.paged_query_size)
             else:
                 return self.catalog.get(self.query, headers=headers).json()
         except requests.HTTPError as e:

--- a/deriva/transfer/download/processors/query/file_download_query_processor.py
+++ b/deriva/transfer/download/processors/query/file_download_query_processor.py
@@ -53,8 +53,6 @@ class FileDownloadQueryProcessor(BaseQueryProcessor):
                         for chunk in r.iter_content(chunk_size=DEFAULT_CHUNK_SIZE):
                             data_file.write(chunk)
                             total += len(chunk)
-                            data_file.flush()
-                            os.fsync(data_file.fileno())
                     elapsed = datetime.datetime.now() - start
                     summary = get_transfer_summary(total, elapsed)
                     logging.info("File [%s] transfer successful. %s" % (output_path, summary))

--- a/deriva/transfer/upload/deriva_upload.py
+++ b/deriva/transfer/upload/deriva_upload.py
@@ -1058,6 +1058,7 @@ class DerivaUpload(object):
             self.transfer_state_fh.truncate()
             json.dump(self.transfer_state, self.transfer_state_fh, indent=2)
             self.transfer_state_fh.flush()
+            os.fsync(self.transfer_state_fh.fileno())
         except Exception as e:
             logger.warning("Unable to write transfer state file: %s" % format_exception(e))
 
@@ -1065,6 +1066,7 @@ class DerivaUpload(object):
         if self.transfer_state_fh and not self.transfer_state_fh.closed:
             try:
                 self.transfer_state_fh.flush()
+                os.fsync(self.transfer_state_fh.fileno())
                 self.transfer_state_fh.close()
             except Exception as e:
                 logger.warning("Unable to flush/close transfer state file: %s" % format_exception(e))


### PR DESCRIPTION
Add paged download option in `ermrest_catalog.getAsFile`. Currently limited to entity API and CSV and JSON-Stream output types. DerivaBackup is currently the only component that is configured to use paged mode by default.

Various tweaks when using `requests.get()` in stream mode and writing responses to files with response body iterators:
* Perform `requests.get()` using context manager where applicable. This will close the response object if not consuming all of response buffer per requests docs in order to ensure the connection is released back to the pool. This can happen if a callback response indicates abort or some other mid-transfer error.
* Call `flush()` after every chunk iteration, and when flushing to the destination file also call `os.fsync` to actually ensure the OS commits the write to disk.

Bumping version to `1.1` as well.