### PR TITLE
Take advantage of schema patterns in sample ACL files

### DIFF
--- a/deriva/config/examples/group_owner_policy.json
+++ b/deriva/config/examples/group_owner_policy.json
@@ -80,7 +80,7 @@
 
   "table_acls": [
     {
-      "schema": "TODO: Schema_Name; NOTE: repeat this stanza for each of your schemas",
+      "schema_pattern": "^(?!(^public)$).+$",
       "table_pattern": ".*",
       "acl_bindings": [
         "row_owner_guard",

--- a/deriva/config/examples/self_serve_policy.json
+++ b/deriva/config/examples/self_serve_policy.json
@@ -66,7 +66,7 @@
 
   "table_acls": [
     {
-      "schema": "TODO: Schema_Name; NOTE: repeat this stanza for each of your schemas",
+      "schema_pattern": "^(?!(^public)$).+$",
       "table_pattern": ".*",
       "acl_bindings": [
         "row_owner_guard"


### PR DESCRIPTION
Use an ugly regex to match all schemas except public rather than making the user create entries for each schema.