### PR TITLE
Datapath refactor

### DIFF
--- a/deriva/core/datapath.py
+++ b/deriva/core/datapath.py
@@ -76,7 +76,7 @@ class _CatalogWrapper (object):
         }
 
     def __dir__(self):
-        return dir(_CatalogWrapper) + ['schemas'] + [key for key in self.schemas if _isidentifier(key)]
+        return super().__dir__() + [key for key in self.schemas if _isidentifier(key)]
 
     def __getattr__(self, a):
         if a in self.schemas:
@@ -188,7 +188,7 @@ class DataPath (object):
         return cp
 
     def __dir__(self):
-        return dir(DataPath) + self._identifiers
+        return super().__dir__() + self._identifiers
 
     def __getattr__(self, a):
         if a in self._table_instances:
@@ -198,14 +198,17 @@ class DataPath (object):
 
     @property
     def table_instances(self):
+        """Collection of the table instances in this datapath expression."""
         return self._table_instances
 
     @property
     def context(self):
+        """Context (i.e., last bound table instance) of this datapath expression."""
         return self._context
 
     @context.setter
     def context(self, value):
+        """Updates the context of this datapath expression (must be a table instance bound to this expression)."""
         assert isinstance(value, TableAlias)
         assert value._name in self._table_instances
         if self._context != value:
@@ -214,6 +217,7 @@ class DataPath (object):
 
     @property
     def uri(self):
+        """The current URI serialization of this datapath expression."""
         return self._base_uri + str(self._path_expression)
 
     def _contextualized_uri(self, context):
@@ -548,8 +552,8 @@ class _TableWrapper (object):
         :param table: the wrapped table
         """
         self._schema = schema
-        self._name = table.name
         self._wrapped_table = table
+        self._name = table.name
 
         self.column_definitions = {
             v.name: _ColumnWrapper(self, v)
@@ -557,7 +561,7 @@ class _TableWrapper (object):
         }
 
     def __dir__(self):
-        return dir(_TableWrapper) + ['sname', 'name'] + [key for key in self.column_definitions if _isidentifier(key)]
+        return super().__dir__() + [key for key in self.column_definitions if _isidentifier(key)]
 
     def __getattr__(self, a):
         if a in self.column_definitions:
@@ -584,7 +588,6 @@ class _TableWrapper (object):
 
     @property
     def _uname(self):
-        """the url encoded name"""
         return urlquote(self._name)
 
     @property

--- a/deriva/core/datapath.py
+++ b/deriva/core/datapath.py
@@ -215,8 +215,10 @@ class DataPath (object):
     @context.setter
     def context(self, value):
         """Updates the context of this datapath expression (must be a table instance bound to this expression)."""
-        assert isinstance(value, _TableAlias)
-        assert value._name in self._table_instances
+        if not isinstance(value, _TableAlias):
+            raise TypeError('context must be a table alias object')
+        if value._name not in self._table_instances:
+            raise ValueError('table alias must be bound in this path')
         if self._context != value:
             self._path_expression = _ResetContext(self._path_expression, value)
             self._context = value

--- a/deriva/core/datapath.py
+++ b/deriva/core/datapath.py
@@ -243,7 +243,7 @@ class DataPath (object):
         """Binds a new table instance into this path.
         """
         assert isinstance(alias, _TableAlias)
-        alias.path = self
+        alias._bind(self)
         self._table_instances[alias._name] = self._context = alias
         if _isidentifier(alias._name):
             self._identifiers.append(alias._name)
@@ -606,12 +606,6 @@ class _TableWrapper (object):
         """
         return DataPath(self.alias(self._name))
 
-    @path.setter
-    def path(self, value):
-        """Not allowed on base tables.
-        """
-        raise Exception("Path assignment not allowed on base table objects.")
-
     @property
     def _contextualized_path(self):
         """Returns the path as contextualized for this table instance.
@@ -819,13 +813,13 @@ class _TableAlias (_TableWrapper):
             self._parent = DataPath(self)
         return self._parent
 
-    @path.setter
-    def path(self, value):
+    def _bind(self, parent_path):
+        """Binds this table instance to the given parent path."""
         if self._parent:
-            raise Exception("Cannot bind a table instance that has already been bound.")
-        elif not isinstance(value, DataPath):
-            raise Exception("value must be a DataPath instance.")
-        self._parent = value
+            raise ValueError("Cannot bind a table instance that has already been bound.")
+        elif not isinstance(parent_path, DataPath):
+            raise TypeError("value must be a DataPath instance.")
+        self._parent = parent_path
 
     @property
     def _contextualized_path(self):

--- a/deriva/core/datapath.py
+++ b/deriva/core/datapath.py
@@ -615,6 +615,7 @@ class _TableWrapper (object):
         return self.path
 
     @property
+    @deprecated
     def uri(self):
         return self.path.uri
 
@@ -833,7 +834,9 @@ class _TableAlias (_TableWrapper):
         return path
 
     @property
+    @deprecated
     def uri(self):
+        warnings.warn("'uri' has been deprecated", DeprecationWarning, stacklevel=2)
         return self.path._contextualized_uri(self)
 
     def _query(self, mode='entity', projection=[], group_key=[], context=None):

--- a/tests/deriva/core/test_datapath.py
+++ b/tests/deriva/core/test_datapath.py
@@ -284,7 +284,7 @@ class DatapathTests (unittest.TestCase):
     def test_attribute_err_table_attr(self):
         table_attr = ['_name', '_schema']
         for attr in table_attr:
-            with self.assertRaises(ValueError):
+            with self.assertRaises(TypeError):
                 self.experiment.attributes(getattr(self.experiment, attr))
 
     def test_update_err_no_targets(self):
@@ -293,11 +293,11 @@ class DatapathTests (unittest.TestCase):
             self.experiment.update(entities)
 
     def test_aggregate_w_invalid_attributes(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             self.experiment.aggregates(Min(self.experiment.column_definitions['Amount']))
 
     def test_aggregate_w_invalid_renames(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             self.experiment.aggregates(
                 self.experiment.column_definitions['Name'],
                 Min(self.experiment.column_definitions['Amount'])
@@ -615,13 +615,13 @@ class DatapathTests (unittest.TestCase):
         self.assertEqual(len(results), 0)
 
     def test_insert_entities_not_iterable(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             self.experiment_type.insert(1)
 
     def test_insert_entities0_not_dict(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             self.experiment_type.insert([1])
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             self.experiment_type.insert('this is not a dict')
 
     def test_insert(self):
@@ -646,13 +646,13 @@ class DatapathTests (unittest.TestCase):
         self.assertEqual(len(results), 0)
 
     def test_update_entities_not_iterable(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             self.experiment_type.update(1)
 
     def test_update_entities0_not_dict(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             self.experiment_type.update([1])
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             self.experiment_type.update('this is not a dict')
 
     def test_nondefaults(self):


### PR DESCRIPTION
- Mostly internal refactoring of datapath module
- Main public impact is clearly naming with leading `_` those classes and properties intended for internal use
- The internal object model now wraps classes from the recently refactored ermrest_model rather than instantiating from json schema
- Some OOPy excesses were scaled back (ie, internal properties that didn't need to be encapsulated in getters)
- Some improvements to exceptions
- A few minor functions now deprecated (they are still available but raise a 'DeprecatedWarning') and will be removed in some future update