### PR TITLE
refactor DerivaServer and ErmrestCatalog and add alias management

### DIFF
--- a/deriva/core/deriva_server.py
+++ b/deriva/core/deriva_server.py
@@ -1,49 +1,5 @@
-from .deriva_binding import DerivaBinding
-from .ermrest_catalog import ErmrestCatalog, ErmrestSnapshot
+from .ermrest_catalog import ErmrestCatalog, ErmrestSnapshot, DerivaServer
 
+# DerivaServer moved to ermrest_catalog to avoid circular imports.
+# This module retained for backwards compatibility of third-party import statements.
 
-class DerivaServer (DerivaBinding):
-    """Persistent handle for a Deriva server."""
-
-    def __init__(self, scheme, server, credentials=None, caching=True, session_config=None):
-        """Create a Deriva server binding.
-
-           Arguments:
-             scheme: 'http' or 'https'
-             server: server FQDN string
-             credentials: credential secrets, e.g. cookie
-             caching: whether to retain a GET response cache
-        """
-        super(DerivaServer, self).__init__(scheme, server, credentials, caching, session_config)
-        self.scheme = scheme
-        self.server = server
-        self.credentials = credentials
-        self.caching = caching
-        self.session_config = session_config
-
-    def connect_ermrest(self, catalog_id, snaptime=None):
-        """Connect to an ERMrest catalog.
-
-           Arguments:
-             catalog_id: e.g., '1' or '1@2PM-DGYP-56Z4'
-             snaptime: e.g., '2PM-DGYP-56Z4' (optional)
-        """
-        if not snaptime:
-            splits = str(catalog_id).split('@')
-            if len(splits) > 2:
-                raise Exception('Malformed catalog identifier: multiple "@" characters found.')
-            catalog_id = splits[0]
-            snaptime = splits[1] if len(splits) == 2 else None
-
-        if snaptime:
-            return ErmrestSnapshot(self.scheme, self.server, catalog_id, snaptime, self.credentials, self.caching, self.session_config)
-
-        return ErmrestCatalog(self.scheme, self.server, catalog_id, self.credentials, self.caching, self.session_config)
-
-    def create_ermrest_catalog(self):
-        """Create an ERMrest catalog.
-        """
-        path = '/ermrest/catalog'
-        r = self.post(path)
-        r.raise_for_status()
-        return self.connect_ermrest(r.json()['id'])


### PR DESCRIPTION
The main functional change is to support new ERMrest features by
adding alias-management methods to DerivaServer and ErmrestCatalog.

First some refactoring of the cluster of DerivaBinding, DerivaServer,
ErmrestCatalog, and ErmrestCatalogSnapshot was needed:

- remove clutter and reuse DerivaBinding superclass state
- extend __init__() calls to allow sharing of session, cache, dcctx
- change server.connect_ermrest to share session, cache, dcctx
- add catalog.deriva_server to get a DerivaServer from an ErmrestCatalog
- change catalog cloning to use self.deriva_server where appropriate
- move DerivaServer into ermrest_catalog.py to avoid circular imports

Expose new ERMrest features:

- add catalog.alias_target to introspect an aliased catalog binding
- extend DerivaServer.create_ermrest_catalog with optional args:
   - id: provide client-specified id string
   - owner: set ownership ACL
- add DerivaServer.create_ermrest_alias(...)
   - id: provide client-specified id string
   - owner: set ownership ACL
   - alias_target: bind alias to storage catalog
- add DerivaServer.read_ermrest_alias(id)
- add DerivaServer.update_ermrest_alias(id, owner, alias_target)
- add DerivaServer.delete_ermrest_alias(id)