### PR TITLE
Datapath contextualize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGE LOG
 
+## 1.6.5
+
+DataPath feature enhancements and changes:
+* new `denormalize()` method that uses a `visible-columns` "context" or a heuristic function to denormalize a path expression.
+* new `limit()` method as a chaining operation so that clients don't need to explicity `fetch()` results with limits.
+* subtle change to `link()` method for how it determines whether an alias name has been "bound" to the path. Now, it more explicitly checks if an alias object is found in the path's bound table instances. This change also relaxes the alias naming constraint to allow for automatic conflict resolution by appending an incremental numeric disambiguator if the given alias name is already in use. This could result in some `link()` methods now succeeding where they would have failed in the past.
+
 ## 1.0.0
 Feature release. 
 * Refactored catalog configuration API.

--- a/deriva/core/__init__.py
+++ b/deriva/core/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.6.4"
+__version__ = "1.6.5"
 
 from deriva.core.utils.core_utils import *
 from deriva.core.base_cli import BaseCLI, KeyValuePairArgs

--- a/deriva/core/datapath.py
+++ b/deriva/core/datapath.py
@@ -1968,12 +1968,11 @@ def _datapath_contextualize(path, context_name='*', context_body=None, groupkey_
     return query
 
 
-def _datapath_generate_simple_denormalization(path, skip_whole_entities=True):
+def _datapath_generate_simple_denormalization(path, include_whole_entities=False):
     """Generates a denormalized form of the table expressed in a visible columns specification.
 
     :param path: a datapath object
-    :param skip_whole_entities: if a denormalization cannot find a 'name' like terminal, skip it, else include the whole
-    related entity in the denormalized expression
+    :param include_whole_entities: if a denormalization cannot find a 'name' like terminal, include the whole entity (i.e., all attributes), else return just the 'RID'
     :return: a generated visible columns specification based on a denormalization heuristic
     """
     assert isinstance(path, DataPath)
@@ -2013,7 +2012,7 @@ def _datapath_generate_simple_denormalization(path, skip_whole_entities=True):
         return {
             'markdown_name': name,
             'source': source,
-            'entity': terminal == 'RID'
+            'entity': include_whole_entities and terminal == 'RID'
         }
 
     # assemble the visible column:
@@ -2043,9 +2042,6 @@ def _datapath_generate_simple_denormalization(path, skip_whole_entities=True):
                 )
             )
 
-    if skip_whole_entities:
-        vizcols = filter(lambda v: not isinstance(v, dict) or not v.get('entity'), vizcols)
-
     return vizcols
 
 def simple_denormalization(path):
@@ -2054,7 +2050,7 @@ def simple_denormalization(path):
 
 def simple_denormalization_with_whole_entities(path):
     """A simple heuristic denormalization with related and associated entities."""
-    return _datapath_generate_simple_denormalization(path, skip_whole_entities=False)
+    return _datapath_generate_simple_denormalization(path, include_whole_entities=True)
 
 def _datapath_denormalize(path, context_name=None, heuristic=None, groupkey_name='RID'):
     """Denormalizes a path based on annotations or heuristics.

--- a/deriva/core/datapath.py
+++ b/deriva/core/datapath.py
@@ -636,6 +636,7 @@ class _ResultSet (object):
         self._fetcher_fn = fetcher_fn
         self._results_doc = None
         self._sort_keys = None
+        self._limit = None
         self.uri = uri
 
     @property
@@ -669,6 +670,19 @@ class _ResultSet (object):
         self._results_doc = None
         return self
 
+    def limit(self, n):
+        """Set a limit on the number of results to be returned.
+
+        :param n: integer or None.
+        :return: self
+        """
+        try:
+            self._limit = None if n is None else int(n)
+            self._results_doc = None
+            return self
+        except ValueError:
+            raise ValueError('limit argument "n" must be an integer or None')
+
     def fetch(self, limit=None, headers=DEFAULT_HEADERS):
         """Fetches the results from the catalog.
 
@@ -676,7 +690,7 @@ class _ResultSet (object):
         :param headers: headers to send in request to server
         :return: self
         """
-        limit = int(limit) if limit else None
+        limit = int(limit) if limit else self._limit
         self._results_doc = self._fetcher_fn(limit, self._sort_keys, headers)
         logger.debug("Fetched %d entities" % len(self._results_doc))
         return self

--- a/deriva/core/datapath.py
+++ b/deriva/core/datapath.py
@@ -1816,6 +1816,7 @@ def datapath_deserialize_vizcolumn(path, vizcol, sources=None):
     :return: the element to be projected from the datapath or None
     """
     warnings.warn('This method is experimental. It is likely to change.')
+    assert isinstance(path, DataPath)
     sources = sources if sources else {}
     context = path.context
     table = context._wrapped_table
@@ -1921,6 +1922,7 @@ def datapath_generate_denormalized_context(path):
     **EXPERIMENTAL ONLY**
 
     """
+    assert isinstance(path, DataPath)
     context = path.context
     table = context._wrapped_table
 
@@ -1942,4 +1944,5 @@ def datapath_denormalize(path, groupkey_name='RID'):
     :param path: a DataPath object
     :param groupkey_name: column name for the group by key of the generated query expression (default: 'RID')
     """
+    assert isinstance(path, DataPath)
     return datapath_contextualize(path, context_body=datapath_generate_denormalized_context(path), groupkey_name=groupkey_name)

--- a/tests/deriva/core/test_datapath.py
+++ b/tests/deriva/core/test_datapath.py
@@ -833,7 +833,7 @@ class DatapathTests (unittest.TestCase):
         entities = self.experiment.entities()
         results = self.experiment.denormalize()
         self.assertEqual(len(entities), len(results))
-        self.assertEqual(entities[0].keys(), results[0].keys())
+        self.assertNotEqual(entities[0].keys(), results[0].keys())
         self.assertIn('Type', results[0])
         self.assertTrue(entities[0]['Type'].startswith('TEST:'))
         self.assertTrue(results[0]['Type'])


### PR DESCRIPTION
DataPath feature enhancements and changes:
* new `denormalize()` method that uses a `visible-columns` "context" or a heuristic function to denormalize a path expression.
* new `limit()` method as a chaining operation so that clients don't need to explicity `fetch()` results with limits.
* subtle change to `link()` method for how it determines whether an alias name has been "bound" to the path. Now, it more explicitly checks if an alias object is found in the path's bound table instances. This change also relaxes the alias naming constraint to allow for automatic conflict resolution by appending an incremental numeric disambiguator if the given alias name is already in use. This could result in some `link()` methods now succeeding where they would have failed in the past.

The `heuristic` function of the `denormalize()` method, introspects the schema of the terminating table instance in the query path expression and generates a visible-columns specification on-the-fly, which is then used for generating the denormalized path expression.

Simple denormalization logic:
* include all columns of the table;
* if a column is the sole member of a single-column outbound foreign key, then replace the column with the foreign key based visible column;
* after all columns, then include all the outbound foreign keys;
* after all outbound foreign keys, look for any binary associations in the table's inbound foreign keys, and include the associated tables
* for the outbound related tables and the associated tables, inspect the schema of the related table's and if they include a "name" column (with several variants of a "name" column looked for), then project on the "name" column rather than the whole entity ("*")

The default `simple_denormalization` will prune any whole entity projections while an optional `simple_denormalization_with_whole_entities` will include them.
