### PR TITLE
Improve and cleanup requests session handling in `get_new_requests_session()`

### DIFF
--- a/deriva/core/__init__.py
+++ b/deriva/core/__init__.py
@@ -55,7 +55,7 @@ def get_credential(host,
             scope_map = globus_client.hosts_to_scope_map(hosts=[host], match_scope_tag=match_scope_tag,
                                                          force_refresh=force_scope_lookup,
                                                          warn_on_discovery_failure=True if not creds else False)
-            tokens = globus_client.is_logged_in(exclude_defaults=True)
+            tokens = globus_client.is_logged_in(exclude_defaults=True, hosts_to_scope_map=scope_map)
             if tokens:
                 # 1. look for the explicitly requested scope in the token store, if specified
                 token = globus_client.find_access_token_for_scope(requested_scope, tokens)

--- a/deriva/core/catalog_cli.py
+++ b/deriva/core/catalog_cli.py
@@ -6,7 +6,7 @@ import traceback
 from pprint import pp
 from requests.exceptions import HTTPError, ConnectionError
 from deriva.core import __version__ as VERSION, BaseCLI, KeyValuePairArgs, DerivaServer, DerivaPathError, \
-    get_credential, format_credential, format_exception, DEFAULT_HEADERS
+    get_credential, format_credential, format_exception, read_config, DEFAULT_SESSION_CONFIG, DEFAULT_HEADERS
 from deriva.core.ermrest_model import nochange
 from deriva.core.utils import eprint
 
@@ -191,6 +191,11 @@ class DerivaCatalogCLI (BaseCLI):
         else:
             return get_credential(host_name)
 
+    @staticmethod
+    def _get_session_config():
+        config = read_config()
+        return config.get("session", DEFAULT_SESSION_CONFIG)
+
     def _post_parser_init(self, args):
         """Shared initialization for all sub-commands.
         """
@@ -202,7 +207,8 @@ class DerivaCatalogCLI (BaseCLI):
                                    credentials=DerivaCatalogCLI._get_credential(
                                        self.host,
                                        token=args.token,
-                                       oauth2_token=args.oauth2_token))
+                                       oauth2_token=args.oauth2_token),
+                                   session_config=DerivaCatalogCLI._get_session_config())
 
     @staticmethod
     def _decorate_headers(headers, file_format, method="get"):
@@ -279,10 +285,10 @@ class DerivaCatalogCLI (BaseCLI):
         catalog = self.server.connect_ermrest(args.id)
         try:
             if args.output_file:
-                catalog.getAsFile(args.path,
-                                  destfilename=args.output_file,
-                                  headers=headers,
-                                  delete_if_empty=args.auto_delete)
+                catalog.get_as_file(args.path,
+                                    destfilename=args.output_file,
+                                    headers=headers,
+                                    delete_if_empty=args.auto_delete)
             else:
                 pp(catalog.get(args.path, headers=headers).json())
         except HTTPError as e:

--- a/deriva/core/deriva_binding.py
+++ b/deriva/core/deriva_binding.py
@@ -139,10 +139,10 @@ class DerivaBinding (object):
             server
         )
         self._server_uri = self._base_server_uri
+        self._auth_uri = self._base_server_uri + "/authn/session"
 
         self.session_config = DEFAULT_SESSION_CONFIG if not session_config else session_config
         self._session = None
-        self._get_new_session(self.session_config)
 
         self._caching = caching
         self._cache = {}
@@ -151,8 +151,6 @@ class DerivaBinding (object):
 
         self.dcctx = DerivaClientContext()
 
-        self.set_credentials(credentials, server)
-
     def get_server_uri(self):
         return self._server_uri
 
@@ -160,9 +158,6 @@ class DerivaBinding (object):
         self._close_session()
         self._session = get_new_requests_session(self._server_uri + '/',
                                                  session_config if session_config else self.session_config)
-        # allow loopback requests to bypass SSL cert verification
-        if "https://localhost" in self._server_uri:
-            self._session.verify = False
 
     def _pre_get(self, path, headers):
         self.check_path(path)
@@ -228,13 +223,13 @@ class DerivaBinding (object):
 
     def get_authn_session(self):
         headers = { 'deriva-client-context': self.dcctx.encoded() }
-        r = self._session.get(self._base_server_uri + "/authn/session", headers=headers)
+        r = self._session.get(self._auth_uri, headers=headers)
         _response_raise_for_status(r)
         return r
 
     def post_authn_session(self, credentials):
         headers = { 'deriva-client-context': self.dcctx.encoded() }
-        r = self._session.post(self._base_server_uri + "/authn/session", data=credentials, headers=headers)
+        r = self._session.post(self._auth_uri, data=credentials, headers=headers)
         _response_raise_for_status(r)
         return r
 

--- a/deriva/core/ermrest_catalog.py
+++ b/deriva/core/ermrest_catalog.py
@@ -333,6 +333,9 @@ class ErmrestCatalog(DerivaBinding):
         self._scheme, self._server, self._catalog_id, self._credentials, self._caching, self._session_config = \
             scheme, server, catalog_id, credentials, caching, session_config
 
+        self._get_new_session(self.session_config)
+        self.set_credentials(credentials, server)
+
     @property
     def catalog_id(self):
         return self._catalog_id
@@ -481,12 +484,26 @@ class ErmrestCatalog(DerivaBinding):
     def getAsFile(self,
                   path,
                   destfilename,
-                  headers=DEFAULT_HEADERS,
-                  callback=None,
-                  delete_if_empty=False,
-                  paged=False,
-                  page_size=DEFAULT_PAGE_SIZE,
-                  page_sort_columns=frozenset(["RID"])):
+                  headers = DEFAULT_HEADERS,
+                  callback = None,
+                  delete_if_empty = False,
+                  paged = False,
+                  page_size = DEFAULT_PAGE_SIZE,
+                  page_sort_columns = frozenset(["RID"])):
+        """
+           Deprecated, call `get_as_file` instead.
+        """
+        self.get_as_file(path, destfilename, headers, callback, delete_if_empty, paged, page_size, page_sort_columns)
+
+    def get_as_file(self,
+                    path,
+                    destfilename,
+                    headers=DEFAULT_HEADERS,
+                    callback=None,
+                    delete_if_empty=False,
+                    paged=False,
+                    page_size=DEFAULT_PAGE_SIZE,
+                    page_sort_columns=frozenset(["RID"])):
         """
            Retrieve catalog data streamed to destination file.
            Caller is responsible to clean up file even on error, when the file may or may not exist.

--- a/deriva/transfer/download/processors/query/file_download_query_processor.py
+++ b/deriva/transfer/download/processors/query/file_download_query_processor.py
@@ -31,13 +31,12 @@ class FileDownloadQueryProcessor(BaseQueryProcessor):
         return self.outputs
 
     def getExternalFile(self, url, output_path, headers=None):
-        host = urlsplit(url).netloc
         if output_path:
             if not headers:
                 headers = self.HEADERS.copy()
             else:
                 headers.update(self.HEADERS)
-            session = self.getExternalSession(host)
+            session = self.getExternalSession(url)
             with session.get(url, headers=headers, stream=True) as r:
                 if r.status_code != 200:
                     file_error = "File [%s] transfer failed." % output_path
@@ -58,6 +57,7 @@ class FileDownloadQueryProcessor(BaseQueryProcessor):
                     length = int(r.headers.get('Content-Length'))
                     content_type = r.headers.get("Content-Type")
                     return output_path, length, content_type
+        return None
 
     def downloadFiles(self, input_manifest):
         logging.info("Attempting to download file(s) based on the results of query: %s" % self.query)


### PR DESCRIPTION
- Allow for whitelist of hostnames in session config that can be used to bypass SSL certificate verification -- obviously to be used with caution. There will be warnings aplenty from urllib. 
- Eliminated some spots where extra round-trips were being made during certain username/password authentication flows. 
- Pseudo-deprecated `ErmrestCatalog.getAsFile()` by renaming it `get_as_file` and wrapping it. Updated existing deriva-py code to call the new function name.