### PR TITLE
fix(upload): _createFileRecordWithRid uses MD5+Filename, fails on RID mismatch

### DIFF
--- a/deriva/transfer/upload/deriva_upload.py
+++ b/deriva/transfer/upload/deriva_upload.py
@@ -826,29 +826,65 @@ class DerivaUpload(object):
         """Create a new record using a caller-supplied RID.
 
         Used when asset_mapping has ``use_pre_allocated_rid: true``.
-        Skips the MD5+Filename lookup in ``_getFileRecord``; the caller
-        (via the scan-path regex) must have supplied an RID that was
-        pre-allocated from ``ERMrest_RID_Lease``.
+        Uses MD5+Filename lookup (same key space as ``_getFileRecord``)
+        to detect existing rows, but enforces RID-authoritative
+        semantics: the caller's pre-allocated RID must match the
+        existing row's RID (or the row must not exist).
 
-        Idempotency: if a row with the supplied RID already exists
-        (e.g., a prior upload landed the catalog row but the client
-        crashed before recording success), returns that row rather
-        than raising an RID-collision error. Callers can safely retry
-        after partial failures.
+        Three cases:
+
+        1. **No existing row** — create with caller's RID in payload.
+        2. **Existing row, matching RID** — idempotent return (retry
+           after partial success).
+        3. **Existing row, different RID** — raise
+           :class:`DerivaUploadCatalogCreateError`. The caller's
+           pre-allocated RID cannot be used because the physical
+           artifact already has a catalog row with a different RID.
+           Silently substituting the existing RID would break any
+           FK reference the caller captured between lease-time and
+           upload-completion.
 
         Returns:
             Tuple of (row, record) mirroring ``_getFileRecord``'s
             return shape.
+
+        Raises:
+            DerivaUploadCatalogCreateError: If an existing catalog
+                row for this MD5+Filename has a RID different from
+                the caller's pre-allocated RID.
         """
         column_map = asset_mapping.get("column_map", {})
         allow_none_col_list = asset_mapping.get("allow_empty_columns_on_update", [])
         target_table = self.metadata['target_table']
-        rid = self.metadata["RID"]
+        caller_rid = self.metadata["RID"]
+        md5 = self.metadata.get("md5", "")
+        file_name = self.metadata.get("file_name", "")
 
-        # Pre-check: does a row with this RID already exist?
-        existing = self.catalog.get("/entity/%s/RID=%s" % (target_table, urlquote(rid))).json()
+        # Pre-check by MD5+Filename (same key space as _getFileRecord).
+        # This detects collisions with physical artifacts already in
+        # the catalog — hatrac upload-by-MD5 is idempotent, so a prior
+        # run's successful insert will have a row with a matching URL
+        # unique key.
+        existing = self.catalog.get(
+            "/entity/%s/MD5=%s&Filename=%s" % (
+                target_table, urlquote(md5), urlquote(file_name),
+            )
+        ).json()
         if existing:
             record = existing[0]
+            existing_rid = record.get("RID")
+            if existing_rid != caller_rid:
+                raise DerivaUploadCatalogCreateError(
+                    "Pre-allocated RID %r cannot be used for file %r: "
+                    "the catalog already has a row for this MD5+Filename "
+                    "with RID %r. Silently substituting the existing RID "
+                    "would break any FK reference the caller captured "
+                    "at lease-time. Either re-lease this asset with the "
+                    "existing RID, or reconcile the catalog state." % (
+                        caller_rid, file_name, existing_rid,
+                    )
+                )
+            # Matching RID — idempotent return.
             self._updateFileMetadata(record, no_overwrite=True)
             return self.pruneDict(record, column_map, allow_none_col_list), record
 

--- a/tests/deriva/transfer/upload/test_pre_allocated_rid.py
+++ b/tests/deriva/transfer/upload/test_pre_allocated_rid.py
@@ -83,7 +83,7 @@ def test_init_file_metadata_passes_when_flag_absent(uploader):
 
 
 def test_create_file_record_with_rid_happy_path(uploader):
-    """No existing row with RID → _catalogRecordCreate called with RID in payload."""
+    """No existing row with MD5+Filename → _catalogRecordCreate called with RID in payload."""
     asset_mapping = {
         "use_pre_allocated_rid": True,
         "column_map": {"MD5": "{md5}", "Filename": "{file_name}", "RID": "{RID}"},
@@ -95,12 +95,11 @@ def test_create_file_record_with_rid_happy_path(uploader):
         "target_table": "S:T",
     }
 
-    # Pre-check GET returns empty — row doesn't exist yet.
+    # Pre-check GET by MD5+Filename returns empty — no existing row.
     get_response = MagicMock()
     get_response.json.return_value = []
     uploader.catalog.get.return_value = get_response
 
-    # Stub _catalogRecordCreate to return a created-record shape.
     uploader._catalogRecordCreate = MagicMock(
         return_value=[{"RID": "1-NEW", "MD5": "abc123", "Filename": "f.bin"}]
     )
@@ -108,45 +107,77 @@ def test_create_file_record_with_rid_happy_path(uploader):
 
     record, result = uploader._createFileRecordWithRid(asset_mapping)
 
-    # Pre-check queried by RID.
-    uploader.catalog.get.assert_called_once_with("/entity/S:T/RID=1-NEW")
+    # Pre-check queried by MD5+Filename.
+    uploader.catalog.get.assert_called_once_with(
+        "/entity/S:T/MD5=abc123&Filename=f.bin"
+    )
     # Create called with RID in the row.
     create_call = uploader._catalogRecordCreate.call_args
-    assert create_call[0][0] == "S:T"  # target_table
+    assert create_call[0][0] == "S:T"
     assert create_call[0][1]["RID"] == "1-NEW"
     # Return shape mirrors _getFileRecord: (dict, record).
     assert isinstance(record, dict)
     assert result["RID"] == "1-NEW"
 
 
-def test_create_file_record_with_rid_idempotent_on_existing(uploader):
-    """RID already exists → skip create, return existing row."""
+def test_create_file_record_with_rid_idempotent_matching_rid(uploader):
+    """Existing row with MATCHING RID → idempotent return, skip create."""
     asset_mapping = {
         "use_pre_allocated_rid": True,
         "column_map": {"MD5": "{md5}", "Filename": "{file_name}", "RID": "{RID}"},
     }
     uploader.metadata = {
-        "RID": "1-OLD",
+        "RID": "1-MATCH",
         "md5": "abc123",
         "file_name": "f.bin",
         "target_table": "S:T",
     }
 
-    existing_row = {"RID": "1-OLD", "MD5": "abc123", "Filename": "f.bin"}
+    existing_row = {"RID": "1-MATCH", "MD5": "abc123", "Filename": "f.bin"}
     get_response = MagicMock()
     get_response.json.return_value = [existing_row]
     uploader.catalog.get.return_value = get_response
 
-    # _catalogRecordCreate MUST NOT be called.
     uploader._catalogRecordCreate = MagicMock()
     uploader._updateFileMetadata = MagicMock()
 
     record, result = uploader._createFileRecordWithRid(asset_mapping)
 
     uploader._catalogRecordCreate.assert_not_called()
-    # Return shape: (pruned dict, existing record).
     assert isinstance(record, dict)
     assert result == existing_row
+
+
+def test_create_file_record_with_rid_raises_on_rid_mismatch(uploader):
+    """Existing row with DIFFERENT RID → raise DerivaUploadCatalogCreateError."""
+    from deriva.transfer.upload.deriva_upload import DerivaUploadCatalogCreateError
+    asset_mapping = {
+        "use_pre_allocated_rid": True,
+        "column_map": {"MD5": "{md5}", "Filename": "{file_name}", "RID": "{RID}"},
+    }
+    uploader.metadata = {
+        "RID": "1-CALLER",  # pre-leased by caller
+        "md5": "abc123",
+        "file_name": "f.bin",
+        "target_table": "S:T",
+    }
+
+    # Existing row has the same MD5+Filename but a DIFFERENT RID.
+    existing_row = {"RID": "1-EXISTING", "MD5": "abc123", "Filename": "f.bin"}
+    get_response = MagicMock()
+    get_response.json.return_value = [existing_row]
+    uploader.catalog.get.return_value = get_response
+
+    uploader._catalogRecordCreate = MagicMock()
+
+    with pytest.raises(DerivaUploadCatalogCreateError) as ei:
+        uploader._createFileRecordWithRid(asset_mapping)
+    msg = str(ei.value)
+    assert "1-CALLER" in msg
+    assert "1-EXISTING" in msg
+    assert "f.bin" in msg
+    # Create MUST NOT be called.
+    uploader._catalogRecordCreate.assert_not_called()
 
 
 def test_flag_off_uses_existing_md5_filename_path(uploader):


### PR DESCRIPTION
## Summary

Follow-up fix for PR #206 (use_pre_allocated_rid). The original implementation did a RID-keyed idempotency pre-check, but hatrac uploads are MD5+Filename-idempotent. A retry after partial success would find an existing row with a DIFFERENT RID from the caller's pre-allocated one, then try to create a new row → 409 URL unique constraint violation.

## Fix

Rework \`_createFileRecordWithRid\`:

1. Pre-check by MD5+Filename (same key space as \`_getFileRecord\`).
2. No existing row → create with caller's RID. (Happy path.)
3. Existing row with matching RID → idempotent return.
4. Existing row with DIFFERENT RID → raise \`DerivaUploadCatalogCreateError\` with a clear message explaining the conflict. Do NOT silently substitute the existing RID — that would break FK references the caller captured at lease-time.

## Test Plan

- [x] 7 unit tests pass:
  - 3 existing \`_initFileMetadata\` tests (unchanged)
  - \`test_flag_off_uses_existing_md5_filename_path\` (unchanged)
  - \`test_create_file_record_with_rid_happy_path\` — updated to verify MD5+Filename lookup
  - \`test_create_file_record_with_rid_idempotent_matching_rid\` — replaces old RID-lookup idempotent test
  - \`test_create_file_record_with_rid_raises_on_rid_mismatch\` — new; verifies the error case

## Backward Compatibility

Strictly additive to the opt-in flag semantics. Callers that don't set \`use_pre_allocated_rid\` see no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)