### PR TITLE
check for binning min/max values determined to be `None` (#121)

### DIFF
--- a/deriva/core/datapath.py
+++ b/deriva/core/datapath.py
@@ -1515,3 +1515,5 @@ class AttributeGroup (object):
                     result = self._source.aggregates(*aggrs)[0]
                     bin.minval = result.get('minval', bin.minval)
                     bin.maxval = result.get('maxval', bin.maxval)
+                    if (bin.minval is None) or (bin.maxval is None):
+                        raise ValueError('Binning minimum or maximum must not be set to None')


### PR DESCRIPTION
This fixes #121 by raising a `ValueError` if the min/max values for binning are found to be `None`.