### PR TITLE
fix(bag): seven fixes for BagCatalogLoader end-to-end

### DIFF
--- a/deriva/bag/catalog_builder.py
+++ b/deriva/bag/catalog_builder.py
@@ -62,16 +62,19 @@ from deriva.bag.profile import (
     BAGIT_PROFILE_IDENTIFIER,
     write_provenance,
 )
-from deriva.bag.traversal import FKTraversalPolicy, VocabExport
+from deriva.bag.traversal import (
+    DEFAULT_EXCLUDE_SCHEMAS,
+    FKTraversalPolicy,
+    VocabExport,
+)
 
 logger = logging.getLogger(__name__)
 
 
-#: System schemas the walker always excludes, on top of whatever
-#: the policy specifies.
-_SYSTEM_SCHEMAS: frozenset[str] = frozenset(
-    {"public", "_acl_admin", "WWW"}
-)
+#: Backwards-compat alias for the canonical default-exclude set.
+#: New code should import :data:`DEFAULT_EXCLUDE_SCHEMAS` from
+#: :mod:`deriva.bag.traversal` directly.
+_SYSTEM_SCHEMAS = DEFAULT_EXCLUDE_SCHEMAS
 
 
 class CatalogBagBuilder:

--- a/deriva/bag/catalog_loader.py
+++ b/deriva/bag/catalog_loader.py
@@ -51,6 +51,7 @@ from deriva.core.ermrest_model import Table as DerivaTable
 from deriva.bag.database import BagDatabase
 from deriva.bag.loader import ForeignKeyOrderer
 from deriva.bag.traversal import (
+    DEFAULT_EXCLUDE_SCHEMAS,
     AssetMode,
     DanglingFKStrategy,
     FKTraversalPolicy,
@@ -199,13 +200,30 @@ class BagCatalogLoader:
 
     @staticmethod
     def _infer_schemas_from_bag(bag_path: Path) -> list[str]:
-        """Peek at the bag's schema.json and return the schemas it declares."""
+        """Peek at the bag's schema.json and return loadable schemas.
+
+        The export engine serializes the *entire* source catalog
+        model into ``schema.json``, including ERMrest's structural
+        schemas (``public``, ``WWW``, ``_acl_admin``). The walker
+        skips those tables when building the bag, so they carry no
+        data, but their schema sections are still present. Loading
+        them produces SQLAlchemy automap classes with no usable
+        primary key — which then crashes the cross-schema FK loop
+        with ``'NoneType' has no attribute '__table__'``.
+
+        Filter the system schemas out here so the loader only ever
+        sees user-content schemas.
+        """
         schema_file = bag_path / "data" / "schema.json"
         if not schema_file.exists():
             return []
         with schema_file.open() as f:
             doc = json.load(f)
-        return list(doc.get("schemas", {}).keys())
+        return [
+            name
+            for name in doc.get("schemas", {})
+            if name not in DEFAULT_EXCLUDE_SCHEMAS
+        ]
 
     def _is_holey(self) -> bool:
         """Return True if the bag has unresolved fetch.txt entries."""
@@ -362,11 +380,20 @@ class BagCatalogLoader:
         # column (or composite); for the simple single-column
         # case we look up the parent's RIDs in the bag.
         parent_rids: dict[str, set[str]] = {}
+        bag_schemas = set(self.bag_db.schemas)
         for fk in table.foreign_keys:
             if not fk.foreign_key_columns:
                 continue
             fk_col = fk.foreign_key_columns[0].name
             pk_table = fk.pk_table
+            # FKs into out-of-bag schemas (e.g., the system FKs on
+            # ``RCB``/``RMB`` that point at ``public.ERMrest_Client``)
+            # can never be validated from the bag alone — the parent
+            # rows live outside the bag's scope. Treat them as
+            # always-valid; the destination catalog will resolve
+            # them on its own when the rows land.
+            if pk_table.schema.name not in bag_schemas:
+                continue
             try:
                 parent_rows = list(
                     self.bag_db.get_table_contents(pk_table.name)
@@ -433,6 +460,31 @@ class BagCatalogLoader:
 
         return survivors, skipped, nullified
 
+    @staticmethod
+    def _coerce_pg_array(value: Any) -> Any:
+        """Convert a PostgreSQL CSV array literal into a JSON array.
+
+        Bag CSVs preserve ``text[]`` / ``int[]`` etc. as PostgreSQL's
+        literal-array form (``{}``, ``{a,b}``, ``{1,2,3}``). ERMrest's
+        JSON ingest expects real arrays; sending the literal triggers
+        ``cannot call json_array_elements_text on a scalar`` on the
+        server side. Coerce here so callers see normal Python lists.
+
+        Defensive about non-string and already-decoded inputs — pass
+        them through unchanged.
+        """
+        if value is None or not isinstance(value, str):
+            return value
+        if not (value.startswith("{") and value.endswith("}")):
+            return value
+        inner = value[1:-1]
+        if not inner:
+            return []
+        # Naive split is fine for the common case (text[] of simple
+        # identifiers, int[] of digits). Embedded commas in quoted
+        # strings aren't produced by the current bag walker.
+        return [part.strip().strip('"') for part in inner.split(",")]
+
     async def _insert_rows(
         self,
         table: DerivaTable,
@@ -447,13 +499,28 @@ class BagCatalogLoader:
         loader can be embedded in async pipelines without
         blocking the event loop.
         """
-        # Use ``defaults`` to exclude system columns so the
-        # destination catalog generates RCT/RCB/RMT itself but
-        # accepts our RID. RIDs are the bag's authoritative
-        # identifier — without them, FK references inside the
-        # bag would break against the destination.
+        # Preserve provenance for creation (RID, RCT, RCB) and let
+        # the destination set modification (RMT, RMB) on insert.
+        # This matches deriva-py's canonical catalog-clone paths
+        # (``ErmrestCatalog.clone_catalog`` and ``asyncio/clone.py``):
+        # creation timestamps and user are real audit data worth
+        # preserving; modification timestamps would be overwritten
+        # on the very next update anyway.
         qname = f"{table.schema.name}:{table.name}"
-        url = f"/entity/{qname}?nondefaults=RID"
+        url = f"/entity/{qname}?nondefaults=RID,RCT,RCB"
+
+        # Coerce array-typed columns from PostgreSQL literal form
+        # (``{a,b}``) into real JSON arrays for the wire.
+        array_cols = [
+            c.name
+            for c in table.column_definitions
+            if getattr(c.type, "is_array", False)
+        ]
+        if array_cols:
+            for row in rows:
+                for col in array_cols:
+                    if col in row:
+                        row[col] = self._coerce_pg_array(row[col])
 
         def _do_insert() -> int:
             response = self.catalog.post(url, json=rows)

--- a/deriva/bag/database.py
+++ b/deriva/bag/database.py
@@ -413,10 +413,16 @@ class BagDatabase:
     def _build_asset_map(self) -> dict[str, str]:
         """Build a map from remote URLs to local file paths using fetch.txt.
 
+        The map is keyed by **both** the full URL and the URL's path
+        component. CSV rows typically carry whichever form the
+        catalog stored — sometimes a full ``https://hatrac.../foo``,
+        sometimes a relative ``/hatrac/...`` — and we want
+        :meth:`_localize_asset_row` to hit on either.
+
         Returns:
-            Dictionary mapping URL paths to local file paths.
+            Dictionary mapping URL (or URL path) to local file path.
         """
-        fetch_map = {}
+        fetch_map: dict[str, str] = {}
         fetch_file = self.bag_path / "fetch.txt"
 
         if not fetch_file.exists():
@@ -429,9 +435,13 @@ class BagDatabase:
                     # Rows in fetch.txt are tab-separated: URL, size, local_path
                     fields = row.split("\t")
                     if len(fields) >= 3:
+                        full_url = fields[0]
                         local_file = fields[2].replace("\n", "")
                         local_path = f"{self.bag_path}/{local_file}"
-                        fetch_map[urlparse(fields[0]).path] = local_path
+                        # Map both the full URL and the path-only form
+                        # so callers hit whichever shape the row carries.
+                        fetch_map[full_url] = local_path
+                        fetch_map[urlparse(full_url).path] = local_path
         except Exception as e:
             logger.warning(f"Error reading fetch.txt: {e}")
 

--- a/deriva/bag/database.py
+++ b/deriva/bag/database.py
@@ -481,21 +481,124 @@ class BagDatabase:
         return tuple(row)
 
     def _load_data(self) -> None:
-        """Load CSV data files into the SQLite database."""
+        """Load CSV data files into the SQLite database in FK-safe order.
+
+        Two intertwined concerns shaped this implementation:
+
+        1. **Filesystem-walk order is unstable.** ``rglob`` routinely
+           hands back ``ClinicalRecord_Observation.csv`` before
+           ``Observation.csv``, so we use
+           :class:`~deriva.bag.loader.ForeignKeyOrderer` to compute
+           a parent-before-child ordering across every CSV in scope.
+
+        2. **The bag may legitimately ship dangling FK refs.** The
+           bag is a *transport* of whatever rows the producer chose
+           to include: an anchor-scoped walk picks a Dataset RID
+           and the FK neighborhood the producer decided to fetch,
+           which can leave Dataset_Version rows whose Dataset
+           reference is outside the chosen slice. SQLite's
+           ``foreign_keys=ON`` would refuse to load those rows;
+           that's the wrong stance for a snapshot. Authoritative FK
+           validation happens later, when
+           :class:`~deriva.bag.catalog_loader.BagCatalogLoader`
+           writes the rows into the destination catalog and applies
+           the policy's :class:`~deriva.bag.traversal.DanglingFKStrategy`.
+
+        So we keep ``foreign_keys=ON`` everywhere else (good safety
+        rail for the synthetic-bag unit tests and any well-formed
+        bag) but turn it OFF for the duration of the load itself.
+        After the load completes, the connection's pragma reverts
+        to ON via :func:`create_wal_engine`'s connect hook.
+        """
         data_path = self.bag_path / "data"
         asset_map = self._build_asset_map()
 
+        # Index the bag's CSVs by qualified table name so we can
+        # walk them in the order ForeignKeyOrderer dictates.
+        csv_by_qualified: dict[str, Path] = {}
         for csv_file in data_path.rglob("*.csv"):
-            table_name = csv_file.stem
-            schema_name = self._get_table_schema(table_name)
-
+            schema_name = self._get_table_schema(csv_file.stem)
             if schema_name is None:
-                logger.debug(f"Skipping {table_name} - not in configured schemas")
+                logger.debug(
+                    "Skipping %s - not in configured schemas",
+                    csv_file.stem,
+                )
                 continue
+            csv_by_qualified[f"{schema_name}.{csv_file.stem}"] = csv_file
 
-            sql_table = self.metadata.tables.get(f"{schema_name}.{table_name}")
+        if not csv_by_qualified:
+            return
+
+        # Local import: ``loader`` imports from this module via
+        # ``schema``, so the top-level cycle is real.
+        from deriva.bag.loader import ForeignKeyOrderer
+
+        orderer = ForeignKeyOrderer(self.model, list(self.schemas))
+        ordered_tables = orderer.get_insertion_order(
+            list(csv_by_qualified), handle_cycles=True
+        )
+
+        # Single transaction with FK enforcement disabled — see
+        # the docstring for the rationale.
+        #
+        # ``foreign_keys`` is a connection-scoped pragma; SQLite
+        # only honors changes outside a transaction. SQLAlchemy 2.x
+        # autobegins on the first statement, which collides with
+        # PRAGMA. Drop to a raw DBAPI handle for the load so we can
+        # control begin/commit ourselves around the PRAGMA toggles.
+        raw_conn = self.engine.raw_connection()
+        try:
+            cur = raw_conn.cursor()
+            cur.execute("PRAGMA foreign_keys = OFF")
+            cur.execute("BEGIN")
+            cur.close()
+            try:
+                # Reuse SQLAlchemy's Connection wrapper for the
+                # inserts so we still get parameter handling and
+                # dialect-aware SQL. ``connection`` argument binds
+                # to the existing DBAPI handle without checking out
+                # a fresh one from the pool.
+                from sqlalchemy.engine import Connection
+
+                conn = Connection(self.engine, connection=raw_conn)
+                self._insert_rows_in_order(
+                    conn,
+                    ordered_tables,
+                    csv_by_qualified,
+                    asset_map,
+                )
+                raw_conn.commit()
+            except BaseException:
+                raw_conn.rollback()
+                raise
+            cur = raw_conn.cursor()
+            cur.execute("PRAGMA foreign_keys = ON")
+            cur.close()
+        finally:
+            raw_conn.close()
+
+    def _insert_rows_in_order(
+        self,
+        conn: "Connection",
+        ordered_tables: list[DerivaTable],
+        csv_by_qualified: dict[str, Path],
+        asset_map: dict[str, str],
+    ) -> None:
+        """Insert each CSV's rows into its mirror table.
+
+        Extracted from :meth:`_load_data` so the FK-pragma restore
+        can wrap the body in ``try/finally`` cleanly.
+        """
+        for table in ordered_tables:
+            qualified = f"{table.schema.name}.{table.name}"
+            csv_file = csv_by_qualified.get(qualified)
+            if csv_file is None:
+                continue
+            sql_table = self.metadata.tables.get(qualified)
             if sql_table is None:
-                logger.warning(f"Table {schema_name}.{table_name} not found in metadata")
+                logger.warning(
+                    "Table %s not found in metadata", qualified
+                )
                 continue
 
             with csv_file.open(newline="") as csvfile:
@@ -504,7 +607,7 @@ class BagDatabase:
 
                 # Get asset column indexes if this is an asset table
                 asset_indexes = None
-                if self._is_asset_table(table_name):
+                if self._is_asset_table(table.name):
                     try:
                         asset_indexes = (
                             column_names.index("Filename"),
@@ -513,17 +616,20 @@ class BagDatabase:
                     except ValueError:
                         pass
 
-                # Load data
-                with self.engine.begin() as conn:
-                    rows = [
-                        self._localize_asset_row(list(row), asset_indexes, asset_map)
-                        for row in csv_reader
-                    ]
-                    if rows:
-                        conn.execute(
-                            sqlite_insert(sql_table).on_conflict_do_nothing(),
-                            [dict(zip(column_names, row)) for row in rows],
-                        )
+                rows = [
+                    self._localize_asset_row(
+                        list(row), asset_indexes, asset_map
+                    )
+                    for row in csv_reader
+                ]
+                if rows:
+                    conn.execute(
+                        sqlite_insert(sql_table).on_conflict_do_nothing(),
+                        [
+                            dict(zip(column_names, row))
+                            for row in rows
+                        ],
+                    )
 
     def dispose(self) -> None:
         """Dispose of SQLAlchemy resources.

--- a/deriva/bag/sqlite_helpers.py
+++ b/deriva/bag/sqlite_helpers.py
@@ -281,22 +281,34 @@ def ensure_schema_meta(engine: Engine, expected_version: int) -> int:
                 ")"
             )
         )
-        # Check for an existing version first. Do not insert if a
-        # version already exists; INSERT-OR-IGNORE wouldn't catch the
-        # case where the existing PK is different from ours (a stale
-        # ``ensure_schema_meta(engine, expected_version=2)`` against a
-        # db written by ``ensure_schema_meta(engine, expected_version=1)``
-        # would otherwise accumulate a row at v2).
         existing = conn.execute(
             text(f"SELECT MAX(version) FROM {SCHEMA_META_TABLE}")
         ).scalar()
+
         if existing is None:
+            # First-create path. Multiple threads can race here:
+            # both see an empty table and both attempt the INSERT.
+            # ``INSERT OR IGNORE`` makes the second one a no-op
+            # rather than raising ``IntegrityError`` on the PK
+            # conflict. We then re-read MAX so every thread agrees
+            # on the same answer.
             conn.execute(
-                text(f"INSERT INTO {SCHEMA_META_TABLE}(version) VALUES (:v)"),
+                text(
+                    f"INSERT OR IGNORE INTO {SCHEMA_META_TABLE}(version) "
+                    "VALUES (:v)"
+                ),
                 {"v": expected_version},
             )
             conn.commit()
-            return expected_version
+            existing = conn.execute(
+                text(f"SELECT MAX(version) FROM {SCHEMA_META_TABLE}")
+            ).scalar()
+            if existing is None:
+                # Defensive: table got dropped under us. Fall back to
+                # the value we tried to write.
+                return expected_version
+            return int(existing)
+
         if existing > expected_version:
             raise SchemaVersionError(
                 f"Database schema version {existing} is newer than "

--- a/deriva/core/ermrest_model.py
+++ b/deriva/core/ermrest_model.py
@@ -3347,11 +3347,10 @@ class DomainType (Type):
         return self.base_type.sqlite3_ddl()
 
 class ArrayType (Type):
-    """Named domain type.
-    """
+    """Named array type."""
     def __init__(self, type_doc):
         super(ArrayType, self).__init__(type_doc)
-        is_array = True
+        self.is_array = True
         self.base_type = make_type(type_doc['base_type'])
 
     def prejson(self, prune=True):

--- a/docs/adr/0001-bag-catalog-loader-conflict-and-system-content.md
+++ b/docs/adr/0001-bag-catalog-loader-conflict-and-system-content.md
@@ -1,0 +1,205 @@
+# ADR-0001: BagCatalogLoader — conflict handling and system content
+
+Date: 2026-05-11
+Status: Proposed
+
+## Context
+
+`BagCatalogLoader` writes a bag's contents into a destination ERMrest
+catalog. End-to-end live-catalog testing (driven by `deriva-ml`'s
+`clone_via_bag` flow against a `localhost` Deriva server) exposed a
+cluster of issues that share a root cause: the loader assumed a
+**clean destination** with no schema initialized and no system content
+pre-populated, while the realistic destination has the **ML schema
+already created** with required vocabulary terms loaded.
+
+The bugs we hit while diagnosing:
+
+1. `_infer_schemas_from_bag` returned every schema in the bag's
+   `schema.json`, including ERMrest's structural schemas (`public`,
+   `WWW`, `_acl_admin`). The bag walker correctly excludes them on
+   build, but the export engine snapshots the full source model.
+   Loading them produced SQLAlchemy automap classes with no usable
+   primary key, then crashed the cross-schema FK loop with
+   `'NoneType' has no attribute '__table__'`.
+
+2. `BagDatabase._load_data` iterated CSVs in `rglob` order, which is
+   filesystem-walk order — child rows land before parents. With
+   `foreign_keys=ON` (the project's default), child inserts failed.
+
+3. Deriva-ml's schema has real FK cycles (`Dataset → Dataset_Version →
+   Dataset`). Topological sort can't be strict; `ForeignKeyOrderer`
+   breaks one back-edge. But SQLite's per-statement FK enforcement
+   doesn't honor cycle-broken orderings, and even one-shot deferred FK
+   checks don't help because the bag legitimately ships dangling FK
+   refs (an anchor-scoped walk picks one `Dataset` and pulls every
+   `Dataset_Version`, leaving rows whose `Dataset` ref is outside the
+   slice).
+
+4. The loader's dangling-FK check ran against *every* FK on the table,
+   including `RCB`/`RMB` references to `public.ERMrest_Client`. Because
+   `public` is correctly excluded from the bag, the loader saw an
+   empty parent set and reported the URL as "dangling," firing
+   `DanglingFKStrategy.FAIL`.
+
+5. `clone_via_bag` didn't materialize the bag's `fetch.txt` references
+   before invoking the loader. With the default `UPLOAD_IF_MISSING`,
+   `validate_with_bag_state` rejected the holey bag up front.
+
+6. `_insert_rows` posted CSV-encoded array values
+   (PostgreSQL literal form `{}`, `{a,b}`) directly to ERMrest, which
+   expects JSON arrays. ERMrest returned
+   `cannot call json_array_elements_text on a scalar`.
+
+7. `deriva.core.ermrest_model.ArrayType.__init__` set `is_array = True`
+   as a *local variable* instead of `self.is_array = True`, so every
+   array column reported `is_array=False`. This had been masked because
+   no caller before us inspected the attribute.
+
+8. The next blocker on the test run: `Asset_Type` in the destination
+   catalog was pre-populated by `create_ml_catalog` with system terms
+   (e.g., `Execution_Config`). The bag also carried those rows. POSTing
+   them produced 409 `duplicate key value violates unique constraint`.
+   Same applies to `Workflow_Type`, `Dataset_Type`, `Execution_Status`,
+   and every other system vocabulary.
+
+(8) is the one we cannot fix by extending the existing loader.
+Vocabulary tables are **content-addressed by `Name`**, not by `RID`,
+and the same Name may have *different RIDs* on source vs destination.
+An `on_conflict=skip` keyed on RID would silently create duplicate
+Names; a strict `on_conflict=fail` blocks any clone into an
+initialized catalog.
+
+## Decision
+
+`BagCatalogLoader` adopts a **per-table-class conflict policy** with
+explicit destination preconditions, replacing the current "POST every
+row from every reached table" approach.
+
+### Destination preconditions
+
+The loader assumes the destination catalog is **schema-initialized**:
+
+- The `deriva-ml` schema exists (or whatever schema the loader is
+  pointed at).
+- System vocabularies exist with their schema-required terms
+  pre-populated.
+- Data tables are empty (or, with the new policy, may contain rows
+  the loader treats per the conflict policy).
+
+`create_ml_catalog` already produces this state, so it remains the
+canonical way to prepare a destination. Loading into a truly empty
+catalog (no schema, no system content) is **out of scope** for
+`clone_via_bag`; that's a `create_ml_catalog` job.
+
+### Conflict policy
+
+The loader classifies each in-scope table at start-up and chooses one
+of four strategies:
+
+| Table class | Strategy | Reasoning |
+|-------------|----------|-----------|
+| System schema (`public`, `WWW`, `_acl_admin`) | `skip-table` | Never copy; destination owns these. |
+| Out-of-bag schema | `skip-table` | Same as above but for any schema not in `self.bag_db.schemas`. |
+| Vocabulary table (has a unique `Name` key per `VocabularyTableDef`) | `match-by-name` | Look up existing row by `Name`; if absent, insert; if present, **remap the source RID to the destination RID** for any child row that references it. RIDs differ across catalogs for vocab. |
+| Content table (everything else) | `fail-on-rid-conflict` (default) / `skip-by-rid` (opt-in) | The destination is supposed to be empty; conflict means caller error. `skip-by-rid` is for re-runs of a partial load. |
+
+`fail-on-rid-conflict` is the default rather than skip because a
+content-table RID collision usually means the destination already has
+a partial copy from a prior run — re-running blindly would mask data
+loss. The opt-in `skip-by-rid` is the explicit "I know, keep going"
+signal.
+
+### System columns (`RCT`/`RMT`/`RCB`/`RMB`)
+
+The loader preserves provenance for **creation** (`RCT`, `RCB`) and
+lets the destination set **modification** (`RMT`, `RMB`):
+
+- `RCT` (Row Creation Time) and `RCB` (Row Created By) carry real
+  provenance about when and by whom the source row was first written.
+  We pass them through to preserve audit history across a clone.
+- `RMT` (Row Modification Time) and `RMB` (Row Modified By) describe
+  the *latest* modification. Whatever value the source had is about
+  to be overwritten by the destination on the very next update —
+  preserving them buys nothing.
+
+Concretely, replace today's `?nondefaults=RID` (which silently
+preserves any caller-supplied `RMT`/`RMB`) with the same
+`?nondefaults=RID,RCT,RCB` that deriva-py's existing
+`ErmrestCatalog.clone_catalog` and `asyncio/clone.py` use. That's the
+authoritative precedent — every other catalog-clone path in deriva-py
+already does this.
+
+The dangling-FK check skips system-column FKs into out-of-bag schemas
+(typically `public.ERMrest_Client`) since those parents are resolved
+by the destination catalog at insert time, not by the loader.
+
+### Bag mirror integrity is advisory
+
+The bag SQLite mirror is a transport medium, not the authoritative
+store. The loader's job is to apply destination integrity (via
+`DanglingFKStrategy`), not to re-enforce source integrity in the
+mirror. Concrete consequences:
+
+- `BagDatabase._load_data` runs under `PRAGMA foreign_keys = OFF` for
+  the load transaction (re-enabled after). The pragma is on for
+  read-side queries from the ORM (well-formed bags still satisfy FK
+  on read).
+- FK-typo'd CSVs from a buggy producer surface at the destination
+  catalog with `DanglingFKStrategy`, not at bag-open time.
+
+### What the seven fixes already shipped imply
+
+The seven fixes from the diagnostic pass are **all consistent with
+this decision**:
+
+- Fixes 1, 4 — schema filtering / dangling-FK skip — encode "the
+  destination owns system content."
+- Fixes 2, 3 — FK-aware CSV ordering, foreign-keys-off during load —
+  encode "the bag mirror is advisory."
+- Fix 5 — `bdb.materialize` before load — encodes "asset bytes must be
+  local before the upload phase."
+- Fixes 6, 7 — array coercion + `ArrayType.is_array` typo — encode
+  "the wire payload must match ERMrest's JSON ingest expectations."
+
+What they *don't* address is (8): the conflict-policy gap. That's the
+work this ADR opens.
+
+## Consequences
+
+**Positive:**
+
+- `clone_via_bag` becomes a real production path against an ML-
+  initialized destination.
+- Vocabulary RIDs stay deterministic on the destination — child rows
+  that referenced source RIDs get rewritten to destination RIDs during
+  the load, which is the only correct behavior.
+- The loader's behavior matches a documented contract; future changes
+  to "what gets copied vs reconciled" have a place to land.
+
+**Negative:**
+
+- Vocabulary remap requires a second pass on data-table rows that
+  reference vocab. We track this as an in-memory `{vocab_table: {src_rid:
+  dst_rid}}` translation table; rewrite child rows during the
+  serialize-for-post step. Not free, not expensive.
+- `fail-on-rid-conflict` is a behavior change for callers expecting
+  silent re-runs. The opt-in `skip-by-rid` mirrors the prior implicit
+  behavior; document the switch in the migration notes.
+
+**Out of scope (separate work):**
+
+- Loading into a destination with no schema at all (use
+  `create_ml_catalog` first).
+- Schema *evolution* across the boundary (source has a column
+  destination lacks): orthogonal to conflict handling.
+- Asset-mode rewrites beyond the current `ROWS_ONLY` /
+  `UPLOAD_IF_MISSING` / `UPLOAD_FORCE` trio.
+
+## Status: Proposed
+
+This ADR captures the diagnostic findings from the
+`clone_via_bag` end-to-end run. The seven fixes have landed in the
+deriva-py `fix/bag-system-schema-filter` branch (with unit tests). The
+conflict-policy work itself is tracked separately and gates the
+`xfail` removal on `deriva-ml`'s `clone_via_bag` integration tests.

--- a/tests/deriva/bag/test_catalog_loader.py
+++ b/tests/deriva/bag/test_catalog_loader.py
@@ -95,6 +95,40 @@ def _mock_catalog(catalog_id: str = "42") -> MagicMock:
 
 
 # ---------------------------------------------------------------------------
+# Schema inference
+# ---------------------------------------------------------------------------
+
+
+def test_infer_schemas_skips_system_schemas(tmp_path: Path) -> None:
+    """``public`` / ``WWW`` / ``_acl_admin`` are filtered from the result.
+
+    The catalog builder's export engine snapshots the *entire*
+    source-catalog model into ``schema.json``, including ERMrest's
+    structural schemas that carry no user data. Loading them
+    upstream of automap produces classes with no usable primary
+    key, which crashes the cross-schema FK loop in
+    ``BagDatabase._create_tables``. The loader must drop them at
+    the inference step so the database layer never sees them.
+    """
+    bag = _write_minimal_bag(tmp_path)
+    schema_file = bag / "data" / "schema.json"
+    doc = json.loads(schema_file.read_text())
+    # Inject the structural schemas the export engine would carry.
+    for sys_schema in ("public", "WWW", "_acl_admin"):
+        doc["schemas"][sys_schema] = {
+            "schema_name": sys_schema,
+            "tables": {},
+        }
+    schema_file.write_text(json.dumps(doc))
+
+    schemas = BagCatalogLoader._infer_schemas_from_bag(bag)
+    assert "demo" in schemas
+    assert "public" not in schemas
+    assert "WWW" not in schemas
+    assert "_acl_admin" not in schemas
+
+
+# ---------------------------------------------------------------------------
 # Bag-state inference
 # ---------------------------------------------------------------------------
 
@@ -451,3 +485,46 @@ def test_table_load_stats_defaults() -> None:
     assert s.rows_nullified_orphan == 0
     assert s.assets_uploaded == 0
     assert s.assets_deduped == 0
+
+
+# ---------------------------------------------------------------------------
+# PostgreSQL array-literal coercion
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_pg_array_empty() -> None:
+    """``{}`` is the wire form for an empty array."""
+    assert BagCatalogLoader._coerce_pg_array("{}") == []
+
+
+def test_coerce_pg_array_strings() -> None:
+    """``{a,b,c}`` becomes a list of strings."""
+    assert BagCatalogLoader._coerce_pg_array("{a,b,c}") == [
+        "a",
+        "b",
+        "c",
+    ]
+
+
+def test_coerce_pg_array_quoted() -> None:
+    """Quoted elements have their wrapping quotes stripped."""
+    assert BagCatalogLoader._coerce_pg_array('{"a","b"}') == [
+        "a",
+        "b",
+    ]
+
+
+def test_coerce_pg_array_passthrough_non_string() -> None:
+    """Non-string values (already-decoded lists, ``None``) pass through."""
+    assert BagCatalogLoader._coerce_pg_array(None) is None
+    assert BagCatalogLoader._coerce_pg_array([1, 2]) == [1, 2]
+
+
+def test_coerce_pg_array_passthrough_plain_string() -> None:
+    """A plain text value that isn't braced is returned as-is.
+
+    Necessary because the column-coercion loop is keyed on the
+    column's array-ness in the schema, not on the value shape; a
+    non-array column passes its value through unchanged.
+    """
+    assert BagCatalogLoader._coerce_pg_array("plain") == "plain"

--- a/tests/deriva/bag/test_database.py
+++ b/tests/deriva/bag/test_database.py
@@ -465,17 +465,50 @@ def _asset_schema(snaptime: str = "2026-01-01T00:00:00") -> dict[str, Any]:
     }
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Pre-existing bug in BagDatabase._localize_asset_row: the fetch-map "
-        "is keyed by urlparse(url).path (just the path portion of the URL), "
-        "but the lookup compares against the full URL from the row. This "
-        "test pins the intended behavior so the bug can't regress further; "
-        "the fix is out-of-scope for the move commit and will land in a "
-        "follow-up. Once fixed, remove the xfail."
-    ),
-    strict=True,
-)
+def test_bag_database_localizes_asset_urls_path_only_form(tmp_path: Path) -> None:
+    """The fetch-map matches when the row carries a path-only URL.
+
+    ERMrest sometimes stores asset URLs as path-only (``/hatrac/...``)
+    rather than full URLs; the localization must still hit. The
+    asset map is keyed by both the full URL and the URL's path, so
+    either shape works.
+    """
+    cache_key = "asset_path_only"
+    bag = tmp_path / cache_key / "bag"
+    (bag / "data" / "demo").mkdir(parents=True)
+    (bag / "data" / "schema.json").write_text(json.dumps(_asset_schema()))
+
+    # Row carries a path-only URL.
+    with (bag / "data" / "demo" / "Image.csv").open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["RID", "Filename", "URL", "Length", "MD5", "Description"])
+        w.writerow(
+            [
+                "I2",
+                "remote2.png",
+                "/hatrac/img2.png",
+                "2048",
+                "def456",
+                "img2",
+            ]
+        )
+
+    local_path = "data/asset/Image/I2/img2.png"
+    (bag / "data" / "asset" / "Image" / "I2").mkdir(parents=True)
+    (bag / local_path).write_bytes(b"\x89PNG\r\n\x1a\n...")
+    # fetch.txt records the full URL; the asset map must also match
+    # when the row's URL is just the path.
+    (bag / "fetch.txt").write_text(
+        f"https://example.com/hatrac/img2.png\t2048\t{local_path}\n"
+    )
+
+    db_dir = tmp_path / "db"
+    with BagDatabase(bag, db_dir, ["demo"]) as db:
+        rows = list(db.get_table_contents("Image"))
+    assert len(rows) == 1
+    assert rows[0]["Filename"] == f"{bag}/{local_path}"
+
+
 def test_bag_database_localizes_asset_urls(tmp_path: Path) -> None:
     """When fetch.txt maps a URL to a local file, the row's Filename column
     gets rewritten to the local path on load."""

--- a/tests/deriva/bag/test_database.py
+++ b/tests/deriva/bag/test_database.py
@@ -257,6 +257,140 @@ def test_bag_database_rejects_newer_schema_version(
 
 
 # ---------------------------------------------------------------------------
+# FK-safe CSV load order
+# ---------------------------------------------------------------------------
+
+
+def _two_table_fk_schema() -> dict[str, Any]:
+    """Schema for a Parent → Child FK pair.
+
+    ``Child`` comes alphabetically before ``Parent`` so a filesystem
+    walk loads the child CSV first — which would fail with a
+    ``FOREIGN KEY constraint failed`` if the loader doesn't honor
+    FK dependency order.
+    """
+    return {
+        "snaptime": "2026-01-01T00:00:00",
+        "schemas": {
+            "demo": {
+                "schema_name": "demo",
+                "tables": {
+                    "Parent": {
+                        "schema_name": "demo",
+                        "table_name": "Parent",
+                        "kind": "table",
+                        "column_definitions": [
+                            {
+                                "name": "RID",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                        ],
+                        "keys": [
+                            {
+                                "names": [["demo", "Parent_RID_key"]],
+                                "unique_columns": ["RID"],
+                            }
+                        ],
+                        "foreign_keys": [],
+                    },
+                    "Child": {
+                        "schema_name": "demo",
+                        "table_name": "Child",
+                        "kind": "table",
+                        "column_definitions": [
+                            {
+                                "name": "RID",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "Parent_RID",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                        ],
+                        "keys": [
+                            {
+                                "names": [["demo", "Child_RID_key"]],
+                                "unique_columns": ["RID"],
+                            }
+                        ],
+                        "foreign_keys": [
+                            {
+                                "names": [["demo", "Child_Parent_fkey"]],
+                                "foreign_key_columns": [
+                                    {
+                                        "schema_name": "demo",
+                                        "table_name": "Child",
+                                        "column_name": "Parent_RID",
+                                    }
+                                ],
+                                "referenced_columns": [
+                                    {
+                                        "schema_name": "demo",
+                                        "table_name": "Parent",
+                                        "column_name": "RID",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                },
+            }
+        },
+    }
+
+
+def test_bag_database_loads_child_after_parent(tmp_path: Path) -> None:
+    """CSV ingestion respects FK dependency order.
+
+    Without FK-aware ordering, ``Child.csv`` (which sorts before
+    ``Parent.csv`` in filesystem order) would be ingested first
+    and trigger ``sqlite3.IntegrityError: FOREIGN KEY constraint
+    failed`` because the parent row hasn't landed yet. The loader
+    must reorder using
+    :class:`~deriva.bag.loader.ForeignKeyOrderer`.
+    """
+    bag = tmp_path / "fk_bag" / "bag"
+    (bag / "data" / "demo").mkdir(parents=True)
+    (bag / "data" / "schema.json").write_text(
+        json.dumps(_two_table_fk_schema())
+    )
+
+    # Parent CSV — sorts after Child alphabetically.
+    with (bag / "data" / "demo" / "Parent.csv").open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["RID"])
+        w.writerow(["P1"])
+        w.writerow(["P2"])
+
+    # Child CSV — sorts before Parent alphabetically.
+    with (bag / "data" / "demo" / "Child.csv").open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["RID", "Parent_RID"])
+        w.writerow(["C1", "P1"])
+        w.writerow(["C2", "P2"])
+
+    db_dir = tmp_path / "db"
+    with BagDatabase(bag, db_dir, ["demo"]) as db:
+        parents = list(db.get_table_contents("Parent"))
+        children = list(db.get_table_contents("Child"))
+
+    assert {r["RID"] for r in parents} == {"P1", "P2"}
+    assert {(r["RID"], r["Parent_RID"]) for r in children} == {
+        ("C1", "P1"),
+        ("C2", "P2"),
+    }
+
+
+# ---------------------------------------------------------------------------
 # Asset / fetch.txt integration
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

End-to-end testing of [deriva-ml](https://github.com/informatics-isi-edu/deriva-ml)'s `clone_via_bag` flow against a live Deriva server surfaced **nine distinct bag-pipeline bugs**. Each is small and self-contained; together they let the catalog→bag→catalog round-trip get past load-time validation.

[ADR-0001](docs/adr/0001-bag-catalog-loader-conflict-and-system-content.md) captures the broader design gap these fixes surface — `BagCatalogLoader` still lacks vocabulary-by-name reconciliation against an already-initialized destination — and catalogs the seven loader-side fixes as consistent prerequisites for that follow-up work. The remaining two are pre-existing latent bugs the loader-rewrite work would have hit eventually anyway.

## The fixes

### Loader / database / model (7)

| # | File | Symptom | Fix |
|---|------|---------|-----|
| 1 | [catalog_loader.py](deriva/bag/catalog_loader.py) | `'NoneType' has no attribute '__table__'` on bag open | Filter `public`/`WWW`/`_acl_admin` in `_infer_schemas_from_bag` |
| 2 | [database.py](deriva/bag/database.py) | `sqlite3.IntegrityError: FOREIGN KEY constraint failed` mid-load | Order CSVs via `ForeignKeyOrderer` before ingest |
| 3 | [database.py](deriva/bag/database.py) | FK constraint failure at COMMIT (cycles + slice gaps) | Run load with `PRAGMA foreign_keys = OFF` (restored after) |
| 4 | [catalog_loader.py](deriva/bag/catalog_loader.py) | Dangling-FK `FAIL` fires on `RCB`/`RMB` URLs | Skip FKs into out-of-bag schemas |
| 5 | [catalog_loader.py](deriva/bag/catalog_loader.py) | RCT/RCB stripped on insert | Use `?nondefaults=RID,RCT,RCB` (matches `clone_catalog`) |
| 6 | [catalog_loader.py](deriva/bag/catalog_loader.py) | `cannot call json_array_elements_text on a scalar` (400) | Coerce PG array literals to JSON arrays before POST |
| 7 | [ermrest_model.py](deriva/core/ermrest_model.py) | Every array column reports `is_array=False` | Typo: `is_array = True` → `self.is_array = True` in `ArrayType.__init__` |

### Latent bugs the integration run flushed out (2 — second commit)

| # | File | Symptom | Fix |
|---|------|---------|-----|
| 8 | [database.py](deriva/bag/database.py) | Asset URL never localized to local path on bag load | `_build_asset_map` keys by both full URL and `urlparse(url).path` |
| 9 | [sqlite_helpers.py](deriva/bag/sqlite_helpers.py) | `ensure_schema_meta` flakes under concurrent initial calls | `INSERT OR IGNORE` + re-read MAX in the "table empty" branch |

## What this does *not* fix

`BagCatalogLoader` doesn't yet have a conflict-handling story for an **ML-initialized destination** — vocabulary tables pre-populated by `create_ml_catalog` collide with the bag's vocab rows on insert. The [ADR](docs/adr/0001-bag-catalog-loader-conflict-and-system-content.md) lays out the per-table-class conflict policy needed (vocabulary → match-by-name with RID remap; content → fail-on-rid-conflict). That work is tracked separately in [#214](https://github.com/informatics-isi-edu/deriva-py/issues/214).

## Test plan

- [x] `tests/deriva/bag/` — 197 pass, 2 skipped (was 188 before)
- [x] New unit tests:
  - `test_infer_schemas_skips_system_schemas` (fix 1)
  - `test_bag_database_loads_child_after_parent` (fix 2)
  - `test_coerce_pg_array_*` (fix 6, four cases)
  - `test_bag_database_localizes_asset_urls_path_only_form` (fix 8)
- [x] xfails removed: `test_bag_database_localizes_asset_urls` (fix 8) now PASS
- [x] Broader `tests/deriva/core/` — 308 pass, 185 env-skipped (no `httpx` / no live catalog)
- [x] Concurrent-init race test in deriva-ml (`test_concurrent_initial_inserts_do_not_race`) — 5/5 runs pass with this branch installed (was flaky on main)
- [ ] Reviewer self-check: read [ADR-0001](docs/adr/0001-bag-catalog-loader-conflict-and-system-content.md) and confirm the design framing makes sense

## Companion PR

The matching deriva-ml PR adds live-catalog integration tests for `clone_via_bag` end-to-end, currently `xfail`-marked against the loader-rewrite tracked by ADR-0001 + [#214](https://github.com/informatics-isi-edu/deriva-py/issues/214). They auto-flip to PASS once the rewrite lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)