### PR TITLE
support for merging and composing paths with other paths

### DIFF
--- a/deriva/core/datapath.py
+++ b/deriva/core/datapath.py
@@ -82,6 +82,30 @@ class Catalog (object):
         else:
             return getattr(super(Catalog, self), a)
 
+    @classmethod
+    def compose(cls, *paths):
+        """Compose path fragments into a path.
+
+        The root of any path fragment must be found in the table instances of the currently composed path from left
+        to right, _but_ it does not have to be the current context (last table instance) of the last left hand path.
+
+        Paths must not have overlapping table instances with the currently composed path from left to right, except for
+        each subsequent path's root table instance which _must_ be defined in one of the left hand paths.
+
+        No input path in 'paths' will be mutated.
+
+        :param paths: instances of `DataPath`
+        :return: a new `DataPath` instance composed from the 'paths'
+        """
+        if not paths:
+            raise ValueError("No input path(s) given")
+        if not all(isinstance(path, DataPath) for path in paths):
+            raise TypeError("Input 'paths' must be an instance of %s" % type(DataPath).__name__)
+        base = copy.deepcopy(paths[0])
+        for path in paths[1:]:
+            base.merge(path)
+        return base
+
 
 class Schema (object):
     """Represents a Schema.

--- a/tests/deriva/core/test_datapath.py
+++ b/tests/deriva/core/test_datapath.py
@@ -707,6 +707,18 @@ class DatapathTests (unittest.TestCase):
                 self.assertNotEqual(path, cp)
                 self.assertEqual(path.uri, cp.uri)
 
+    def test_merge_paths(self):
+        path1 = self.experiment.filter(self.experiment.Amount >= 0)
+        path2 = self.experiment.link(self.experiment_type).filter(self.experiment_type.ID >= '0')
+        path3 = self.experiment.link(self.project).filter(self.project.Num >= 0)
+        original_uri = path1.uri
+
+        # merge paths 1..3
+        path1.merge(path2).merge(path3)
+        self.assertNotEqual(path1.uri, original_uri, "Merged path's URI should have changed from its original URI")
+        self.assertEqual(path1.context.name, path3.context.name, "Context of merged paths should equal far right-hand path's context")
+        self.assertGreater(len(path1.Experiment.entities()), 0, "Should have returned results")
+
 
 if __name__ == '__main__':
     sys.exit(unittest.main())

--- a/tests/deriva/core/test_datapath.py
+++ b/tests/deriva/core/test_datapath.py
@@ -719,6 +719,21 @@ class DatapathTests (unittest.TestCase):
         self.assertEqual(path1.context.name, path3.context.name, "Context of merged paths should equal far right-hand path's context")
         self.assertGreater(len(path1.Experiment.entities()), 0, "Should have returned results")
 
+    def test_compose_paths(self):
+        path1 = self.experiment.filter(self.experiment.Amount >= 0)
+        path2 = self.experiment.link(self.experiment_type).filter(self.experiment_type.ID >= '0')
+        path3 = self.experiment.link(self.project).filter(self.project.Num >= 0)
+        original_uri = path1.uri
+
+        # compose paths 1..3
+        path = self.paths.compose(path1, path2, path3)
+        self.assertNotEqual(path, path1, "Compose should have copied the first path rather than mutate it")
+        self.assertNotEqual(path.uri, path1.uri, "Composed path URI should not match the first path URI")
+        self.assertEqual(path1.uri, original_uri, "First path was changed")
+        self.assertNotEqual(path.uri, original_uri, "Merged path's URI should have changed from its original URI")
+        self.assertEqual(path.context.name, path3.context.name, "Context of composed paths should equal far right-hand path's context")
+        self.assertGreater(len(path.Experiment.entities()), 0, "Should have returned results")
+
 
 if __name__ == '__main__':
     sys.exit(unittest.main())


### PR DESCRIPTION
This is a feature branch based on a conversation with @karlcz . I'm opening this PR for review and comments -- including whether it is worth moving forward. I'd like your input on (a) whether the feature is useful, (b) if you have time can you look at my `__deepcopy__` implementation because I feel a little iffy about it. If I go forward, I need to add unit tests. Here's an example of how it is used.

```python
from deriva.core import DerivaServer
server = DerivaServer('https', 'dev.facebase.org')
catalog = server.connect_ermrest('1')
builder = catalog.getPathBuilder()

# reusable right-hand paths
pi_path = builder.isa.project.link(builder.isa.project_investigator).link(builder.isa.person.alias('pi'))
pm_path = builder.isa.project.link(builder.isa.project_member).link(builder.isa.person.alias('pm'))

# 2 replicas of a base left-hand path
path1 = builder.isa.dataset.filter(builder.isa.dataset.id < 10000).link(builder.isa.project).filter(builder.isa.project.id < 500)
path2 = builder.isa.dataset.filter(builder.isa.dataset.id < 10000).link(builder.isa.project).filter(builder.isa.project.id < 500)

# merge path 1
path1.merge(pi_path)
print(path1.uri)
# https://dev.facebase.org/ermrest/catalog/1/entity/dataset:=isa:dataset/id::lt::10000/project:=isa:project/id::lt::500/$project/project_investigator:=isa:project_investigator/person:=isa:person

# merge path 2
path2.merge(pm_path)
print(path2.uri)
# https://dev.facebase.org/ermrest/catalog/1/entity/dataset:=isa:dataset/id::lt::10000/project:=isa:project/id::lt::500/$project/project_member:=isa:project_member/person:=isa:person

print('DONE')
# DONE
```

Also supported is `compose`ing multiple path fragment from left to right _without_ mutating any of them. To do so, it deepcopies the left-most path and then merges the subsequent paths into it.

```python
...
path = builder.compose(path1, pi_path, pm_path)
# path != path1
# path.uri != path1.uri
...
```
