### PR TITLE
Uploader allow none on update

### DIFF
--- a/deriva/transfer/__init__.py
+++ b/deriva/transfer/__init__.py
@@ -4,8 +4,8 @@ from deriva.transfer.download.deriva_download import DerivaDownload, GenericDown
 from deriva.transfer.download.deriva_download_cli import DerivaDownloadCLI
 from deriva.transfer.download.deriva_export import DerivaExport, DerivaExportCLI
 
-from deriva.transfer.upload.deriva_upload import DerivaUpload, GenericUploader, DerivaUploadError, DerivaUploadError, \
-    DerivaUploadConfigurationError, DerivaUploadCatalogCreateError, DerivaUploadCatalogUpdateError, \
+from deriva.transfer.upload.deriva_upload import DerivaUpload, GenericUploader, UploadState, DerivaUploadError, \
+    DerivaUploadError, DerivaUploadConfigurationError, DerivaUploadCatalogCreateError, DerivaUploadCatalogUpdateError, \
     DerivaUploadAuthenticationError
 from deriva.transfer.upload.deriva_upload_cli import DerivaUploadCLI
 

--- a/deriva/transfer/upload/deriva_upload.py
+++ b/deriva/transfer/upload/deriva_upload.py
@@ -725,7 +725,8 @@ class DerivaUpload(object):
         # 8. Update an existing record, if necessary
         column_map = asset_mapping.get("column_map", {})
         allow_none_col_list = asset_mapping.get("allow_empty_columns_on_update", [])
-        updated_record = self.interpolateDict(self.metadata, column_map, True, allow_none_col_list)
+        allow_none = True if allow_none_col_list else False
+        updated_record = self.interpolateDict(self.metadata, column_map, allow_none, allow_none_col_list)
         if updated_record != record:
             record_update_template = asset_mapping.get("record_update_template")
             require_record_update_template = stob(asset_mapping.get("require_record_update_template", False))

--- a/deriva/transfer/upload/deriva_upload.py
+++ b/deriva/transfer/upload/deriva_upload.py
@@ -346,7 +346,7 @@ class DerivaUpload(object):
         return '%s:%s' % (urlquote(schema_name), urlquote(table_name))
 
     @staticmethod
-    def interpolateDict(src, dst, allowNone=False):
+    def interpolateDict(src, dst, allow_none=False, allow_none_column_list=[]):
         if not (isinstance(src, dict) and isinstance(dst, dict)):
             raise ValueError("Invalid input parameter type(s): (src = %s, dst = %s), expected (dict, dict)" % (
                 type(src).__name__, type(dst).__name__))
@@ -366,10 +366,10 @@ class DerivaUpload(object):
                     if value.startswith('{') and value.endswith('}'):
                         value = None
             dst.update({k: value})
-        # remove all None valued entries in the dest, if disallowed
-        if not allowNone:
-            empty = [k for k, v in dst.items() if v is None]
-            for k in empty:
+        # remove all None valued entries in the dest, if globally disallowed or the column is not explicitly allowed
+        empty = [k for k, v in dst.items() if v is None]
+        for k in empty:
+            if not allow_none or (allow_none and k not in allow_none_column_list):
                 del dst[k]
 
         return dst
@@ -724,7 +724,8 @@ class DerivaUpload(object):
 
         # 8. Update an existing record, if necessary
         column_map = asset_mapping.get("column_map", {})
-        updated_record = self.interpolateDict(self.metadata, column_map)
+        allow_none_col_list = asset_mapping.get("allow_empty_columns_on_update", [])
+        updated_record = self.interpolateDict(self.metadata, column_map, True, allow_none_col_list)
         if updated_record != record:
             record_update_template = asset_mapping.get("record_update_template")
             require_record_update_template = stob(asset_mapping.get("require_record_update_template", False))
@@ -798,7 +799,7 @@ class DerivaUpload(object):
             if result:
                 record = result[0]
                 self._updateFileMetadata(record)
-            return self.interpolateDict(self.metadata, column_map, allowNone=True), record
+            return self.interpolateDict(self.metadata, column_map, allow_none=True), record
 
     def _urlEncodeMetadata(self, safe_overrides=None):
         urlencoded = dict()


### PR DESCRIPTION
Provide a mechanism to allow for None/Null values during uploader record update. Use `asset_mapping` parameter `allow_empty_columns_on_update` with an array of allowed `column_map` key names.