### PR TITLE
Drop support for Python2 and make Python 3.8 the min required version.

### DIFF
--- a/deriva/config/annotation_config.py
+++ b/deriva/config/annotation_config.py
@@ -4,9 +4,6 @@ import re
 from deriva.core import ErmrestCatalog, AttrDict, ermrest_model, get_credential
 from deriva.config.base_config import BaseSpec, BaseSpecList, ConfigUtil, ConfigBaseCLI
 
-if sys.version_info > (3,):
-    unicode = str
-
 MY_VERSION = 0.99
 
 

--- a/deriva/core/__init__.py
+++ b/deriva/core/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.6.4"
+__version__ = "1.7.0"
 
 from deriva.core.utils.core_utils import *
 from deriva.core.base_cli import BaseCLI, KeyValuePairArgs

--- a/deriva/core/ermrest_catalog.py
+++ b/deriva/core/ermrest_catalog.py
@@ -10,7 +10,7 @@ import requests
 from typing import NamedTuple
 
 from . import urlquote, urlsplit, urlunsplit, datapath, DEFAULT_HEADERS, DEFAULT_CHUNK_SIZE, DEFAULT_SESSION_CONFIG, \
-    Megabyte, Kilobyte, get_transfer_summary, IS_PY2
+    Megabyte, Kilobyte, get_transfer_summary
 from .deriva_binding import DerivaBinding, DerivaPathError
 from . import ermrest_model
 from .ermrest_model import nochange
@@ -592,7 +592,7 @@ class ErmrestCatalog(DerivaBinding):
                     if buf == b"[]\n" or buf == b"{}\n":
                         delete_file = True
                 elif content_type == "text/csv":
-                    reader = csv.reader(codecs.iterdecode(destfile, 'utf-8') if not IS_PY2 else destfile)
+                    reader = csv.reader(codecs.iterdecode(destfile, 'utf-8'))
                     rowcount = 0
                     for row in reader:
                         rowcount += 1

--- a/deriva/core/utils/core_utils.py
+++ b/deriva/core/utils/core_utils.py
@@ -13,29 +13,10 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 from collections import OrderedDict
 from distutils import util as du_util
+from urllib.parse import quote as _urlquote, unquote as urlunquote
+from urllib.parse import urlparse, urlsplit, urlunsplit, urljoin
+from http.cookiejar import MozillaCookieJar
 
-IS_PY2 = (sys.version_info[0] == 2)
-IS_PY3 = (sys.version_info[0] == 3)
-
-
-def force_unicode_py2(s):
-    """Reliably return a Unicode string given a possible unicode or byte string"""
-    if isinstance(s, str):
-        return s.decode("utf-8")
-    else:
-        return unicode(s)
-
-
-if IS_PY3:
-    from urllib.parse import quote as _urlquote, unquote as urlunquote
-    from urllib.parse import urlparse, urlsplit, urlunsplit, urljoin
-    from http.cookiejar import MozillaCookieJar
-    force_unicode = str
-else:
-    from urllib import quote as _urlquote, unquote as urlunquote
-    from urlparse import urlparse, urlsplit, urlunsplit, urljoin
-    from cookielib import MozillaCookieJar
-    force_unicode = force_unicode_py2
 
 Kilobyte = 1024
 Megabyte = Kilobyte ** 2
@@ -237,8 +218,6 @@ def write_config(config_file=DEFAULT_CONFIG_FILE, config=DEFAULT_CONFIG):
     make_dirs(config_dir, mode=0o750)
     with io.open(config_file, 'w', newline='\n', encoding='utf-8') as cf:
         config_data = json.dumps(config, ensure_ascii=False, indent=2)
-        if IS_PY2 and isinstance(config_data, str):
-            config_data = unicode(config_data, 'utf-8')
         cf.write(config_data)
         cf.close()
 
@@ -275,8 +254,6 @@ def write_credential(credential_file=DEFAULT_CREDENTIAL_FILE, credential=DEFAULT
     with lock_file(credential_file, mode='w', exclusive=True) as cf:
         os.chmod(credential_file, 0o600)
         credential_data = json.dumps(credential, ensure_ascii=False, indent=2)
-        if IS_PY2 and isinstance(credential_data, str):
-            credential_data = unicode(credential_data, 'utf-8')
         cf.write(credential_data)
         cf.flush()
         os.fsync(cf.fileno())

--- a/deriva/core/utils/mime_utils.py
+++ b/deriva/core/utils/mime_utils.py
@@ -1,6 +1,6 @@
 import mimetypes
 import re
-from deriva.core import urlunquote, IS_PY2
+from deriva.core import urlunquote
 
 if not mimetypes.inited:
     mimetypes.init()
@@ -38,11 +38,5 @@ def parse_content_disposition(value):
         n = urlunquote(str(n))
     except Exception as e:
         raise ValueError('Invalid URL encoding of content-disposition filename component. %s.' % e)
-
-    try:
-        if IS_PY2:
-            n = n.decode('utf8')
-    except Exception as e:
-        raise ValueError('Invalid UTF-8 encoding of content-disposition filename component. %s.' % e)
 
     return n

--- a/deriva/seo/sitemap_builder.py
+++ b/deriva/seo/sitemap_builder.py
@@ -64,8 +64,6 @@ class SitemapBuilder:
         :param license_url: the url to the license used for images in this catalog
         """
 
-        if sys.version_info[0] < 3:
-            raise NotImplementedError("SitemapBuilder is only supported for Python 3.x")
         self.protocol = protocol
         self.host = host
         self.catalog_id = catalog_id

--- a/deriva/transfer/upload/deriva_upload.py
+++ b/deriva/transfer/upload/deriva_upload.py
@@ -13,7 +13,7 @@ import signal
 from collections import OrderedDict
 from deriva.core import ErmrestCatalog, HatracStore, HatracJobAborted, HatracJobPaused, \
     HatracJobTimeout, urlquote, urlparse, stob, format_exception, get_credential, read_config, write_config, \
-    copy_config, resource_path, make_dirs, lock_file, DEFAULT_CHUNK_SIZE, IS_PY2, __version__ as VERSION
+    copy_config, resource_path, make_dirs, lock_file, DEFAULT_CHUNK_SIZE, __version__ as VERSION
 from deriva.core import DEFAULT_SESSION_CONFIG, DEFAULT_CREDENTIAL_FILE
 from deriva.core.utils import hash_utils as hu, mime_utils as mu, version_utils as vu
 from deriva.transfer.upload import *
@@ -412,8 +412,6 @@ class DerivaUpload(object):
             with io.open(updated_config_path, 'w', newline='\n', encoding='utf-8') as config:
                 remote_config_data = json.dumps(
                     remote_config, ensure_ascii=False, sort_keys=True, separators=(',', ': '), indent=2)
-                if IS_PY2 and isinstance(remote_config_data, str):
-                    remote_config_data = unicode(remote_config_data, 'utf-8')
                 config.write(remote_config_data)
             new_md5 = hu.compute_file_hashes(updated_config_path, hashes=['md5'])['md5'][0]
             if current_md5 != new_md5:
@@ -1199,7 +1197,7 @@ class DerivaUpload(object):
         self.acquire_dependent_locks(directory)
         try:
             if not os.path.isfile(transfer_state_file_path):
-                with lock_file(transfer_state_file_path, mode="wb" if IS_PY2 else "w") as tsfp:
+                with lock_file(transfer_state_file_path, "w") as tsfp:
                     json.dump(self.transfer_state, tsfp)
 
             transfer_state_lock = self.transfer_state_locks.get(transfer_state_file_path)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'deriva.config': ['examples/*.json'],
         'deriva.core': ['schemas/*.schema.json']
     },
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4',
+    python_requires='>=3.8, <4',
     entry_points={
         'console_scripts': [
             'deriva-upload-cli = deriva.transfer.upload.__main__:main',
@@ -68,8 +68,7 @@ setup(
         'pika',
         'urllib3>=1.26.0,<2.0',
         'portalocker>=1.2.1',
-        'scandir; python_version <= "2.7"',
-        'bdbag>=1.6.0',
+        'bdbag>=1.7.2',
         'globus_sdk>=3,<4',
         'fair-research-login>=0.3.1',
         'fair-identifiers-client>=0.5.1',
@@ -87,6 +86,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11'
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12'
     ]
 )

--- a/tests/deriva/core/test_datapath.py
+++ b/tests/deriva/core/test_datapath.py
@@ -14,18 +14,6 @@ import sys
 from deriva.core import DerivaServer, get_credential, ermrest_model as _em, __version__
 from deriva.core.datapath import DataPathException, Min, Max, Sum, Avg, Cnt, CntD, Array, ArrayD, Bin
 
-# unittests did not support 'subTests' until 3.4
-if sys.version_info[0] < 3 or sys.version_info[1] < 4:
-    HAS_SUBTESTS = False
-else:
-    HAS_SUBTESTS = True
-
-# unittests did not support 'assertWarns' until 3.2
-if sys.version_info[0] < 3 or sys.version_info[1] < 2:
-    HAS_ASSERTWARNS = False
-else:
-    HAS_ASSERTWARNS = True
-
 try:
     from pandas import DataFrame
     HAS_PANDAS = True
@@ -347,7 +335,6 @@ class DatapathTests (unittest.TestCase):
                 Min(self.experiment.column_definitions['Amount'])
             )
 
-    @unittest.skipUnless(HAS_SUBTESTS, "This tests is not available unless running python 3.4+")
     def test_aggregate_fns(self):
         tests = [
             ('min_amount',      Min,    0),
@@ -378,7 +365,6 @@ class DatapathTests (unittest.TestCase):
         self.assertIn('max_amount', result)
         self.assertEqual(result['max_amount'], TEST_EXP_MAX-1)
 
-    @unittest.skipUnless(HAS_SUBTESTS, "This tests is not available unless running python 3.4+")
     def test_aggregate_fns_array_star(self):
         path = self.experiment.path
         tests = [
@@ -395,7 +381,6 @@ class DatapathTests (unittest.TestCase):
                 self.assertEqual(len(result['arr']), TEST_EXP_MAX)
                 self.assertIn('Time', result['arr'][0])
 
-    @unittest.skipUnless(HAS_SUBTESTS, "This tests is not available unless running python 3.4+")
     def test_aggregate_fns_cnt_star(self):
         path = self.experiment.path
         tests = [
@@ -409,7 +394,6 @@ class DatapathTests (unittest.TestCase):
                 self.assertIn('cnt', result)
                 self.assertEqual(result['cnt'], TEST_EXP_MAX)
 
-    @unittest.skipUnless(HAS_SUBTESTS, "This tests is not available unless running python 3.4+")
     def test_attributegroup_fns(self):
         tests = [
             ('one group key',     [self.experiment.column_definitions['Type']]),
@@ -420,7 +404,6 @@ class DatapathTests (unittest.TestCase):
             with self.subTest(name=test_name):
                 self._do_attributegroup_fn_subtests(group_key)
 
-    @unittest.skipUnless(HAS_SUBTESTS, "This tests is not available unless running python 3.4+")
     def _do_attributegroup_fn_subtests(self, group_key):
         """Helper method for running common attributegroup subtests for different group keys."""
         tests = [
@@ -444,7 +427,6 @@ class DatapathTests (unittest.TestCase):
                 self.assertIn(name, result)
                 self.assertEqual(result[name], value)
 
-    @unittest.skipUnless(HAS_SUBTESTS, "This tests is not available unless running python 3.4+")
     def test_attributegroup_w_bin(self):
         tests = [
             ('min/max given',     0,    TEST_EXP_MAX),
@@ -488,7 +470,6 @@ class DatapathTests (unittest.TestCase):
                         continue
                     self.assertTrue(compare(result[name], bin))
 
-    @unittest.skipUnless(HAS_SUBTESTS, "This tests is not available unless running python 3.4+")
     def test_attributegroup_w_bin_sort(self):
         bin_name = 'bin'
         nbins = int(TEST_EXP_MAX/20)
@@ -515,7 +496,6 @@ class DatapathTests (unittest.TestCase):
                 self.assertIn(name, results[0])
                 self.assertTrue(compfn(name, results[0], results[1]))
 
-    @unittest.skipUnless(HAS_SUBTESTS, "This test is not available unless running python 3.4+")
     def test_attributegroup_w_bin_resolution(self):
         binkey = self.experiment.column_definitions['Empty']
         binname = 'bin'
@@ -766,7 +746,6 @@ class DatapathTests (unittest.TestCase):
         for i in range(TEST_EXP_MAX):
             self.assertEqual(ig(results[i]), ig(entities_copy[i]), 'copied values do not match')
 
-    @unittest.skipUnless(HAS_SUBTESTS, "This test is not available unless running python 3.4+")
     def test_deepcopy_of_paths(self):
         paths = [
             self.experiment.path,


### PR DESCRIPTION
Remove conditional code for PY2 support.
Bump version to 1.7.0 (minor version update).