### PR TITLE
Association vocab keying tweaks

### DIFF
--- a/deriva/core/ermrest_model.py
+++ b/deriva/core/ermrest_model.py
@@ -1227,7 +1227,10 @@ class Table (object):
         associates = list(associates)
         metadata = list(metadata)
 
-        if not key_column_search_order:
+        if key_column_search_order is not None:
+            # materialize iterable for reuse
+            key_column_search_order = list(key_column_search_order)
+        else:
             key_column_search_order = cls.default_key_column_search_order
                 
         if len(associates) < 2:


### PR DESCRIPTION
1. Revises `define_vocabulary` to add a key constraint on the `Name` column by default, with a kwarg to override.
2. Revises `define_association` to prefer keys based on `Name` or `ID` over `RID` when forming fkeys based on bare Table instances, with a kwarg to override this key selection heuristic.