### PR TITLE
fix(clone): repair Column.sname AttributeError + warn on default mismatch

### DIFF
--- a/deriva/core/ermrest_catalog.py
+++ b/deriva/core/ermrest_catalog.py
@@ -897,19 +897,37 @@ class ErmrestCatalog(DerivaBinding):
             return (sname, tname, prune_parts(c.prejson()))
 
         def check_column_compatibility(src, dst):
-            """Check compatibility of source and destination column definitions."""
+            """Check compatibility of source and destination column definitions.
+
+            Type and nullability mismatches are real schema
+            incompatibilities — the clone can't proceed. Default
+            mismatches are softer: they only affect rows the
+            destination might generate on its own, and
+            ``clone_catalog`` always carries explicit values for
+            every copied row. We log defaults that differ instead of
+            failing — typically these are CURIE templates baked
+            with the source catalog's project name (e.g.,
+            ``"src-name:{RID}"`` vs ``"dst-name:{RID}"``), which are
+            both correct for their respective catalogs.
+            """
             def error(fieldname, sv, dv):
                 return ValueError("Source/dest column %s mismatch %s != %s for %s:%s:%s" % (
                     fieldname,
                     sv, dv,
-                    src.sname, src.tname, src.name
+                    src.table.schema.name, src.table.name, src.name
                 ))
             if src.type.typename != dst.type.typename:
                 raise error("type", src.type.typename, dst.type.typename)
             if src.nullok != dst.nullok:
                 raise error("nullok", src.nullok, dst.nullok)
             if src.default != dst.default:
-                raise error("default", src.default, dst.default)
+                logging.warning(
+                    "Source/dest column default differs for %s:%s:%s "
+                    "(src=%r, dst=%r); proceeding (clone copies explicit "
+                    "values for every row)",
+                    src.table.schema.name, src.table.name, src.name,
+                    src.default, dst.default,
+                )
 
         def copy_kdef(k):
             return (sname, tname, prune_parts(k.prejson()))


### PR DESCRIPTION
## Summary

Two adjacent fixes to `ErmrestCatalog.clone_catalog`, both surfaced when [deriva-ml#98](https://github.com/informatics-isi-edu/deriva-ml/pull/98)'s integration-test fixture tries to schema-clone a deriva-ml source catalog into a sibling destination.

## Fix 1: `Column.sname` AttributeError

`check_column_compatibility` referenced `src.sname` / `src.tname` to label the offending column, but `Column` doesn't have those attributes — it carries a `self.table` backreference. When a real column mismatch fired, the error builder raised `AttributeError` instead of the intended `ValueError`, masking the actual mismatch from callers.

**Fix:** use `src.table.schema.name` and `src.table.name`.

## Fix 2: over-strict `default` comparison

`check_column_compatibility` aborted whenever source and destination column `default` values differed. Too strict for the typical deriva-ml case: every vocabulary table's `ID` column default is a CURIE template baked with the catalog's project name — `"src-name:{RID}"` vs `"dst-name:{RID}"`. Both are correct for their respective catalogs, and `clone_catalog` never actually uses them — it carries explicit values for every copied row.

**Fix:** log a warning instead of raising. Type and nullability mismatches still abort (real schema incompatibilities).

## Verification

End-to-end repro: schema-clone of a deriva-ml catalog into a sibling now succeeds with the expected warnings:

```
WARNING:root:Source/dest column default differs for deriva-ml:Asset_Role:ID (src='clone-repro-src:{RID}', dst='clone-repro-dst:{RID}'); proceeding (clone copies explicit values for every row)
[similar for Execution_Status, Dataset_Type, Feature_Name, ...]
CLONE OK
```

`tests/deriva/` (excluding env-dependent live-catalog and `httpx` suites) — **310 pass**, 185 skipped (unchanged).

## Companion work

This unblocks the `dest_catalog` fixture in [deriva-ml#98](https://github.com/informatics-isi-edu/deriva-ml/pull/98). One more upstream item remains before those integration tests can XPASS — the `BagCatalogLoader._upload_assets` stub awaiting `DerivaUpload` integration. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)