### PR TITLE
fix(upload): pass nondefaults=RID so ERMrest honors pre-allocated RID

### DIFF
--- a/deriva/transfer/upload/deriva_upload.py
+++ b/deriva/transfer/upload/deriva_upload.py
@@ -890,7 +890,9 @@ class DerivaUpload(object):
 
         # Fresh create — RID goes into the payload via column_map.
         row = self.interpolateDict(self.metadata, column_map, allow_none_col_list)
-        result = self._catalogRecordCreate(target_table, row)
+        # Bug E.2: pass nondefaults=["RID"] so ERMrest uses our pre-allocated
+        # RID (from ERMrest_RID_Lease) instead of its implicit default behavior.
+        result = self._catalogRecordCreate(target_table, row, nondefaults=["RID"])
         record = result[0] if result else row
         if record:
             self._updateFileMetadata(record)
@@ -1139,12 +1141,13 @@ class DerivaUpload(object):
 
         return defaults
 
-    def _catalogRecordCreate(self, catalog_table, row, default_columns=None):
+    def _catalogRecordCreate(self, catalog_table, row, default_columns=None, nondefaults=None):
         """
 
         :param catalog_table:
         :param row:
         :param default_columns:
+        :param nondefaults:
         :return:
         """
         if self.cancelled:
@@ -1159,6 +1162,16 @@ class DerivaUpload(object):
             if not default_columns:
                 default_columns = self._get_catalog_default_columns(row, catalog_table)
             default_param = ('?defaults=%s' % ','.join(default_columns)) if len(default_columns) > 0 else ''
+            # Bug E.2: opt out of implicit RID-is-default behavior when
+            # the caller is supplying a pre-allocated RID from
+            # ERMrest_RID_Lease. The server validates the RID against
+            # the lease table and uses the supplied value.
+            if nondefaults:
+                nondefaults_str = ','.join(nondefaults)
+                if default_param:
+                    default_param += '&nondefaults=%s' % nondefaults_str
+                else:
+                    default_param = '?nondefaults=%s' % nondefaults_str
             # for default in default_columns:
             #    row[default] = None
             create_uri = '/entity/%s%s' % (catalog_table, default_param)

--- a/tests/deriva/transfer/upload/test_pre_allocated_rid.py
+++ b/tests/deriva/transfer/upload/test_pre_allocated_rid.py
@@ -111,10 +111,12 @@ def test_create_file_record_with_rid_happy_path(uploader):
     uploader.catalog.get.assert_called_once_with(
         "/entity/S:T/MD5=abc123&Filename=f.bin"
     )
-    # Create called with RID in the row.
+    # Create called with RID in the row AND nondefaults=["RID"] to opt out
+    # of ERMrest's implicit RID-is-default behavior.
     create_call = uploader._catalogRecordCreate.call_args
     assert create_call[0][0] == "S:T"
     assert create_call[0][1]["RID"] == "1-NEW"
+    assert create_call.kwargs.get("nondefaults") == ["RID"]
     # Return shape mirrors _getFileRecord: (dict, record).
     assert isinstance(record, dict)
     assert result["RID"] == "1-NEW"


### PR DESCRIPTION
## Summary

Follow-up fix for Bug E.2 (PRs #206, #207). `_createFileRecordWithRid` puts the pre-allocated RID in the INSERT payload, but ERMrest's implicit default-column behavior treats RID as auto-generated unless the POST URL includes `?nondefaults=RID`. Without this, the server assigns its own RID and the pre-allocated one is wasted.

## Fix

- Extend `_catalogRecordCreate` with an optional `nondefaults` kwarg that appends `&nondefaults=col1,col2` to the POST URL.
- `_createFileRecordWithRid` passes `nondefaults=["RID"]` when creating rows with caller-supplied RIDs.

Per ERMrest's `docs/api-doc/data/rest.md`:
> "the ability to write values RID, RCT, and RCB is limited to the catalog owner except that other users may claim RID values they have pre-allocated in the special public.ERMrest_RID_Lease table."

With `?nondefaults=RID`, ERMrest validates the supplied RID against the lease table and uses it.

## Test Plan

- [x] All 7 existing unit tests pass (1 updated to assert `nondefaults=["RID"]` is passed).

## Backward Compatibility

`_catalogRecordCreate` gains an optional kwarg with default `None` — existing callers see no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)