### PR TITLE
Generalize reference targets for Table define utility methods

### DIFF
--- a/deriva/core/__init__.py
+++ b/deriva/core/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.7.3"
+__version__ = "1.7.4"
 
 from deriva.core.utils.core_utils import *
 from deriva.core.base_cli import BaseCLI, KeyValuePairArgs

--- a/deriva/core/ermrest_model.py
+++ b/deriva/core/ermrest_model.py
@@ -880,6 +880,10 @@ class Table (object):
         out_column_defs = []
         out_fkey_defs = list(fkey_defs)
 
+        if not isinstance(column_defs, list):
+            # materialize other iterables for mutation and replay
+            column_defs = list(column_defs)
+
         if key_column_search_order is not None:
             # materialize iterable for reuse
             key_column_search_order = list(key_column_search_order)

--- a/deriva/core/ermrest_model.py
+++ b/deriva/core/ermrest_model.py
@@ -770,6 +770,8 @@ class FindAssociationResult (object):
 class Table (object):
     """Named table.
     """
+    default_key_column_search_order = ["Name", "name", "ID", "id"]
+
     def __init__(self, schema, tname, table_doc):
         self.schema = schema
         self.name = tname
@@ -834,11 +836,174 @@ class Table (object):
         ] + custom
 
     @classmethod
-    def define(cls, tname, column_defs=[], key_defs=[], fkey_defs=[], comment=None, acls={}, acl_bindings={}, annotations={}, provide_system=True):
+    def _expand_references(
+        cls,
+        table_name: str,
+        column_defs: list[Key | Table | dict | tuple[str, bool, Key | Table] | tuple[str, Key | Table]],
+        fkey_defs: Iterable[dict],
+        used_names: set =set(),
+        key_column_search_order: Iterable[str] | None = None,
+    ):
+        """Expand implicit references in column_defs into actual column and fkey definitions.
+
+        :param table_name: Name of table, needed to build fkey constraint names
+        :param column_defs: List of column definitions and/or reference targets (see below)
+        :param fkey_defs: List of foreign key definitions
+        :param used_names: Set of reference base names to consider already in use
+
+        Each reference target may be one of:
+           - Key
+           - Table
+           - tuple (str, Key|Table)
+           - tuple (str, bool, Key|Table)
+
+        A target Key specifies the columns of the remote table to
+        reference. A target Table instance specifies the remote table
+        and relies on heuristics to choose the target Key. A target
+        tuple specifies a string "base name" and optionally a boolean
+        "nullok" for the implied referencing columns. When omitted, a
+        default base name is constructed from target table
+        information, and a default nullok=False is specified for
+        referencing columns. The key_column_search_order parameter
+        influences the heuristic for selecting a target Key for an
+        input target Table.
+
+        This method mutates the input column_defs and used_names
+        containers. This can be abused to chain state through a
+        sequence of calls.
+
+        Returns the column_defs and fkey_defs which includes input
+        definitions and implied definitions while removing the corresponding input
+        reference targets.
+
+        """
+        out_column_defs = []
+        out_fkey_defs = list(fkey_defs)
+
+        if key_column_search_order is not None:
+            # materialize iterable for reuse
+            key_column_search_order = list(key_column_search_order)
+        else:
+            key_column_search_order = cls.default_key_column_search_order
+
+        def check_basename(basename):
+            if not isinstance(base_name, str):
+                raise TypeError('Base name %r is not of required type str' % (base_name,))
+            if base_name in used_names:
+                raise ValueError('Base name %r is not unique among inputs' % (base_name,))
+            used_names.add(base_name)
+
+        def choose_basename(key):
+            base_name = key.table.name
+            n = 2
+            while base_name in used_names or any(used.startswith(base_name) for used in used_names):
+                base_name = '%s%d' % (key.table.name, n)
+                n += 1
+            used_names.add(base_name)
+            return base_name
+
+        def check_key(key):
+            if isinstance(key, Table):
+                # opportunistic case: prefer (non-nullable) "name" or "id" keys, if found
+                for cname in key_column_search_order:
+                    try:
+                        candidate = key.key_by_columns([cname])
+                        if not candidate.unique_columns[0].nullok:
+                            return candidate
+                    except (KeyError, ValueError) as e:
+                        continue
+
+                # general case: try to use RID key
+                try:
+                    return key.key_by_columns(["RID"])
+                except (KeyError, ValueError) as e:
+                    raise ValueError('Could not determine default key for table %s' % (key,))
+            elif isinstance(key, Key):
+                return key
+            raise TypeError('Expected Key or Table instance as target reference, not %s' (key,))
+
+        # check and normalize cdefs into list[(str, Key)] with distinct base names
+        for i in range(len(column_defs)):
+            if isinstance(column_defs[i], tuple):
+                base_name, key = column_defs[i]
+                check_basename(base_name)
+                key = check_key(key)
+                column_defs[i] = (base_name, key)
+            elif isinstance(column_defs[i], (Key, Table)):
+                key = check_key(column_defs[i])
+                base_name = choose_basename(key)
+                column_defs[i] = (base_name, key)
+            elif isinstance(column_defs[i], dict):
+                pass
+            else:
+                raise TypeError('Expected column definition dict, Key, or Table input, not %s' % (column_defs[i],))
+
+        def simplify_type(ctype):
+            if ctype.is_domain and ctype.typename.startswith('ermrest_'):
+                return ctype.base_type
+            return ctype
+
+        def cdefs_for_key(*args):
+            if len(args) == 2:
+                base_name = args[0]
+                nullok = False
+                key = args[1]
+            elif len(args) == 3:
+                base_name = args[0]
+                nullok = args[1]
+                key = args[2]
+            else:
+                raise TypeError("expected tuple (base_name, target) or (base_name, nullok, target) not %s" % (args,))
+            return [
+                Column.define(
+                    '%s_%s' % (base_name, col.name) if len(key.unique_columns) > 1 else base_name,
+                    simplify_type(col.type),
+                    nullok=nullok,
+                )
+                for col in key.unique_columns
+            ]
+
+        def fkdef_for_key(base_name, key):
+            return ForeignKey.define(
+                [
+                    '%s_%s' % (base_name, col.name) if len(key.unique_columns) > 1 else base_name
+                    for col in key.unique_columns
+                ],
+                key.table.schema.name,
+                key.table.name,
+                [ col.name for col in key.unique_columns ],
+                on_update='CASCADE',
+                on_delete='CASCADE',
+                constraint_name=make_id(table_name, base_name, 'fkey'),
+            )
+
+        for cdef in column_defs:
+            if isinstance(cdef, tuple):
+                out_column_defs.extend(cdefs_for_key(*cdef))
+                out_fkey_defs.append(fkdef_for_key(*cdef))
+            else:
+                out_column_defs.append(cdef)
+
+        return out_column_defs, out_fkey_defs
+
+    @classmethod
+    def define(
+        cls,
+        tname: str,
+        column_defs: Iterable[dict | Key | Table | tuple[str, bool, Key | Table] | tuple[str, Key | Table]] = [],
+        key_defs: Iterable[dict] = [],
+        fkey_defs: Iterable[dict] = [],
+        comment: str | None = None,
+        acls: dict = {},
+        acl_bindings: dict = {},
+        annotations: dict = {},
+        provide_system: bool = True,
+        key_column_search_order: Iterable[str] | None = None,
+    ):
         """Build a table definition.
 
         :param tname: the name of the newly defined table
-        :param column_defs: a list of Column.define() results for extra or overridden column definitions
+        :param column_defs: a list of custom Column.define() results and/or reference targets (see below)
         :param key_defs: a list of Key.define() results for extra or overridden key constraint definitions
         :param fkey_defs: a list of ForeignKey.define() results for foreign key definitions
         :param comment: a comment string for the table
@@ -846,8 +1011,30 @@ class Table (object):
         :param acl_bindings: a dictionary of dynamic ACL bindings
         :param annotations: a dictionary of annotations
         :param provide_system: whether to inject standard system column definitions when missing from column_defs
+        :param key_column_search_order: override heuristic for choosing a Key from a Table input
+
+        Each reference target may be one of:
+           - Key
+           - Table
+           - tuple (str, Key|Table)
+           - tuple (str, bool, Key|Table)
+
+        A target Key specifies the columns of the remote table to
+        reference. A target Table instance specifies the remote table
+        and relies on heuristics to choose the target Key. A target
+        tuple specifies a string "base name" and optionally a boolean
+        "nullok" for the implied referencing columns. When omitted, a
+        default base name is constructed from target table
+        information, and a default nullok=False is specified for
+        referencing columns. The key_column_search_order parameter
+        influences the heuristic for selecting a target Key for an
+        input target Table.
 
         """
+        column_defs = list(column_defs) # materialize to allow replay
+        used_names = { cdef["name"] for cdef in column_defs if 'name' in cdef }
+        column_defs, fkey_defs = cls._expand_references(tname, column_defs, fkey_defs, used_names, key_column_search_order)
+
         if provide_system:
             column_defs = cls.system_column_defs(column_defs)
             key_defs = cls.system_key_defs(key_defs)
@@ -864,13 +1051,28 @@ class Table (object):
         }
 
     @classmethod
-    def define_vocabulary(cls, tname, curie_template, uri_template='/id/{RID}', column_defs=[], key_defs=[], fkey_defs=[], comment=None, acls={}, acl_bindings={}, annotations={}, provide_system=True, provide_name_key=True):
+    def define_vocabulary(
+        cls,
+        tname: str,
+        curie_template: str,
+        uri_template: str = '/id/{RID}',
+        column_defs: Iterable[dict | Key | Table | tuple[str, bool, Key | Table] | tuple[str, Key | Table]] = [],
+        key_defs=[],
+        fkey_defs=[],
+        comment: str | None = None,
+        acls: dict = {},
+        acl_bindings: dict = {},
+        annotations: dict = {},
+        provide_system: bool = True,
+        provide_name_key: bool = True,
+        key_column_search_order: Iterable[str] | None = None,
+    ):
         """Build a vocabulary table definition.
 
         :param tname: the name of the newly defined table
         :param curie_template: the RID-based template for the CURIE of locally-defined terms, e.g. 'MYPROJECT:{RID}'
         :param uri_template: the RID-based template for the URI of locally-defined terms, e.g. 'https://server.example.org/id/{RID}'
-        :param column_defs: a list of Column.define() results for extra or overridden column definitions
+        :param column_defs: a list of Column.define() results and/or reference targets (see below)
         :param key_defs: a list of Key.define() results for extra or overridden key constraint definitions
         :param fkey_defs: a list of ForeignKey.define() results for foreign key definitions
         :param comment: a comment string for the table
@@ -879,6 +1081,7 @@ class Table (object):
         :param annotations: a dictionary of annotations
         :param provide_system: whether to inject standard system column definitions when missing from column_defs
         :param provide_name_key: whether to inject a key definition for the Name column
+        :param key_column_search_order: override heuristic for choosing a Key from a Table input
 
         These core vocabulary columns are generated automatically if
         absent from the input column_defs.
@@ -889,7 +1092,10 @@ class Table (object):
         - Description: markdown, not null
         - Synonyms: text[]
 
-        However, caller-supplied definitions override the default.
+        However, caller-supplied definitions override the default. See
+        Table.define() documentation for an explanation reference
+        targets in the column_defs list and the related
+        key_column_search_order parameter.
 
         """
         if not re.match("^[A-Za-z][-_A-Za-z0-9]*:[{]RID[}]$", curie_template):
@@ -949,6 +1155,9 @@ class Table (object):
                 if ktup(key_def) not in { ktup(kdef): kdef for kdef in custom }
             ] + custom
 
+        used_names = {'ID', 'URI', 'Name', 'Description', 'Synonyms'}
+        column_defs, fkey_defs = cls._expand_references(tname, column_defs, fkey_defs, used_names, key_column_search_order)
+
         return cls.define(
             tname,
             add_vocab_columns(column_defs),
@@ -962,18 +1171,21 @@ class Table (object):
         )
 
     @classmethod
-    def define_asset(cls,
-                     sname,
-                     tname,
-                     hatrac_template=None,
-                     column_defs=[],
-                     key_defs=[],
-                     fkey_defs=[],
-                     comment=None,
-                     acls={},
-                     acl_bindings={},
-                     annotations={},
-                     provide_system=True):
+    def define_asset(
+        cls,
+        sname: str,
+        tname: str,
+        hatrac_template=None,
+        column_defs: Iterable[dict | Key | Table | tuple[str, bool, Key | Table] | tuple[str, Key | Table]] = [],
+        key_defs=[],
+        fkey_defs=[],
+        comment: str | None = None,
+        acls: dict = {},
+        acl_bindings: dict = {},
+        annotations: dict = {},
+        provide_system: bool = True,
+        key_column_search_order: Iterable[str] | None = None,
+    ):
         """Build an asset  table definition.
 
           :param sname: the name of the schema for the asset table
@@ -983,7 +1195,7 @@ class Table (object):
                      /hatrac/schema_name/table_name/md5.filename
                  where the filename and md5 value is computed on upload and the schema_name and table_name are the
                  values of the provided arguments.  If value is set to False, no hatrac_template is used.
-          :param column_defs: a list of Column.define() results for extra or overridden column definitions
+          :param column_defs: a list of Column.define() results and/or reference targets (see below)
           :param key_defs: a list of Key.define() results for extra or overridden key constraint definitions
           :param fkey_defs: a list of ForeignKey.define() results for foreign key definitions
           :param comment: a comment string for the table
@@ -991,6 +1203,7 @@ class Table (object):
           :param acl_bindings: a dictionary of dynamic ACL bindings
           :param annotations: a dictionary of annotations
           :param provide_system: whether to inject standard system column definitions when missing from column_defs
+          :param key_column_search_order: override heuristic for choosing a Key from a Table input
 
           These core asset table columns are generated automatically if
           absent from the input column_defs.
@@ -1002,11 +1215,15 @@ class Table (object):
           - MD5: text
           - Description: markdown, not null
 
-          However, caller-supplied definitions override the default.
+          However, caller-supplied definitions override the
+          default. See Table.define() documentation for an explanation
+          reference targets in the column_defs list and the related
+          key_column_search_order parameter.
 
           In addition to creating the columns, this function also creates an asset annotation on the URL column to
           facilitate use of the table by Chaise.
-          """
+
+        """
 
         if hatrac_template is None:
             hatrac_template = '/hatrac/{{$catalog.id}}/%s/%s/{{{MD5}}}.{{#encode}}{{{Filename}}}{{/encode}}' % (sname, tname)
@@ -1061,6 +1278,9 @@ class Table (object):
             asset_annotations.update(custom)
             return asset_annotations
 
+        used_names = {'URL', 'Filename', 'Description', 'Length', 'MD5'}
+        column_defs, fkey_defs = cls._expand_references(tname, column_defs, fkey_defs, used_names, key_column_search_order)
+
         return cls.define(
             tname,
             add_asset_columns(column_defs),
@@ -1074,25 +1294,41 @@ class Table (object):
         )
 
     @classmethod
-    def define_page(cls, tname, column_defs=[], key_defs=[], fkey_defs=[], comment=None, acls={}, acl_bindings={}, annotations={}, provide_system=True):
+    def define_page(
+        cls,
+        tname,
+        column_defs: Iterable[dict | Key | Table | tuple[str, bool, Key | Table] | tuple[str, Key | Table]] = [],
+        key_defs=[],
+        fkey_defs=[],
+        comment: str | None = None,
+        acls: dict = {},
+        acl_bindings: dict = {},
+        annotations: dict = {},
+        provide_system: bool = True,
+        key_column_search_order: Iterable[str] | None = None,
+    ):
         """Build a wiki-like "page" table definition.
 
         :param tname: the name of the newly defined table
         :param column_defs: a list of Column.define() results for extra or overridden column definitions
-        :param key_defs: a list of Key.define() results for extra or overridden key constraint definitions
+        :param key_defs: a list of Key.define() results and/or reference targets (see below)
         :param fkey_defs: a list of ForeignKey.define() results for foreign key definitions
         :param comment: a comment string for the table
         :param acls: a dictionary of ACLs for specific access modes
         :param acl_bindings: a dictionary of dynamic ACL bindings
         :param annotations: a dictionary of annotations
         :param provide_system: whether to inject standard system column definitions when missing from column_defs
+        :param key_column_search_order: override heuristic for choosing a Key from a Table input
 
         These core page columns are generated automatically if absent from the input column_defs.
 
         - Title: text, unique not null
         - Content: markdown
 
-        However, caller-supplied definitions override the default.
+        However, caller-supplied definitions override the default. See
+        Table.define() documentation for an explanation reference
+        targets in the column_defs list and the related
+        key_column_search_order parameter.
         """
 
         def add_page_columns(custom):
@@ -1147,6 +1383,9 @@ class Table (object):
             page_annotations.update(annotations)
             return page_annotations
 
+        used_names = {'Title', 'Content'}
+        column_defs, fkey_defs = cls._expand_references(tname, column_defs, fkey_defs, used_names, key_column_search_order)
+
         return cls.define(
             tname,
             add_page_columns(column_defs),
@@ -1158,8 +1397,6 @@ class Table (object):
             add_page_annotations(annotations),
             provide_system
         )
-
-    default_key_column_search_order = ["Name", "name", "ID", "id"]
 
     @classmethod
     def define_association(
@@ -1173,8 +1410,8 @@ class Table (object):
     ) -> dict:
         """Build an association table definition.
 
-        :param associates: the existing Key instances being associated
-        :param metadata: additional metadata fields for impure associations
+        :param associates: reference targets being associated (see below)
+        :param metadata: additional metadata fields and/or reference targets for impure associations
         :param table_name: name for the association table or None for default naming
         :param comment: comment for the association table or None for default comment
         :param provide_system: add ERMrest system columns when True
@@ -1194,34 +1431,23 @@ class Table (object):
         An "impure" association table adds additional metadata
         alongside the N foreign keys.
 
-        The "associates" parameter takes an iterable of Key instances
-        from other tables.  The association will be comprised of
-        foreign keys referencing these associates. Optionally, a tuple
-        of (str, Key) can supply a string _base name_ to influence how
-        the foreign key columns and constraint will be named in the
-        new association table. A bare Key instance will get a base
-        name derived from the referenced table name.
+        The "associates" parameter takes an iterable of reference
+        targets.  The association will be comprised of foreign keys
+        referencing these associates. This includes columns to store
+        the associated foreign key values, foreign key constraints to
+        the associated tables, and a composite key constraint
+        covering all the associated foreign key values.
 
-        The "metadata" parameter takes an iterable of plain dict
-        column definitions or Key instances. Each dict must be a
-        scalar column definition, such as produced by the
-        Column.define() class method. Key instance will cause
-        corresponding columns and foreign keys to be added to the
-        association table to act as metadata. Optionally, a tuple of
-        (str, bool, Key) can supply a string _base name_ and a boolean
-        _nullok_ property to influence how the foreign key columns and
-        constraint will be constructed and named. A bare Key instance
-        will get a base name derived from the referened table name,
-        and presumed as nullok=False.
+        The "metadata" parameter takes an iterable Column.define()
+        results and/or reference targets. The association table will
+        be augmented with extra metadata columns and foreign keys as
+        directed by these inputs.
 
-        If a Table instance is supplied instead of a Key instance for
-        associates or metadata inputs, an attempt will be made to
-        locate a key based search heuristics. The
-        "key_column_search_order" parameter can provide a preferred
-        search order for this invocation, or by default the built-in
-        class attribute "default_key_column_search_order" will be
-        used. The first non-nullable, single-column key found in the
-        table will be used.
+        See the Table.define() method documentation for more on
+        reference targets. Association columns must be defined with
+        nullok=False, so the associates parameter is restricted to a
+        more limited form of reference target input without
+        caller-controlled nullok boolean values.
 
         """
         associates = list(associates)
@@ -1236,132 +1462,38 @@ class Table (object):
         if len(associates) < 2:
             raise ValueError('An association table requires at least 2 associates')
 
-        cdefs = []
-        kdefs = []
-        fkdefs = []
-
         used_names = set()
 
-        def check_basename(basename):
-            if not isinstance(base_name, str):
-                raise TypeError('Base name %r is not of required type str' % (base_name,))
-            if base_name in used_names:
-                raise ValueError('Base name %r is not unique among associates and metadata' % (base_name,))
-            used_names.add(base_name)
+        for assoc in associates:
+            if not isinstance(assoc, (tuple, Table, Key)):
+                raise TypeError("Associates must be Table or Key instances, not %s" % (assoc,))
 
-        def choose_basename(key):
-            base_name = key.table.name
-            n = 2
-            while base_name in used_names:
-                base_name = '%s%d' % (key.table.name, n)
-                n += 1
-            used_names.add(base_name)
-            return base_name
+        # first pass: build "pure" association table parts
+        # HACK: use dummy table name if we don't have one yet
+        tname = table_name if table_name is not None else "dummy"
+        cdefs, fkdefs = cls._expand_references(tname, associates, [], used_names)
 
-        def check_key(key):
-            if isinstance(key, Table):
-                # opportunistic case: prefer (non-nullable) "name" or "id" keys, if found
-                for cname in key_column_search_order:
-                    try:
-                        candidate = key.key_by_columns([cname])
-                        if not candidate.unique_columns[0].nullok:
-                            return candidate
-                    except (KeyError, ValueError) as e:
-                        continue
-
-                # general case: try to use RID key
-                try:
-                    return key.key_by_columns(["RID"])
-                except (KeyError, ValueError) as e:
-                    raise ValueError('Could not determine default key for table %s' % (key,))
-            return key
-
-        # check and normalize associates into list[(str, Key)] with distinct base names
-        for i in range(len(associates)):
-            if isinstance(associates[i], tuple):
-                base_name, key = associates[i]
-                check_basename(base_name)
-                key = check_key(key)
-                associates[i] = (base_name, key)
-            else:
-                key = check_key(associates[i])
-                base_name = choose_basename(key)
-                associates[i] = (base_name, key)
-
-        # build assoc table name if not provided
         if table_name is None:
+            # use first pass results to build table_name
             table_name = make_id(*[ assoc[1].table.name for assoc in associates ])
+            # HACK: repeat first pass to make proper fkey def constraint names
+            used_names = set()
+            cdefs, fkdefs = cls._expand_references(table_name, associates, [], used_names)
 
-        def simplify_type(ctype):
-            if ctype.is_domain and ctype.typename.startswith('ermrest_'):
-                return ctype.base_type
-
-            return ctype
-
-        def cdefs_for_key(base_name, key, nullok=False):
-            return [
-                Column.define(
-                    '%s_%s' % (base_name, col.name) if len(key.unique_columns) > 1 else base_name,
-                    simplify_type(col.type),
-                    nullok=nullok,
-                )
-                for col in key.unique_columns
-            ]
-
-        def fkdef_for_key(base_name, key):
-            return ForeignKey.define(
-                [
-                    '%s_%s' % (base_name, col.name) if len(key.unique_columns) > 1 else base_name
-                    for col in key.unique_columns
-                ],
-                key.table.schema.name,
-                key.table.name,
-                [ col.name for col in key.unique_columns ],
-                on_update='CASCADE',
-                on_delete='CASCADE',
-                constraint_name=make_id(table_name, base_name, 'fkey'),
-            )
-
-        # build core association definition (i.e. the "pure" parts)
+        # build assoc key from union of associates' foreign key columns
         k_cnames = []
-        for base_name, key in associates:
-            cdefs.extend(cdefs_for_key(base_name, key))
-            fkdefs.append(fkdef_for_key(base_name, key))
+        for fkdef in fkdefs:
+            k_cnames.extend([ colref["column_name"] for colref in fkdef["foreign_key_columns"] ])
 
-            k_cnames.extend([
-                '%s_%s' % (base_name, col.name) if len(key.unique_columns) > 1 else base_name
-                for col in key.unique_columns
-            ])
-
-        kdefs.append(
+        kdefs = [
             Key.define(
                 k_cnames,
                 constraint_name=make_id(table_name, 'assoc', 'key'),
             )
-        )
+        ]
 
-        # check and normalize metadata into list[dict | (str, bool, Key)]
-        for i in range(len(metadata)):
-            if isinstance(metadata[i], tuple):
-                base_name, nullok, key = metadata[i]
-                check_basename(base_name)
-                key = check_key(key)
-                metadata[i] = (base_name, nullok, key)
-            elif isinstance(metadata[i], dict):
-                pass
-            else:
-                key = check_key(metadata[i])
-                base_name = choose_basename(key)
-                metadata[i] = (base_name, False, key)
-
-        # add metadata to definition
-        for md in metadata:
-            if isinstance(md, dict):
-                cdefs.append(md)
-            else:
-                base_name, nullok, key = md
-                cdefs.extend(cdefs_for_key(base_name, key, nullok))
-                fkdefs.append(fkdef_for_key(base_name, key))
+        # run second pass to expand out metadata targets
+        cdefs, fkdefs = cls._expand_references(table_name, cdefs + metadata, fkdefs, used_names)
 
         return Table.define(table_name, cdefs, kdefs, fkdefs, comment=comment, provide_system=provide_system)
 
@@ -1530,7 +1662,7 @@ class Table (object):
             created = created[0]
         return registerfunc(constructor(self, created))
 
-    def create_column(self, column_def):
+    def create_column(self, column_def: dict) -> Column:
         """Add a new column to this table in the remote database based on column_def.
 
            Returns a new Column instance based on the server-supplied
@@ -1545,7 +1677,7 @@ class Table (object):
             return col
         return self._create_table_part('column', add_column, Column, column_def)
 
-    def create_key(self, key_def):
+    def create_key(self, key_def: dict) -> Key:
         """Add a new key to this table in the remote database based on key_def.
 
            Returns a new Key instance based on the server-supplied
@@ -1558,12 +1690,12 @@ class Table (object):
             return key
         return self._create_table_part('key', add_key, Key, key_def)
 
-    def create_fkey(self, fkey_def):
+    def create_fkey(self, fkey_def: dict) -> ForeignKey:
         """Add a new foreign key to this table in the remote database based on fkey_def.
 
            Returns a new ForeignKey instance based on the
            server-supplied representation of the new foreign key, and
-           adds it to self.fkeys too.
+           adds it to self.foreign_keys too.
 
         """
         def add_fkey(fkey):
@@ -1571,6 +1703,29 @@ class Table (object):
             fkey.digest_referenced_columns(self.schema.model)
             return fkey
         return self._create_table_part('foreignkey', add_fkey, ForeignKey, fkey_def)
+
+    def create_reference(
+        self,
+        target: Key | Table | tuple[str, bool, Key | Table] | tuple[str, Key | Table],
+        key_column_search_order: Iterable[str] | None = None,
+    ) -> tuple[ list[Column], ForeignKey ]:
+        """Add column(s) and a foreign key to this table in the remote database for a reference target.
+
+        See Table.define() documentation for more about reference
+        targets.
+
+        Returns a list of new Column instances and a ForeignKey instance based on
+        the server-supplied representation of the new model elements, and
+        adds them to the self.columns and self.foreign_keys too.
+
+        """
+        used_names = { col.name for col in self.columns }
+        cdefs, fkdefs = self._expand_references(self.name, [ target ], [], used_names, key_column_search_order)
+        if not cdefs or len(fkdefs) != 1:
+            raise NotImplementedError("BUG? got unexpected results from self._expand_reference()")
+        cols = [ self.create_column(cdef) for cdef in cdefs ]
+        fkeys = [ self.create_fkey(fkdef) for fkdef in fkdefs ]
+        return cols, fkeys[0]
 
     def drop(self):
         """Remove this table from the remote database.

--- a/tests/deriva/core/test_ermrest_model.py
+++ b/tests/deriva/core/test_ermrest_model.py
@@ -9,7 +9,7 @@
 import logging
 import os
 import unittest
-from deriva.core import DerivaServer, get_credential, ermrest_model
+from deriva.core import DerivaServer, get_credential, ermrest_model, tag
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
@@ -107,6 +107,596 @@ class ErmrestModelTests (unittest.TestCase):
         self.catalog.post('/schema', json=[schema_def])
         # refresh the local state of the model
         self.model = self.catalog.getCatalogModel()
+
+    def test_0a_schema_define_defaults(self):
+        sname = "test_schema"
+        sdef = ermrest_model.Schema.define(sname)
+        self.assertEqual(sdef.get("schema_name"), sname)
+        self.assertEqual(sdef.get("comment"), None)
+        self.assertEqual(sdef.get("acls"), dict())
+        self.assertEqual(sdef.get("annotations"), dict())
+
+    _test_comment = "my comment"
+    _test_acls = {
+        "insert": ["a"],
+        "update": ["b"],
+    }
+    _test_acl_bindings = {
+    }
+    _test_annotations = {"tag1": "value1"}
+
+    def test_0b_schema_define_custom(self):
+        sname = "test_schema"
+        sdef = ermrest_model.Schema.define(sname, self._test_comment, self._test_acls, self._test_annotations)
+        self.assertEqual(sdef.get("schema_name"), sname)
+        self.assertEqual(sdef.get("comment"), self._test_comment)
+        self.assertEqual(sdef.get("acls"), self._test_acls)
+        self.assertEqual(sdef.get("annotations"), self._test_annotations)
+
+    def test_1a_column_define_defaults(self):
+        cname = "test_column"
+        cdef = ermrest_model.Column.define(cname, ermrest_model.builtin_types.text)
+        self.assertEqual(cdef.get("name"), cname)
+        ctype = cdef.get("type")
+        self.assertIsInstance(ctype, dict)
+        self.assertEqual(ctype.get("typename"), "text")
+        self.assertEqual(cdef.get("nullok"), True)
+        self.assertEqual(cdef.get("default"), None)
+        self.assertEqual(cdef.get("comment"), None)
+        self.assertEqual(cdef.get("acls"), dict())
+        self.assertEqual(cdef.get("acl_bindings"), dict())
+        self.assertEqual(cdef.get("annotations"), dict())
+
+    def test_1b_column_define_custom(self):
+        cname = "test_column"
+        nullok = False
+        default = "my default"
+        cdef = ermrest_model.Column.define(
+            cname, ermrest_model.builtin_types.text, nullok, default,
+            self._test_comment, self._test_acls, self._test_acl_bindings, self._test_annotations,
+        )
+        self.assertEqual(cdef.get("name"), cname)
+        ctype = cdef.get("type")
+        self.assertIsInstance(ctype, dict)
+        self.assertEqual(ctype.get("typename"), "text")
+        self.assertEqual(cdef.get("nullok"), nullok)
+        self.assertEqual(cdef.get("default"), default)
+        self.assertEqual(cdef.get("comment"), self._test_comment)
+        self.assertEqual(cdef.get("acls"), self._test_acls)
+        self.assertEqual(cdef.get("acl_bindings"), self._test_acl_bindings)
+        self.assertEqual(cdef.get("annotations"), self._test_annotations)
+
+    def test_1c_key_define_defaults(self):
+        cnames = ["id"]
+        kdef = ermrest_model.Key.define(cnames)
+        self.assertEqual(kdef.get("unique_columns"), cnames)
+        self.assertEqual(not kdef.get("names"), True)
+        self.assertEqual(kdef.get("comment"), None)
+        self.assertEqual(kdef.get("annotations"), dict())
+
+    def test_1d_key_define_custom(self):
+        cnames = ["id"]
+        constraint_name = "my_constraint"
+        kdef = ermrest_model.Key.define(cnames, None, self._test_comment, self._test_annotations, constraint_name)
+        self.assertEqual(kdef.get("unique_columns"), cnames)
+        self.assertIsInstance(kdef.get("names"), list)
+        self.assertIsInstance(kdef.get("names")[0], list)
+        self.assertEqual(kdef.get("names")[0][1], constraint_name)
+        self.assertEqual(kdef.get("comment"), self._test_comment)
+        self.assertEqual(kdef.get("annotations"), self._test_annotations)
+
+    def test_1e_fkey_define_defaults(self):
+        fk_colnames = ["fk1"]
+        pk_sname = "pk_schema"
+        pk_tname = "pk_table"
+        pk_colnames = ["RID"]
+        fkdef = ermrest_model.ForeignKey.define(
+            fk_colnames,
+            pk_sname,
+            pk_tname,
+            pk_colnames,
+        )
+        self.assertEqual([ c.get("column_name") for c in fkdef.get("foreign_key_columns") ], fk_colnames)
+        self.assertEqual([ c.get("column_name") for c in fkdef.get("referenced_columns") ], pk_colnames)
+        self.assertEqual(all([ c.get("schema_name") == pk_sname for c in fkdef.get("referenced_columns") ]), True)
+        self.assertEqual(all([ c.get("table_name") == pk_tname for c in fkdef.get("referenced_columns") ]), True)
+        self.assertEqual(fkdef.get("on_update"), "NO ACTION")
+        self.assertEqual(fkdef.get("on_delete"), "NO ACTION")
+        self.assertEqual(not fkdef.get("names"), True)
+        self.assertEqual(fkdef.get("comment"), None)
+        self.assertEqual(fkdef.get("acls"), dict())
+        self.assertEqual(fkdef.get("acl_bindings"), dict())
+        self.assertEqual(fkdef.get("annotations"), dict())
+
+    def test_1f_fkey_define_custom(self):
+        fk_colnames = ["fk1"]
+        pk_sname = "pk_schema"
+        pk_tname = "pk_table"
+        pk_colnames = ["RID"]
+        constraint_name = "my_constraint"
+        action1 = "CASCADE"
+        action2 = "RESTRICT"
+        fkdef = ermrest_model.ForeignKey.define(
+            fk_colnames,
+            pk_sname,
+            pk_tname,
+            pk_colnames,
+            action1,
+            action2,
+            None,
+            self._test_comment,
+            self._test_acls,
+            self._test_acl_bindings,
+            self._test_annotations,
+            constraint_name,
+        )
+        self.assertEqual([ c.get("column_name") for c in fkdef.get("foreign_key_columns") ], fk_colnames)
+        self.assertEqual([ c.get("column_name") for c in fkdef.get("referenced_columns") ], pk_colnames)
+        self.assertEqual(all([ c.get("schema_name") == pk_sname for c in fkdef.get("referenced_columns") ]), True)
+        self.assertEqual(all([ c.get("table_name") == pk_tname for c in fkdef.get("referenced_columns") ]), True)
+        self.assertEqual(fkdef.get("on_update"), action1)
+        self.assertEqual(fkdef.get("on_delete"), action2)
+        self.assertIsInstance(fkdef.get("names"), list)
+        self.assertIsInstance(fkdef.get("names")[0], list)
+        self.assertEqual(fkdef.get("names")[0][1], constraint_name)
+        self.assertEqual(fkdef.get("comment"), self._test_comment)
+        self.assertEqual(fkdef.get("acls"), self._test_acls)
+        self.assertEqual(fkdef.get("acl_bindings"), self._test_acl_bindings)
+        self.assertEqual(fkdef.get("annotations"), self._test_annotations)
+
+    def test_2a_table_define_defaults(self):
+        tname = "test_table"
+        tdef = ermrest_model.Table.define(
+            tname,
+            [
+                ermrest_model.Column.define("id", ermrest_model.builtin_types.text),
+            ],
+        )
+        self.assertEqual(tdef.get("table_name"), tname)
+        cdefs = tdef.get("column_definitions")
+        self.assertIsInstance(cdefs, list)
+        self.assertEqual(len(cdefs), 5 + 1)
+        kdefs = tdef.get("keys")
+        self.assertIsInstance(kdefs, list)
+        self.assertEqual(len(kdefs), 1)
+        fkdefs = tdef.get("foreign_keys")
+        self.assertIsInstance(fkdefs, list)
+        self.assertEqual(len(fkdefs), 0)
+        self.assertEqual(tdef.get("comment"), None)
+        self.assertEqual(tdef.get("acls"), dict())
+        self.assertEqual(tdef.get("acl_bindings"), dict())
+        self.assertEqual(tdef.get("annotations"), dict())
+        schema = self.model.create_schema(ermrest_model.Schema.define("model_define_schema"))
+        table = schema.create_table(tdef)
+        self.assertIsInstance(table, ermrest_model.Table)
+
+    def test_2b_table_define_custom(self):
+        tname = "test_table"
+        tdef = ermrest_model.Table.define(
+            tname,
+            [
+                ermrest_model.Column.define("id", ermrest_model.builtin_types.text),
+                ermrest_model.Column.define("fk1", ermrest_model.builtin_types.text),
+            ],
+            [
+                ermrest_model.Key.define(["id"]),
+            ],
+            [
+                ermrest_model.ForeignKey.define(["fk1"], "public", "ERMrest_Client", ["RID"]),
+            ],
+            self._test_comment,
+            self._test_acls,
+            self._test_acl_bindings,
+            self._test_annotations,
+        )
+        self.assertEqual(tdef.get("table_name"), tname)
+        cdefs = tdef.get("column_definitions")
+        self.assertIsInstance(cdefs, list)
+        self.assertEqual(len(cdefs), 5 + 2)
+        kdefs = tdef.get("keys")
+        self.assertIsInstance(kdefs, list)
+        self.assertEqual(len(kdefs), 1 + 1)
+        fkdefs = tdef.get("foreign_keys")
+        self.assertIsInstance(fkdefs, list)
+        self.assertEqual(len(fkdefs), 1)
+        self.assertEqual(tdef.get("comment"), self._test_comment)
+        self.assertEqual(tdef.get("acls"), self._test_acls)
+        self.assertEqual(tdef.get("acl_bindings"), self._test_acl_bindings)
+        self.assertEqual(tdef.get("annotations"), self._test_annotations)
+        schema = self.model.create_schema(ermrest_model.Schema.define("model_define_schema"))
+        table = schema.create_table(tdef)
+        self.assertIsInstance(table, ermrest_model.Table)
+
+    def test_2c_table_define_with_reference(self):
+        tname = "test_table"
+        tdef = ermrest_model.Table.define(
+            tname,
+            [
+                ermrest_model.Column.define("id", ermrest_model.builtin_types.text),
+                self.model.schemas["public"].tables["ERMrest_Client"],
+            ],
+            [],
+            [],
+            self._test_comment,
+            self._test_acls,
+            self._test_acl_bindings,
+            self._test_annotations,
+        )
+        self.assertEqual(tdef.get("table_name"), tname)
+        cdefs = tdef.get("column_definitions")
+        self.assertIsInstance(cdefs, list)
+        self.assertEqual(len(cdefs), 5 + 2)
+        kdefs = tdef.get("keys")
+        self.assertIsInstance(kdefs, list)
+        self.assertEqual(len(kdefs), 1)
+        fkdefs = tdef.get("foreign_keys")
+        self.assertIsInstance(fkdefs, list)
+        self.assertEqual(len(fkdefs), 1)
+        fkdef = fkdefs[0]
+        self.assertEqual([ c["column_name"] for c in fkdef["foreign_key_columns"]], ["ERMrest_Client"])
+        self.assertEqual([ c["column_name"] for c in fkdef["referenced_columns"]], ["ID"])
+        self.assertEqual(fkdef["referenced_columns"][0]["schema_name"], "public")
+        self.assertEqual(fkdef["referenced_columns"][0]["table_name"], "ERMrest_Client")
+        self.assertEqual(tdef.get("comment"), self._test_comment)
+        self.assertEqual(tdef.get("acls"), self._test_acls)
+        self.assertEqual(tdef.get("acl_bindings"), self._test_acl_bindings)
+        self.assertEqual(tdef.get("annotations"), self._test_annotations)
+        schema = self.model.create_schema(ermrest_model.Schema.define("model_define_schema"))
+        table = schema.create_table(tdef)
+        self.assertIsInstance(table, ermrest_model.Table)
+
+    def test_3a_vocab_define_defaults(self):
+        tname = "test_table"
+        curie_template = "test:{RID}"
+        tdef = ermrest_model.Table.define_vocabulary(
+            tname,
+            curie_template,
+        )
+        self.assertEqual(tdef.get("table_name"), tname)
+        cdefs = tdef.get("column_definitions")
+        self.assertIsInstance(cdefs, list)
+        self.assertEqual(len(cdefs), 5 + 5)
+        self.assertEqual({ c["name"] for c in cdefs }, {"RID","RCT","RMT","RCB","RMB","ID","Name","Description","Synonyms","URI"})
+        cdefs = { c["name"]: c for c in cdefs }
+        self.assertEqual(cdefs["ID"]["default"], curie_template)
+        self.assertEqual(cdefs["URI"]["default"], '/id/{RID}')
+        kdefs = tdef.get("keys")
+        self.assertIsInstance(kdefs, list)
+        self.assertEqual(len(kdefs), 1 + 3)
+        fkdefs = tdef.get("foreign_keys")
+        self.assertIsInstance(fkdefs, list)
+        self.assertEqual(len(fkdefs), 0)
+        self.assertEqual(tdef.get("comment"), None)
+        self.assertEqual(tdef.get("acls"), dict())
+        self.assertEqual(tdef.get("acl_bindings"), dict())
+        self.assertEqual(tdef.get("annotations"), dict())
+        schema = self.model.create_schema(ermrest_model.Schema.define("model_define_schema"))
+        table = schema.create_table(tdef)
+        self.assertIsInstance(table, ermrest_model.Table)
+
+    def test_3b_vocab_define_custom(self):
+        tname = "test_table"
+        curie_template = "test:{RID}"
+        uri_template = "/id/1/{RID}"
+        tdef = ermrest_model.Table.define_vocabulary(
+            tname,
+            curie_template,
+            uri_template,
+            [
+                ermrest_model.Column.define("fk1", ermrest_model.builtin_types.text),
+            ],
+            [],
+            [
+                ermrest_model.ForeignKey.define(["fk1"], "public", "ERMrest_Client", ["RID"]),
+            ],
+            self._test_comment,
+            self._test_acls,
+            self._test_acl_bindings,
+            self._test_annotations,
+            provide_name_key=False,
+        )
+        self.assertEqual(tdef.get("table_name"), tname)
+        cdefs = tdef.get("column_definitions")
+        self.assertIsInstance(cdefs, list)
+        self.assertEqual(len(cdefs), 5 + 5 + 1)
+        self.assertEqual({ c["name"] for c in cdefs }, {"RID","RCT","RMT","RCB","RMB","ID","Name","Description","Synonyms","URI","fk1"})
+        cdefs = { c["name"]: c for c in cdefs }
+        self.assertEqual(cdefs["ID"]["default"], curie_template)
+        self.assertEqual(cdefs["URI"]["default"], uri_template)
+        kdefs = tdef.get("keys")
+        self.assertIsInstance(kdefs, list)
+        self.assertEqual(len(kdefs), 1 + 2)
+        fkdefs = tdef.get("foreign_keys")
+        self.assertIsInstance(fkdefs, list)
+        self.assertEqual(len(fkdefs), 1)
+        self.assertEqual(tdef.get("comment"), self._test_comment)
+        self.assertEqual(tdef.get("acls"), self._test_acls)
+        self.assertEqual(tdef.get("acl_bindings"), self._test_acl_bindings)
+        self.assertEqual(tdef.get("annotations"), self._test_annotations)
+        schema = self.model.create_schema(ermrest_model.Schema.define("model_define_schema"))
+        table = schema.create_table(tdef)
+        self.assertIsInstance(table, ermrest_model.Table)
+
+    def test_3c_vocab_define_with_reference(self):
+        tname = "test_table"
+        curie_template = "test:{RID}"
+        uri_template = "/id/1/{RID}"
+        target = self.model.schemas["public"].tables["ERMrest_Client"]
+        self.assertIsInstance(target, ermrest_model.Table)
+        tdef = ermrest_model.Table.define_vocabulary(
+            tname,
+            curie_template,
+            uri_template,
+            [ target, ],
+            [],
+            [],
+            self._test_comment,
+            self._test_acls,
+            self._test_acl_bindings,
+            self._test_annotations,
+        )
+        self.assertEqual(tdef.get("table_name"), tname)
+        cdefs = tdef.get("column_definitions")
+        self.assertIsInstance(cdefs, list)
+        self.assertEqual(len(cdefs), 5 + 5 + 1)
+        self.assertEqual({ c["name"] for c in cdefs }, {"RID","RCT","RMT","RCB","RMB","ID","Name","Description","Synonyms","URI","ERMrest_Client"})
+        kdefs = tdef.get("keys")
+        self.assertIsInstance(kdefs, list)
+        self.assertEqual(len(kdefs), 1 + 3)
+        fkdefs = tdef.get("foreign_keys")
+        self.assertIsInstance(fkdefs, list)
+        self.assertEqual(len(fkdefs), 1)
+        fkdef = fkdefs[0]
+        self.assertEqual([ c["column_name"] for c in fkdef["foreign_key_columns"]], ["ERMrest_Client"])
+        self.assertEqual([ c["column_name"] for c in fkdef["referenced_columns"]], ["ID"])
+        self.assertEqual(fkdef["referenced_columns"][0]["schema_name"], "public")
+        self.assertEqual(fkdef["referenced_columns"][0]["table_name"], "ERMrest_Client")
+        self.assertEqual(tdef.get("comment"), self._test_comment)
+        self.assertEqual(tdef.get("acls"), self._test_acls)
+        self.assertEqual(tdef.get("acl_bindings"), self._test_acl_bindings)
+        self.assertEqual(tdef.get("annotations"), self._test_annotations)
+        schema = self.model.create_schema(ermrest_model.Schema.define("model_define_schema"))
+        table = schema.create_table(tdef)
+        self.assertIsInstance(table, ermrest_model.Table)  
+
+    def test_4a_asset_define_defaults(self):
+        tname = "test_table"
+        tdef = ermrest_model.Table.define_asset(
+            "model_define_schema",
+            tname,
+        )
+        self.assertEqual(tdef.get("table_name"), tname)
+        cdefs = tdef.get("column_definitions")
+        self.assertIsInstance(cdefs, list)
+        self.assertEqual(len(cdefs), 5 + 5)
+        self.assertEqual({ c["name"] for c in cdefs }, {"RID","RCT","RMT","RCB","RMB","Filename","Description","Length","MD5","URL"})
+        cdefs = { c["name"]: c for c in cdefs }
+        kdefs = tdef.get("keys")
+        self.assertIsInstance(kdefs, list)
+        self.assertEqual(len(kdefs), 1 + 1)
+        fkdefs = tdef.get("foreign_keys")
+        self.assertIsInstance(fkdefs, list)
+        self.assertEqual(len(fkdefs), 0)
+        self.assertEqual(tdef.get("acls"), dict())
+        self.assertEqual(tdef.get("acl_bindings"), dict())
+        self.assertEqual(set(tdef.get("annotations").keys()), {tag.table_display})
+        schema = self.model.create_schema(ermrest_model.Schema.define("model_define_schema"))
+        table = schema.create_table(tdef)
+        self.assertIsInstance(table, ermrest_model.Table)
+
+    def test_4b_asset_define_custom(self):
+        tname = "test_table"
+        hatrac_template = "/hatrac/foo/{{{MD5}}}.{{{Filename}}}"
+        tdef = ermrest_model.Table.define_asset(
+            "model_define_schema",
+            tname,
+            hatrac_template,
+            [
+                ermrest_model.Column.define("fk1", ermrest_model.builtin_types.text),
+            ],
+            [],
+            [
+                ermrest_model.ForeignKey.define(["fk1"], "public", "ERMrest_Client", ["RID"]),
+            ],
+            self._test_comment,
+            self._test_acls,
+            self._test_acl_bindings,
+            self._test_annotations,
+        )
+        self.assertEqual(tdef.get("table_name"), tname)
+        cdefs = tdef.get("column_definitions")
+        self.assertIsInstance(cdefs, list)
+        self.assertEqual(len(cdefs), 5 + 5 + 1)
+        self.assertEqual({ c["name"] for c in cdefs }, {"RID","RCT","RMT","RCB","RMB","Filename","Description","Length","MD5","URL","fk1"})
+        cdefs = { c["name"]: c for c in cdefs }
+        self.assertEqual(cdefs["URL"]["annotations"][tag.asset]["url_pattern"], hatrac_template)
+        kdefs = tdef.get("keys")
+        self.assertIsInstance(kdefs, list)
+        self.assertEqual(len(kdefs), 1 + 1)
+        fkdefs = tdef.get("foreign_keys")
+        self.assertIsInstance(fkdefs, list)
+        self.assertEqual(len(fkdefs), 1)
+        self.assertEqual(tdef.get("comment"), self._test_comment)
+        self.assertEqual(tdef.get("acls"), self._test_acls)
+        self.assertEqual(tdef.get("acl_bindings"), self._test_acl_bindings)
+        annotations = tdef.get("annotations")
+        for k, v in self._test_annotations.items():
+            self.assertEqual(annotations[k], v)
+        self.assertIn(tag.table_display, annotations)
+        schema = self.model.create_schema(ermrest_model.Schema.define("model_define_schema"))
+        table = schema.create_table(tdef)
+        self.assertIsInstance(table, ermrest_model.Table)
+
+    def test_4c_asset_define_with_reference(self):
+        tname = "test_table"
+        hatrac_template = "/hatrac/foo/{{{MD5}}}.{{{Filename}}}"
+        target = self.model.schemas["public"].tables["ERMrest_Client"]
+        self.assertIsInstance(target, ermrest_model.Table)
+        tdef = ermrest_model.Table.define_asset(
+            "model_define_schema",
+            tname,
+            hatrac_template,
+            [ target, ],
+            [],
+            [],
+            self._test_comment,
+            self._test_acls,
+            self._test_acl_bindings,
+            self._test_annotations,
+        )
+        self.assertEqual(tdef.get("table_name"), tname)
+        cdefs = tdef.get("column_definitions")
+        self.assertIsInstance(cdefs, list)
+        self.assertEqual(len(cdefs), 5 + 5 + 1)
+        self.assertEqual({ c["name"] for c in cdefs }, {"RID","RCT","RMT","RCB","RMB","Filename","Description","Length","MD5","URL","ERMrest_Client"})
+        kdefs = tdef.get("keys")
+        self.assertIsInstance(kdefs, list)
+        self.assertEqual(len(kdefs), 1 + 1)
+        fkdefs = tdef.get("foreign_keys")
+        self.assertIsInstance(fkdefs, list)
+        self.assertEqual(len(fkdefs), 1)
+        fkdef = fkdefs[0]
+        self.assertEqual([ c["column_name"] for c in fkdef["foreign_key_columns"]], ["ERMrest_Client"])
+        self.assertEqual([ c["column_name"] for c in fkdef["referenced_columns"]], ["ID"])
+        self.assertEqual(fkdef["referenced_columns"][0]["schema_name"], "public")
+        self.assertEqual(fkdef["referenced_columns"][0]["table_name"], "ERMrest_Client")
+        self.assertEqual(tdef.get("comment"), self._test_comment)
+        self.assertEqual(tdef.get("acls"), self._test_acls)
+        self.assertEqual(tdef.get("acl_bindings"), self._test_acl_bindings)
+        annotations = tdef.get("annotations")
+        for k, v in self._test_annotations.items():
+            self.assertEqual(annotations[k], v)
+        self.assertIn(tag.table_display, annotations)
+        schema = self.model.create_schema(ermrest_model.Schema.define("model_define_schema"))
+        table = schema.create_table(tdef)
+        self.assertIsInstance(table, ermrest_model.Table)  
+
+    def test_5a_assoctable_define_defaults(self):
+        tdef = ermrest_model.Table.define_association(
+            [
+                self.model.schemas["public"].tables["ERMrest_Client"],
+                self.model.schemas["public"].tables["ERMrest_Group"],
+            ],
+        )
+        self.assertEqual(tdef.get("table_name"), "ERMrest_Client_ERMrest_Group")
+        self.assertEqual(tdef.get("comment"), None)
+        cdefs = tdef.get("column_definitions")
+        self.assertIsInstance(cdefs, list)
+        self.assertEqual(len(cdefs), 5 + 2)
+        kdefs = tdef.get("keys")
+        self.assertIsInstance(kdefs, list)
+        self.assertEqual(
+            { tuple(key["unique_columns"]) for key in kdefs },
+            { ('RID',), ('ERMrest_Client', 'ERMrest_Group') },
+        )
+        fkdefs = tdef.get("foreign_keys")
+        self.assertIsInstance(fkdefs, list)
+        self.assertEqual(
+            {
+                (
+                    tuple( c["column_name"] for c in fkdef["foreign_key_columns"] ),
+                    fkdef["referenced_columns"][0]["schema_name"],
+                    fkdef["referenced_columns"][0]["table_name"],
+                    tuple( c["column_name"] for c in fkdef["referenced_columns"] ),
+                )
+                for fkdef in fkdefs
+             },
+            {
+                (("ERMrest_Client",), "public", "ERMrest_Client", ("ID",)),
+                (("ERMrest_Group",), "public", "ERMrest_Group", ("ID",)),
+            }
+        )
+        schema = self.model.create_schema(ermrest_model.Schema.define("model_define_schema"))
+        table = schema.create_table(tdef)
+        self.assertIsInstance(table, ermrest_model.Table)
+
+    def test_5b_assoctable_define_custom(self):
+        tname = "client_group"
+        tdef = ermrest_model.Table.define_association(
+            [
+                ('c_id', self.model.schemas["public"].tables["ERMrest_Client"]),
+                ('g_id', self.model.schemas["public"].tables["ERMrest_Group"]),
+            ],
+            [],
+            tname,
+            self._test_comment,
+        )
+        self.assertEqual(tdef.get("table_name"), tname)
+        self.assertEqual(tdef.get("comment"), self._test_comment)
+        cdefs = tdef.get("column_definitions")
+        self.assertIsInstance(cdefs, list)
+        self.assertEqual(len(cdefs), 5 + 2)
+        kdefs = tdef.get("keys")
+        self.assertIsInstance(kdefs, list)
+        self.assertEqual(
+            { tuple(key["unique_columns"]) for key in kdefs },
+            { ('RID',), ('c_id', 'g_id') },
+        )
+        fkdefs = tdef.get("foreign_keys")
+        self.assertIsInstance(fkdefs, list)
+        self.assertEqual(
+            {
+                (
+                    tuple( c["column_name"] for c in fkdef["foreign_key_columns"] ),
+                    fkdef["referenced_columns"][0]["schema_name"],
+                    fkdef["referenced_columns"][0]["table_name"],
+                    tuple( c["column_name"] for c in fkdef["referenced_columns"] ),
+                )
+                for fkdef in fkdefs
+             },
+            {
+                (("c_id",), "public", "ERMrest_Client", ("ID",)),
+                (("g_id",), "public", "ERMrest_Group", ("ID",)),
+            }
+        )
+        schema = self.model.create_schema(ermrest_model.Schema.define("model_define_schema"))
+        table = schema.create_table(tdef)
+        self.assertIsInstance(table, ermrest_model.Table)
+
+    def test_5c_assoctable_define_with_metadata(self):
+        tname = "client_group"
+        tdef = ermrest_model.Table.define_association(
+            [
+                ('c_id', self.model.schemas["public"].tables["ERMrest_Client"]),
+                ('g_id', self.model.schemas["public"].tables["ERMrest_Group"]),
+            ],
+            [
+                ermrest_model.Column.define("md1", ermrest_model.builtin_types.text),
+            ],
+            tname,
+            self._test_comment,
+        )
+        self.assertEqual(tdef.get("table_name"), tname)
+        self.assertEqual(tdef.get("comment"), self._test_comment)
+        cdefs = tdef.get("column_definitions")
+        self.assertIsInstance(cdefs, list)
+        self.assertEqual(len(cdefs), 5 + 2 + 1)
+        kdefs = tdef.get("keys")
+        self.assertIsInstance(kdefs, list)
+        self.assertEqual(
+            { tuple(key["unique_columns"]) for key in kdefs },
+            { ('RID',), ('c_id', 'g_id') },
+        )
+        fkdefs = tdef.get("foreign_keys")
+        self.assertIsInstance(fkdefs, list)
+        self.assertEqual(
+            {
+                (
+                    tuple( c["column_name"] for c in fkdef["foreign_key_columns"] ),
+                    fkdef["referenced_columns"][0]["schema_name"],
+                    fkdef["referenced_columns"][0]["table_name"],
+                    tuple( c["column_name"] for c in fkdef["referenced_columns"] ),
+                )
+                for fkdef in fkdefs
+             },
+            {
+                (("c_id",), "public", "ERMrest_Client", ("ID",)),
+                (("g_id",), "public", "ERMrest_Group", ("ID",)),
+            }
+        )
+        schema = self.model.create_schema(ermrest_model.Schema.define("model_define_schema"))
+        table = schema.create_table(tdef)
+        self.assertIsInstance(table, ermrest_model.Table)
 
     def test_key_drop_cascading(self):
         self._create_schema_with_fkeys()

--- a/tests/deriva/core/test_ermrest_model.py
+++ b/tests/deriva/core/test_ermrest_model.py
@@ -261,7 +261,7 @@ class ErmrestModelTests (unittest.TestCase):
         self.assertEqual(len(kdefs), 1)
         fkdefs = tdef.get("foreign_keys")
         self.assertIsInstance(fkdefs, list)
-        self.assertEqual(len(fkdefs), 0)
+        self.assertEqual(len(fkdefs), 2)
         self.assertEqual(tdef.get("comment"), None)
         self.assertEqual(tdef.get("acls"), dict())
         self.assertEqual(tdef.get("acl_bindings"), dict())
@@ -288,6 +288,7 @@ class ErmrestModelTests (unittest.TestCase):
             self._test_acls,
             self._test_acl_bindings,
             self._test_annotations,
+            provide_system_fkeys=False,
         )
         self.assertEqual(tdef.get("table_name"), tname)
         cdefs = tdef.get("column_definitions")
@@ -331,12 +332,25 @@ class ErmrestModelTests (unittest.TestCase):
         self.assertEqual(len(kdefs), 1)
         fkdefs = tdef.get("foreign_keys")
         self.assertIsInstance(fkdefs, list)
-        self.assertEqual(len(fkdefs), 1)
-        fkdef = fkdefs[0]
-        self.assertEqual([ c["column_name"] for c in fkdef["foreign_key_columns"]], ["ERMrest_Client"])
-        self.assertEqual([ c["column_name"] for c in fkdef["referenced_columns"]], ["ID"])
-        self.assertEqual(fkdef["referenced_columns"][0]["schema_name"], "public")
-        self.assertEqual(fkdef["referenced_columns"][0]["table_name"], "ERMrest_Client")
+        self.assertEqual(len(fkdefs), 2 + 1)
+        self.assertEqual(
+            {
+                (
+                    fkdef["referenced_columns"][0]["schema_name"],
+                    fkdef["referenced_columns"][0]["table_name"],
+                    frozenset(zip(
+                        ( c["column_name"] for c in fkdef["foreign_key_columns"] ),
+                        ( c["column_name"] for c in fkdef["referenced_columns"] ),
+                    ))
+                )
+                for fkdef in fkdefs
+             },
+            {
+                ("public", "ERMrest_Client", frozenset([ ("ERMrest_Client", "ID",) ])),
+                ("public", "ERMrest_Client", frozenset([ ("RCB", "ID",) ])),
+                ("public", "ERMrest_Client", frozenset([ ("RMB", "ID",) ])),
+            }
+        )
         self.assertEqual(tdef.get("comment"), self._test_comment)
         self.assertEqual(tdef.get("acls"), self._test_acls)
         self.assertEqual(tdef.get("acl_bindings"), self._test_acl_bindings)
@@ -365,7 +379,7 @@ class ErmrestModelTests (unittest.TestCase):
         self.assertEqual(len(kdefs), 1 + 3)
         fkdefs = tdef.get("foreign_keys")
         self.assertIsInstance(fkdefs, list)
-        self.assertEqual(len(fkdefs), 0)
+        self.assertEqual(len(fkdefs), 2)
         self.assertEqual(tdef.get("comment"), None)
         self.assertEqual(tdef.get("acls"), dict())
         self.assertEqual(tdef.get("acl_bindings"), dict())
@@ -394,6 +408,7 @@ class ErmrestModelTests (unittest.TestCase):
             self._test_acl_bindings,
             self._test_annotations,
             provide_name_key=False,
+            provide_system_fkeys=False,
         )
         self.assertEqual(tdef.get("table_name"), tname)
         cdefs = tdef.get("column_definitions")
@@ -445,12 +460,25 @@ class ErmrestModelTests (unittest.TestCase):
         self.assertEqual(len(kdefs), 1 + 3)
         fkdefs = tdef.get("foreign_keys")
         self.assertIsInstance(fkdefs, list)
-        self.assertEqual(len(fkdefs), 1)
-        fkdef = fkdefs[0]
-        self.assertEqual([ c["column_name"] for c in fkdef["foreign_key_columns"]], ["ERMrest_Client"])
-        self.assertEqual([ c["column_name"] for c in fkdef["referenced_columns"]], ["ID"])
-        self.assertEqual(fkdef["referenced_columns"][0]["schema_name"], "public")
-        self.assertEqual(fkdef["referenced_columns"][0]["table_name"], "ERMrest_Client")
+        self.assertEqual(len(fkdefs), 2 + 1)
+        self.assertEqual(
+            {
+                (
+                    fkdef["referenced_columns"][0]["schema_name"],
+                    fkdef["referenced_columns"][0]["table_name"],
+                    frozenset(zip(
+                        ( c["column_name"] for c in fkdef["foreign_key_columns"] ),
+                        ( c["column_name"] for c in fkdef["referenced_columns"] ),
+                    ))
+                )
+                for fkdef in fkdefs
+             },
+            {
+                ("public", "ERMrest_Client", frozenset([ ("ERMrest_Client", "ID",) ])),
+                ("public", "ERMrest_Client", frozenset([ ("RCB", "ID",) ])),
+                ("public", "ERMrest_Client", frozenset([ ("RMB", "ID",) ])),
+            }
+        )
         self.assertEqual(tdef.get("comment"), self._test_comment)
         self.assertEqual(tdef.get("acls"), self._test_acls)
         self.assertEqual(tdef.get("acl_bindings"), self._test_acl_bindings)
@@ -476,7 +504,7 @@ class ErmrestModelTests (unittest.TestCase):
         self.assertEqual(len(kdefs), 1 + 1)
         fkdefs = tdef.get("foreign_keys")
         self.assertIsInstance(fkdefs, list)
-        self.assertEqual(len(fkdefs), 0)
+        self.assertEqual(len(fkdefs), 2)
         self.assertEqual(tdef.get("acls"), dict())
         self.assertEqual(tdef.get("acl_bindings"), dict())
         self.assertEqual(set(tdef.get("annotations").keys()), {tag.table_display})
@@ -502,6 +530,7 @@ class ErmrestModelTests (unittest.TestCase):
             self._test_acls,
             self._test_acl_bindings,
             self._test_annotations,
+            provide_system_fkeys=False,
         )
         self.assertEqual(tdef.get("table_name"), tname)
         cdefs = tdef.get("column_definitions")
@@ -554,12 +583,25 @@ class ErmrestModelTests (unittest.TestCase):
         self.assertEqual(len(kdefs), 1 + 1)
         fkdefs = tdef.get("foreign_keys")
         self.assertIsInstance(fkdefs, list)
-        self.assertEqual(len(fkdefs), 1)
-        fkdef = fkdefs[0]
-        self.assertEqual([ c["column_name"] for c in fkdef["foreign_key_columns"]], ["ERMrest_Client"])
-        self.assertEqual([ c["column_name"] for c in fkdef["referenced_columns"]], ["ID"])
-        self.assertEqual(fkdef["referenced_columns"][0]["schema_name"], "public")
-        self.assertEqual(fkdef["referenced_columns"][0]["table_name"], "ERMrest_Client")
+        self.assertEqual(len(fkdefs), 2 + 1)
+        self.assertEqual(
+            {
+                (
+                    fkdef["referenced_columns"][0]["schema_name"],
+                    fkdef["referenced_columns"][0]["table_name"],
+                    frozenset(zip(
+                        ( c["column_name"] for c in fkdef["foreign_key_columns"] ),
+                        ( c["column_name"] for c in fkdef["referenced_columns"] ),
+                    ))
+                )
+                for fkdef in fkdefs
+             },
+            {
+                ("public", "ERMrest_Client", frozenset([ ("ERMrest_Client", "ID",) ])),
+                ("public", "ERMrest_Client", frozenset([ ("RCB", "ID",) ])),
+                ("public", "ERMrest_Client", frozenset([ ("RMB", "ID",) ])),
+            }
+        )
         self.assertEqual(tdef.get("comment"), self._test_comment)
         self.assertEqual(tdef.get("acls"), self._test_acls)
         self.assertEqual(tdef.get("acl_bindings"), self._test_acl_bindings)
@@ -594,16 +636,20 @@ class ErmrestModelTests (unittest.TestCase):
         self.assertEqual(
             {
                 (
-                    tuple( c["column_name"] for c in fkdef["foreign_key_columns"] ),
                     fkdef["referenced_columns"][0]["schema_name"],
                     fkdef["referenced_columns"][0]["table_name"],
-                    tuple( c["column_name"] for c in fkdef["referenced_columns"] ),
+                    frozenset(zip(
+                        tuple( c["column_name"] for c in fkdef["foreign_key_columns"] ),
+                        tuple( c["column_name"] for c in fkdef["referenced_columns"] ),
+                    ))
                 )
                 for fkdef in fkdefs
              },
             {
-                (("ERMrest_Client",), "public", "ERMrest_Client", ("ID",)),
-                (("ERMrest_Group",), "public", "ERMrest_Group", ("ID",)),
+                ("public", "ERMrest_Client", frozenset([ ("ERMrest_Client", "ID",) ])),
+                ("public", "ERMrest_Group", frozenset([ ("ERMrest_Group", "ID",) ])),
+                ("public", "ERMrest_Client", frozenset([ ("RCB", "ID",) ])),
+                ("public", "ERMrest_Client", frozenset([ ("RMB", "ID",) ])),
             }
         )
         schema = self.model.create_schema(ermrest_model.Schema.define("model_define_schema"))
@@ -620,6 +666,7 @@ class ErmrestModelTests (unittest.TestCase):
             [],
             tname,
             self._test_comment,
+            provide_system_fkeys=False,
         )
         self.assertEqual(tdef.get("table_name"), tname)
         self.assertEqual(tdef.get("comment"), self._test_comment)
@@ -637,16 +684,18 @@ class ErmrestModelTests (unittest.TestCase):
         self.assertEqual(
             {
                 (
-                    tuple( c["column_name"] for c in fkdef["foreign_key_columns"] ),
                     fkdef["referenced_columns"][0]["schema_name"],
                     fkdef["referenced_columns"][0]["table_name"],
-                    tuple( c["column_name"] for c in fkdef["referenced_columns"] ),
+                    frozenset(zip(
+                        tuple( c["column_name"] for c in fkdef["foreign_key_columns"] ),
+                        tuple( c["column_name"] for c in fkdef["referenced_columns"] ),
+                    ))
                 )
                 for fkdef in fkdefs
              },
             {
-                (("c_id",), "public", "ERMrest_Client", ("ID",)),
-                (("g_id",), "public", "ERMrest_Group", ("ID",)),
+                ("public", "ERMrest_Client", frozenset([ ("c_id", "ID",) ])),
+                ("public", "ERMrest_Group", frozenset([ ("g_id", "ID",) ])),
             }
         )
         schema = self.model.create_schema(ermrest_model.Schema.define("model_define_schema"))
@@ -682,16 +731,20 @@ class ErmrestModelTests (unittest.TestCase):
         self.assertEqual(
             {
                 (
-                    tuple( c["column_name"] for c in fkdef["foreign_key_columns"] ),
                     fkdef["referenced_columns"][0]["schema_name"],
                     fkdef["referenced_columns"][0]["table_name"],
-                    tuple( c["column_name"] for c in fkdef["referenced_columns"] ),
+                    frozenset(zip(
+                        tuple( c["column_name"] for c in fkdef["foreign_key_columns"] ),
+                        tuple( c["column_name"] for c in fkdef["referenced_columns"] ),
+                    ))
                 )
                 for fkdef in fkdefs
              },
             {
-                (("c_id",), "public", "ERMrest_Client", ("ID",)),
-                (("g_id",), "public", "ERMrest_Group", ("ID",)),
+                ("public", "ERMrest_Client", frozenset([ ("c_id", "ID",) ])),
+                ("public", "ERMrest_Group", frozenset([ ("g_id", "ID",) ])),
+                ("public", "ERMrest_Client", frozenset([ ("RCB", "ID",) ])),
+                ("public", "ERMrest_Client", frozenset([ ("RMB", "ID",) ])),
             }
         )
         schema = self.model.create_schema(ermrest_model.Schema.define("model_define_schema"))


### PR DESCRIPTION
Recently, a Table.define_association utility method was added, including a concept of reference targets to simplify the construction of columns and foreign key constraints.  This PR generalizes the reference target concept so that other Table definition utilities can also supply reference targets instead of basic column and foreign key definitions.