### PR TITLE
add 'domain_filter' to 'foreign-key' schema

### DIFF
--- a/deriva/core/schemas/foreign_key.schema.json
+++ b/deriva/core/schemas/foreign_key.schema.json
@@ -32,11 +32,16 @@
       },
       "additionalProperties": false
     },
-    "domain_filter_pattern": { "type": "string" },
-    "template_engine": { "$ref": "#/definitions/template-engine" }
+    "domain_filter": {
+        "type": "object",
+        "properties": {
+            "ermrest_path_pattern": {"type": "string"},
+            "display_markdown_pattern": {"type": "string"},
+            "template_engine": { "$ref": "#/definitions/template-engine" }
+        },
+        "additionalProperties": false,
+        "required": ["ermrest_path_pattern"]
+    }
   },
-  "additionalProperties": false,
-  "dependencies": {
-      "template_engine": [ "domain_filter_pattern" ]
-  }
+  "additionalProperties": false
 }


### PR DESCRIPTION
As part of [ermrestjs#860](https://github.com/informatics-isi-edu/ermrestjs/pull/860) I added a new `domain_filter` attribute to `foreign-key` annotation. We also decided to deprecate the `domain_filter_pattern` attribute. The new documentation can be found [here](https://github.com/informatics-isi-edu/ermrestjs/blob/67b33d29b8b5d073440163df9f8fef25cd48d5b8/docs/user-docs/annotation.md#tag-2016-foreign-key).

This PR modifies the "foreign-key" JSON schema to reflect these changes.

