### PR TITLE
feat(upload): soft-by-default preallocated RID; annotation opts into strict

### DIFF
--- a/deriva/core/utils/core_utils.py
+++ b/deriva/core/utils/core_utils.py
@@ -783,4 +783,5 @@ tag = AttrDict({
     'google_dataset':     'tag:isrd.isi.edu,2021:google-dataset',
     'column_defaults':    'tag:isrd.isi.edu,2023:column-defaults',
     'viz_3d_display':     'tag:isrd.isi.edu,2021:viz-3d-display',
+    'strict_preallocated_rid': 'tag:isrd.isi.edu,2026:strict-preallocated-rid',
 })

--- a/deriva/transfer/upload/deriva_upload.py
+++ b/deriva/transfer/upload/deriva_upload.py
@@ -873,18 +873,30 @@ class DerivaUpload(object):
         if existing:
             record = existing[0]
             existing_rid = record.get("RID")
-            if existing_rid != caller_rid:
+            if existing_rid == caller_rid:
+                # Matching RID — idempotent return.
+                self._updateFileMetadata(record, no_overwrite=True)
+                return self.pruneDict(record, column_map, allow_none_col_list), record
+
+            # RID mismatch — check the table's strict-preallocated-rid
+            # annotation. If set, the caller asserted that any RID
+            # divergence is an error. Otherwise, soft fallback: adopt
+            # the existing row's RID (legacy _getFileRecord semantics).
+            if self._is_strict_preallocated_rid(target_table):
                 raise DerivaUploadCatalogCreateError(
                     "Pre-allocated RID %r cannot be used for file %r: "
                     "the catalog already has a row for this MD5+Filename "
-                    "with RID %r. Silently substituting the existing RID "
-                    "would break any FK reference the caller captured "
-                    "at lease-time. Either re-lease this asset with the "
+                    "with RID %r. The target table has "
+                    "tag:isrd.isi.edu,2026:strict-preallocated-rid set, "
+                    "so silently substituting the existing RID would "
+                    "break FK references the caller captured at "
+                    "lease-time. Either re-lease this asset with the "
                     "existing RID, or reconcile the catalog state." % (
                         caller_rid, file_name, existing_rid,
                     )
                 )
-            # Matching RID — idempotent return.
+            # Soft mode (default): adopt the existing row's RID.
+            self.metadata["RID"] = existing_rid
             self._updateFileMetadata(record, no_overwrite=True)
             return self.pruneDict(record, column_map, allow_none_col_list), record
 
@@ -899,6 +911,32 @@ class DerivaUpload(object):
         return self.interpolateDict(
             self.metadata, column_map, allow_none_column_list=allow_none_col_list
         ), record
+
+    def _is_strict_preallocated_rid(self, target_table):
+        """Return True if the table has the strict-preallocated-rid annotation.
+
+        Looks up the table's annotation via the lazily-loaded
+        ``catalog_model``. The annotation
+        ``tag:isrd.isi.edu,2026:strict-preallocated-rid`` with value
+        ``{"strict": true}`` opts the table into strict mode — RID
+        mismatches between caller-supplied pre-allocated RIDs and
+        existing catalog rows raise an error rather than falling back
+        to the existing row's RID.
+
+        Annotation absent or ``{"strict": false}`` → soft mode.
+        """
+        from deriva.core.utils.core_utils import tag as _tag
+        if not self.catalog_model:
+            self.catalog_model = self.catalog.getCatalogModel()
+        schema_name, table_name = self.catalog.splitQualifiedCatalogName(target_table)
+        schema_obj = self.catalog_model.schemas.get(schema_name)
+        if not schema_obj:
+            return False
+        table_obj = schema_obj.tables.get(table_name)
+        if not table_obj:
+            return False
+        anno = table_obj.annotations.get(_tag.strict_preallocated_rid, {})
+        return bool(anno.get("strict", False)) if isinstance(anno, dict) else False
 
     def _urlEncodeMetadata(self, safe_overrides=None):
         urlencoded = dict()

--- a/tests/deriva/transfer/upload/test_pre_allocated_rid.py
+++ b/tests/deriva/transfer/upload/test_pre_allocated_rid.py
@@ -150,21 +150,20 @@ def test_create_file_record_with_rid_idempotent_matching_rid(uploader):
     assert result == existing_row
 
 
-def test_create_file_record_with_rid_raises_on_rid_mismatch(uploader):
-    """Existing row with DIFFERENT RID → raise DerivaUploadCatalogCreateError."""
+def test_create_file_record_with_rid_raises_on_rid_mismatch_when_strict(uploader):
+    """Existing row with different RID + strict annotation set → raise."""
     from deriva.transfer.upload.deriva_upload import DerivaUploadCatalogCreateError
     asset_mapping = {
         "use_pre_allocated_rid": True,
         "column_map": {"MD5": "{md5}", "Filename": "{file_name}", "RID": "{RID}"},
     }
     uploader.metadata = {
-        "RID": "1-CALLER",  # pre-leased by caller
+        "RID": "1-CALLER",
         "md5": "abc123",
         "file_name": "f.bin",
         "target_table": "S:T",
     }
 
-    # Existing row has the same MD5+Filename but a DIFFERENT RID.
     existing_row = {"RID": "1-EXISTING", "MD5": "abc123", "Filename": "f.bin"}
     get_response = MagicMock()
     get_response.json.return_value = [existing_row]
@@ -172,13 +171,108 @@ def test_create_file_record_with_rid_raises_on_rid_mismatch(uploader):
 
     uploader._catalogRecordCreate = MagicMock()
 
+    # Set the strict annotation on the mocked table.
+    table_obj = MagicMock()
+    table_obj.annotations = {
+        "tag:isrd.isi.edu,2026:strict-preallocated-rid": {"strict": True}
+    }
+    schema_obj = MagicMock()
+    schema_obj.tables = {"T": table_obj}
+    catalog_model = MagicMock()
+    catalog_model.schemas = {"S": schema_obj}
+    uploader.catalog_model = catalog_model
+    uploader.catalog.splitQualifiedCatalogName = MagicMock(return_value=("S", "T"))
+
     with pytest.raises(DerivaUploadCatalogCreateError) as ei:
         uploader._createFileRecordWithRid(asset_mapping)
     msg = str(ei.value)
     assert "1-CALLER" in msg
     assert "1-EXISTING" in msg
     assert "f.bin" in msg
-    # Create MUST NOT be called.
+    uploader._catalogRecordCreate.assert_not_called()
+
+
+def test_create_file_record_with_rid_soft_mode_adopts_existing_rid(uploader):
+    """Existing row with different RID + annotation absent → soft fallback.
+
+    Returns the existing row's RID and updates self.metadata['RID'] so
+    downstream processing sees the final RID.
+    """
+    asset_mapping = {
+        "use_pre_allocated_rid": True,
+        "column_map": {"MD5": "{md5}", "Filename": "{file_name}", "RID": "{RID}"},
+    }
+    uploader.metadata = {
+        "RID": "1-CALLER",
+        "md5": "abc123",
+        "file_name": "f.bin",
+        "target_table": "S:T",
+    }
+
+    existing_row = {"RID": "1-EXISTING", "MD5": "abc123", "Filename": "f.bin"}
+    get_response = MagicMock()
+    get_response.json.return_value = [existing_row]
+    uploader.catalog.get.return_value = get_response
+
+    uploader._catalogRecordCreate = MagicMock()
+    uploader._updateFileMetadata = MagicMock()
+
+    # Table has NO strict annotation → soft mode.
+    table_obj = MagicMock()
+    table_obj.annotations = {}
+    schema_obj = MagicMock()
+    schema_obj.tables = {"T": table_obj}
+    catalog_model = MagicMock()
+    catalog_model.schemas = {"S": schema_obj}
+    uploader.catalog_model = catalog_model
+    uploader.catalog.splitQualifiedCatalogName = MagicMock(return_value=("S", "T"))
+
+    record, result = uploader._createFileRecordWithRid(asset_mapping)
+
+    # Soft mode: adopt the existing row's RID.
+    assert uploader.metadata["RID"] == "1-EXISTING"
+    assert result == existing_row
+    # No create attempt.
+    uploader._catalogRecordCreate.assert_not_called()
+
+
+def test_create_file_record_with_rid_soft_mode_when_strict_false(uploader):
+    """Annotation present with strict=false → treated the same as absent."""
+    asset_mapping = {
+        "use_pre_allocated_rid": True,
+        "column_map": {"MD5": "{md5}", "Filename": "{file_name}", "RID": "{RID}"},
+    }
+    uploader.metadata = {
+        "RID": "1-CALLER",
+        "md5": "abc123",
+        "file_name": "f.bin",
+        "target_table": "S:T",
+    }
+
+    existing_row = {"RID": "1-EXISTING", "MD5": "abc123", "Filename": "f.bin"}
+    get_response = MagicMock()
+    get_response.json.return_value = [existing_row]
+    uploader.catalog.get.return_value = get_response
+
+    uploader._catalogRecordCreate = MagicMock()
+    uploader._updateFileMetadata = MagicMock()
+
+    # strict=false is the same as absent.
+    table_obj = MagicMock()
+    table_obj.annotations = {
+        "tag:isrd.isi.edu,2026:strict-preallocated-rid": {"strict": False}
+    }
+    schema_obj = MagicMock()
+    schema_obj.tables = {"T": table_obj}
+    catalog_model = MagicMock()
+    catalog_model.schemas = {"S": schema_obj}
+    uploader.catalog_model = catalog_model
+    uploader.catalog.splitQualifiedCatalogName = MagicMock(return_value=("S", "T"))
+
+    record, result = uploader._createFileRecordWithRid(asset_mapping)
+
+    assert uploader.metadata["RID"] == "1-EXISTING"
+    assert result == existing_row
     uploader._catalogRecordCreate.assert_not_called()
 
 


### PR DESCRIPTION
## Summary

Follow-up to Bug E.2 PRs #206, #207, #208. Invert the default behavior of `_createFileRecordWithRid`:

- **Default (annotation absent):** soft fallback. On MD5+Filename match with a different existing RID, adopt the existing row's RID. Preserves legacy `_getFileRecord` semantics — identical files across executions resolve to the same catalog row. Self.metadata['RID'] is updated so downstream processing sees the final RID.
- **Opt-in (annotation set):** strict. With `tag:isrd.isi.edu,2026:strict-preallocated-rid = {"strict": true}` on the target table, a RID mismatch raises `DerivaUploadCatalogCreateError`. Use for tables whose rows are referenced by FK columns in the same upload batch.

## Motivation

PR #207's always-strict behavior broke uploads of identical files across executions (e.g., `configuration.json`, `uv.lock`) — a common, legitimate pattern protected by catalog `URL UNIQUE` constraints. Making strict the default broke backward compatibility. Annotation-gated opt-in restores legacy semantics for existing callers while preserving the new FK-critical guarantee for tables that declare strict intent.

## Changes

- **`deriva/core/utils/core_utils.py`**: Added `strict_preallocated_rid` entry to the `tag` enumeration.
- **`deriva/transfer/upload/deriva_upload.py`**:
  - `_createFileRecordWithRid`: mismatch branch now consults the target table's annotation via new helper `_is_strict_preallocated_rid`. Soft mode (default) adopts the existing row's RID and updates `self.metadata['RID']`. Strict mode raises.
  - New helper `_is_strict_preallocated_rid(target_table)`: lazily loads `catalog_model` and reads the table's annotation.

## Test Plan

- [x] Unit tests updated:
  - `test_create_file_record_with_rid_raises_on_rid_mismatch_when_strict` (replaces old unconditional-raise test)
  - `test_create_file_record_with_rid_soft_mode_adopts_existing_rid` (new)
  - `test_create_file_record_with_rid_soft_mode_when_strict_false` (new)
  - Other tests (initFileMetadata, happy path, matching-idempotent, flag-off) unchanged and still pass.

## Backward Compatibility

Existing callers that used PR #207/208's strict behavior would need to set the annotation on their tables to keep it. No known production callers rely on the always-strict behavior (the feature was added in the same release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)