### PR TITLE
raise tailored AttributeError on datapath object property errors

### DIFF
--- a/deriva/core/datapath.py
+++ b/deriva/core/datapath.py
@@ -158,7 +158,10 @@ class _CatalogWrapper (object):
         if a in self._identifiers:
             return self.schemas[self._identifiers[a]]
         else:
-            return getattr(super(_CatalogWrapper, self), a)
+            try:
+                return getattr(super(_CatalogWrapper, self), a)
+            except AttributeError:
+                raise AttributeError("'%s' object has no attribute or schema '%s'" % (type(self).__name__, a))
 
     @classmethod
     def compose(cls, *paths):
@@ -216,7 +219,10 @@ class _SchemaWrapper (object):
         if a in self._identifiers:
             return self.tables[self._identifiers[a]]
         else:
-            return getattr(super(_SchemaWrapper, self), a)
+            try:
+                return getattr(super(_SchemaWrapper, self), a)
+            except AttributeError:
+                raise AttributeError("'%s' object has no attribute or table '%s'" % (type(self).__name__, a))
 
     @deprecated
     def describe(self):
@@ -259,7 +265,10 @@ class DataPath (object):
         if a in self._identifiers:
             return self._table_instances[self._identifiers[a]]
         else:
-            return getattr(super(DataPath, self), a)
+            try:
+                return getattr(super(DataPath, self), a)
+            except AttributeError:
+                raise AttributeError("'%s' object has no attribute or table instance '%s'" % (type(self).__name__, a))
 
     def __deepcopy__(self, memodict={}):
         cp = DataPath(copy.deepcopy(self._root, memo=memodict))
@@ -665,7 +674,10 @@ class _TableWrapper (object):
         if a in self._identifiers:
             return self.column_definitions[self._identifiers[a]]
         else:
-            return getattr(super(_TableWrapper, self), a)
+            try:
+                return getattr(super(_TableWrapper, self), a)
+            except AttributeError:
+                raise AttributeError("'%s' object has no attribute or column '%s'" % (type(self).__name__, a))
 
     @deprecated
     def describe(self):

--- a/deriva/core/datapath.py
+++ b/deriva/core/datapath.py
@@ -157,11 +157,10 @@ class _CatalogWrapper (object):
     def __getattr__(self, a):
         if a in self._identifiers:
             return self.schemas[self._identifiers[a]]
+        elif hasattr(super(_CatalogWrapper, self), a):
+            return getattr(super(_CatalogWrapper, self), a)
         else:
-            try:
-                return getattr(super(_CatalogWrapper, self), a)
-            except AttributeError:
-                raise AttributeError("'%s' object has no attribute or schema '%s'" % (type(self).__name__, a))
+            raise AttributeError("'%s' object has no attribute or schema '%s'" % (type(self).__name__, a))
 
     @classmethod
     def compose(cls, *paths):
@@ -218,11 +217,10 @@ class _SchemaWrapper (object):
     def __getattr__(self, a):
         if a in self._identifiers:
             return self.tables[self._identifiers[a]]
+        elif hasattr(super(_SchemaWrapper, self), a):
+            return getattr(super(_SchemaWrapper, self), a)
         else:
-            try:
-                return getattr(super(_SchemaWrapper, self), a)
-            except AttributeError:
-                raise AttributeError("'%s' object has no attribute or table '%s'" % (type(self).__name__, a))
+            raise AttributeError("'%s' object has no attribute or table '%s'" % (type(self).__name__, a))
 
     @deprecated
     def describe(self):
@@ -264,11 +262,10 @@ class DataPath (object):
     def __getattr__(self, a):
         if a in self._identifiers:
             return self._table_instances[self._identifiers[a]]
+        elif hasattr(super(DataPath, self), a):
+            return getattr(super(DataPath, self), a)
         else:
-            try:
-                return getattr(super(DataPath, self), a)
-            except AttributeError:
-                raise AttributeError("'%s' object has no attribute or table instance '%s'" % (type(self).__name__, a))
+            raise AttributeError("'%s' object has no attribute or table instance '%s'" % (type(self).__name__, a))
 
     def __deepcopy__(self, memodict={}):
         cp = DataPath(copy.deepcopy(self._root, memo=memodict))
@@ -673,11 +670,10 @@ class _TableWrapper (object):
     def __getattr__(self, a):
         if a in self._identifiers:
             return self.column_definitions[self._identifiers[a]]
+        elif hasattr(super(_TableWrapper, self), a):
+            return getattr(super(_TableWrapper, self), a)
         else:
-            try:
-                return getattr(super(_TableWrapper, self), a)
-            except AttributeError:
-                raise AttributeError("'%s' object has no attribute or column '%s'" % (type(self).__name__, a))
+            raise AttributeError("'%s' object has no attribute or column '%s'" % (type(self).__name__, a))
 
     @deprecated
     def describe(self):

--- a/deriva/core/datapath.py
+++ b/deriva/core/datapath.py
@@ -160,7 +160,7 @@ class _CatalogWrapper (object):
         elif hasattr(super(_CatalogWrapper, self), a):
             return getattr(super(_CatalogWrapper, self), a)
         else:
-            raise AttributeError("'%s' object has no attribute or schema '%s'" % (type(self).__name__, a))
+            raise AttributeError("'%s' object for catalog '%s' has no attribute or schema '%s'" % (type(self).__name__, self._wrapped_catalog.catalog_id, a))
 
     @classmethod
     def compose(cls, *paths):
@@ -220,7 +220,7 @@ class _SchemaWrapper (object):
         elif hasattr(super(_SchemaWrapper, self), a):
             return getattr(super(_SchemaWrapper, self), a)
         else:
-            raise AttributeError("'%s' object has no attribute or table '%s'" % (type(self).__name__, a))
+            raise AttributeError("'%s' object for schema '%s' has no attribute or table '%s'" % (type(self).__name__, self._name, a))
 
     @deprecated
     def describe(self):
@@ -673,7 +673,7 @@ class _TableWrapper (object):
         elif hasattr(super(_TableWrapper, self), a):
             return getattr(super(_TableWrapper, self), a)
         else:
-            raise AttributeError("'%s' object has no attribute or column '%s'" % (type(self).__name__, a))
+            raise AttributeError("'%s' object for table '%s' has no attribute or column '%s'" % (type(self).__name__, self._wrapped_table.name, a))
 
     @deprecated
     def describe(self):


### PR DESCRIPTION
Follows closely to the original pattern:

"'class name' object has no attribute or {table|schema|...} 'name'"

Since we are still claiming support for python 2.7 the above does _not_
use the exception chaining `from` keyword when raising the error caused
by the upstream AttributeError.

### Examples

#### Catalog object (ie, "builder") level
```
>>> paths.foo
Traceback (most recent call last):
  File "/Users/schuler/devel/deriva-py/deriva/core/datapath.py", line 162, in __getattr__
    return getattr(super(_CatalogWrapper, self), a)
AttributeError: 'super' object has no attribute 'foo'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/schuler/devel/deriva-py/deriva/core/datapath.py", line 164, in __getattr__
    raise AttributeError("'%s' object has no attribute or schema '%s'" % (type(self).__name__, a))
AttributeError: '_CatalogWrapper' object has no attribute or schema 'foo'
```

#### Schema object level
```
>>> paths.isa.foo
Traceback (most recent call last):
  File "/Users/schuler/devel/deriva-py/deriva/core/datapath.py", line 223, in __getattr__
    return getattr(super(_SchemaWrapper, self), a)
AttributeError: 'super' object has no attribute 'foo'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/schuler/devel/deriva-py/deriva/core/datapath.py", line 225, in __getattr__
    raise AttributeError("'%s' object has no attribute or table '%s'" % (type(self).__name__, a))
AttributeError: '_SchemaWrapper' object has no attribute or table 'foo'
```

#### Table object level
```
>>> paths.isa.dataset.foo
Traceback (most recent call last):
  File "/Users/schuler/devel/deriva-py/deriva/core/datapath.py", line 678, in __getattr__
    return getattr(super(_TableWrapper, self), a)
AttributeError: 'super' object has no attribute 'foo'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/schuler/devel/deriva-py/deriva/core/datapath.py", line 680, in __getattr__
    raise AttributeError("'%s' object has no attribute or column '%s'" % (type(self).__name__, a))
AttributeError: '_TableWrapper' object has no attribute or column 'foo'
```

#### DataPath object level
```
>>> paths.isa.dataset.path.foo
Traceback (most recent call last):
  File "/Users/schuler/devel/deriva-py/deriva/core/datapath.py", line 269, in __getattr__
    return getattr(super(DataPath, self), a)
AttributeError: 'super' object has no attribute 'foo'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/schuler/devel/deriva-py/deriva/core/datapath.py", line 271, in __getattr__
    raise AttributeError("'%s' object has no attribute or table instance '%s'" % (type(self).__name__, a))
AttributeError: 'DataPath' object has no attribute or table instance 'foo'
```

Fixes issue #151 