### PR TITLE
feat(bag): implement BagCatalogLoader._upload_assets via HatracStore

### DIFF
--- a/deriva/bag/catalog_loader.py
+++ b/deriva/bag/catalog_loader.py
@@ -777,47 +777,146 @@ class BagCatalogLoader:
         table: DerivaTable,
         rows: list[dict[str, Any]],
     ) -> tuple[int, int]:
-        """Run per-asset uploads. Returns ``(uploaded, deduped)``.
+        """Push asset bytes to the destination Hatrac. Returns ``(uploaded, deduped)``.
 
-        Delegates each upload to deriva-py's
-        :class:`~deriva.transfer.upload.deriva_upload.DerivaUpload`
-        recipe so we get Hatrac dedupe + catalog row reconciliation
-        + pre-allocated-RID handling for free.
+        For each asset row in ``rows``:
 
-        This implementation is intentionally minimal — the full
-        producer-side integration with DerivaUpload's asset
-        mapping is a larger piece that needs the destination
-        catalog's upload configuration. For now we count the rows
-        that *would* be uploaded so the report is accurate;
-        full implementation lands in a follow-up commit once
-        the asset-mapping shape is settled.
+        - Use ``Filename`` (now a local path inside the bag — see
+          :meth:`BagDatabase._localize_asset_row`) as the source
+          file.
+        - Use the path component of the row's ``URL`` (the
+          source-catalog Hatrac URL) as the destination Hatrac
+          path. Source and destination share the same logical
+          ``/hatrac/{table}/...`` layout, so the path is portable
+          across catalogs.
+        - With ``UPLOAD_IF_MISSING`` (default), HEAD the
+          destination first and skip the byte transfer when the
+          MD5 already matches.
+        - With ``UPLOAD_FORCE``, re-upload unconditionally.
+
+        Rows missing a local file or URL are warned and skipped
+        (they count as neither uploaded nor deduped). HTTP errors
+        during upload propagate to the caller — the loader's job
+        is to surface them, not to swallow them.
         """
-        # TODO(deriva-bag): integrate with DerivaUpload._uploadAsset
-        # once the asset-mapping config for arbitrary destination
-        # catalogs is settled. The shape needed:
-        #
-        #   1. For each row, build an asset-mapping entry with
-        #      use_pre_allocated_rid=True so the bag's RID is
-        #      preserved at the destination.
-        #   2. Pass the bag's data/asset/{table}/{rid}/{filename}
-        #      path as the source file.
-        #   3. DerivaUpload._uploadAsset does the HEAD-and-MD5
-        #      dedupe internally; we get the dedup count back via
-        #      its FileUploadState.
-        #
-        # The integration is real code, not a stub — it just
-        # needs a paired destination-catalog upload config to
-        # exercise. That arrives with the deriva-ml migration PR.
-        logger.warning(
-            "BagCatalogLoader: asset upload (%s) not yet "
-            "implemented; %d asset rows in %s will have rows "
-            "inserted but bytes will be deferred to DerivaUpload "
-            "integration.",
-            self.policy.asset_mode.value,
-            len(rows),
-            table.name,
+        hatrac = self._dest_hatrac_store()
+
+        uploaded = 0
+        deduped = 0
+        force = self.policy.asset_mode == AssetMode.UPLOAD_FORCE
+
+        for row in rows:
+            local_path = row.get("Filename")
+            url = row.get("URL")
+            if not local_path or not url:
+                logger.warning(
+                    "asset row %s.%s/RID=%s missing Filename or URL; skipping",
+                    table.schema.name, table.name, row.get("RID"),
+                )
+                continue
+            if not Path(local_path).is_file():
+                logger.warning(
+                    "asset row %s.%s/RID=%s Filename=%r does not exist on "
+                    "disk; skipping (was the bag materialized?)",
+                    table.schema.name, table.name, row.get("RID"),
+                    local_path,
+                )
+                continue
+            hatrac_path = self._hatrac_path_for(url)
+            if hatrac_path is None:
+                logger.warning(
+                    "asset row %s.%s/RID=%s URL=%r is not a hatrac URL; "
+                    "skipping",
+                    table.schema.name, table.name, row.get("RID"),
+                    url,
+                )
+                continue
+
+            md5 = row.get("MD5") or None
+
+            # HEAD-then-PUT so we can count dedupes accurately. For
+            # ``UPLOAD_FORCE`` skip the HEAD and just push.
+            if not force and await self._hatrac_already_has(
+                hatrac, hatrac_path, md5
+            ):
+                deduped += 1
+                continue
+
+            await asyncio.to_thread(
+                hatrac.put_loc,
+                hatrac_path,
+                local_path,
+                md5=md5,
+                force=force,
+            )
+            uploaded += 1
+
+        return uploaded, deduped
+
+    def _dest_hatrac_store(self) -> Any:
+        """Return a :class:`HatracStore` bound to the destination host.
+
+        Cached on the loader since every asset upload reuses the
+        same store. The store reuses the catalog's credentials.
+        """
+        if getattr(self, "_hatrac_store", None) is not None:
+            return self._hatrac_store
+        from deriva.core import HatracStore
+
+        deriva_server = self.catalog.deriva_server
+        self._hatrac_store = HatracStore(
+            deriva_server.scheme,
+            deriva_server.server,
+            credentials=self.catalog._credentials,
         )
-        return 0, 0
+        return self._hatrac_store
+
+    @staticmethod
+    def _hatrac_path_for(url: str) -> str | None:
+        """Extract the ``/hatrac/...`` path from a hatrac URL.
+
+        Accepts both full ``https://host/hatrac/...`` and bare
+        ``/hatrac/...``. Returns ``None`` for anything else —
+        non-hatrac URLs (CDN refs, external links) aren't uploadable
+        as Hatrac objects.
+        """
+        from urllib.parse import urlparse
+
+        if url.startswith("/hatrac/"):
+            return url
+        parsed = urlparse(url)
+        if parsed.path.startswith("/hatrac/"):
+            return parsed.path
+        return None
+
+    async def _hatrac_already_has(
+        self,
+        hatrac: Any,
+        hatrac_path: str,
+        md5: str | None,
+    ) -> bool:
+        """HEAD the destination Hatrac object; True iff MD5 matches.
+
+        Missing MD5 means we can't be sure dedupe is safe, so we
+        return False (forcing an upload). A 404 on HEAD also means
+        we need to upload.
+        """
+        if not md5:
+            return False
+        import requests
+
+        def _head() -> bool:
+            try:
+                r = hatrac.head(hatrac_path)
+            except requests.HTTPError as e:
+                if getattr(e.response, "status_code", None) == 404:
+                    return False
+                raise
+            if r.status_code != 200:
+                return False
+            return r.headers.get("Content-MD5") == md5
+
+        return await asyncio.to_thread(_head)
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/tests/deriva/bag/test_catalog_loader.py
+++ b/tests/deriva/bag/test_catalog_loader.py
@@ -879,3 +879,226 @@ def test_content_conflict_skip_by_rid_filters_existing(
         "SKIP_BY_RID should drop W1 (already on destination) but "
         f"send W2; got {widget_rids!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Hatrac URL → path extraction
+# ---------------------------------------------------------------------------
+
+
+def test_hatrac_path_for_full_url() -> None:
+    """Full https URL → path-only form."""
+    assert (
+        BagCatalogLoader._hatrac_path_for(
+            "https://example.org/hatrac/Image/abc.png"
+        )
+        == "/hatrac/Image/abc.png"
+    )
+
+
+def test_hatrac_path_for_bare_path() -> None:
+    """Already-bare hatrac path passes through unchanged."""
+    assert (
+        BagCatalogLoader._hatrac_path_for("/hatrac/Image/abc.png")
+        == "/hatrac/Image/abc.png"
+    )
+
+
+def test_hatrac_path_for_non_hatrac_returns_none() -> None:
+    """A non-hatrac URL is unrecognized — callers warn and skip."""
+    assert (
+        BagCatalogLoader._hatrac_path_for(
+            "https://cdn.example.org/img.png"
+        )
+        is None
+    )
+    assert BagCatalogLoader._hatrac_path_for("/other/img.png") is None
+
+
+# ---------------------------------------------------------------------------
+# Asset upload — dedupe + force semantics
+# ---------------------------------------------------------------------------
+
+
+def _build_asset_only_bag(tmp_path: Path) -> Path:
+    """Build a bag with one asset table and one row referencing a local file."""
+    bag = tmp_path / "asset_only" / "bag"
+    (bag / "data" / "demo").mkdir(parents=True)
+    (bag / "data" / "asset" / "Image" / "I1").mkdir(parents=True)
+    local_asset = bag / "data" / "asset" / "Image" / "I1" / "img.png"
+    local_asset.write_bytes(b"\x89PNG\r\n\x1a\n...")
+
+    doc = {
+        "snaptime": "2026-01-01T00:00:00",
+        "schemas": {
+            "demo": {
+                "schema_name": "demo",
+                "tables": {
+                    "Image": {
+                        "schema_name": "demo",
+                        "table_name": "Image",
+                        "kind": "table",
+                        "column_definitions": [
+                            {"name": "RID", "type": {"typename": "text"}, "nullok": False, "default": None, "comment": None},
+                            {"name": "Filename", "type": {"typename": "text"}, "nullok": True, "default": None, "comment": None},
+                            {"name": "URL", "type": {"typename": "text"}, "nullok": True, "default": None, "comment": None},
+                            {"name": "Length", "type": {"typename": "int8"}, "nullok": True, "default": None, "comment": None},
+                            {"name": "MD5", "type": {"typename": "text"}, "nullok": True, "default": None, "comment": None},
+                            {"name": "Description", "type": {"typename": "markdown"}, "nullok": True, "default": None, "comment": None},
+                        ],
+                        "keys": [{"names": [["demo", "Image_RID_key"]], "unique_columns": ["RID"]}],
+                        "foreign_keys": [],
+                    },
+                },
+            }
+        },
+    }
+    (bag / "data" / "schema.json").write_text(json.dumps(doc))
+    with (bag / "data" / "demo" / "Image.csv").open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["RID", "Filename", "URL", "Length", "MD5", "Description"])
+        w.writerow(
+            [
+                "I1",
+                str(local_asset),  # local path already populated
+                "https://src.example.org/hatrac/Image/img.png",
+                "8",
+                "deadbeef",  # md5 (fake, but the test mocks the HEAD)
+                "img",
+            ]
+        )
+    return bag
+
+
+def test_upload_assets_dedupe_skips_when_md5_matches(tmp_path: Path) -> None:
+    """``UPLOAD_IF_MISSING`` skips bytes when destination MD5 matches."""
+    import asyncio
+
+    bag = _build_asset_only_bag(tmp_path)
+    catalog = _mock_catalog()
+    hatrac = MagicMock()
+    head_resp = MagicMock()
+    head_resp.status_code = 200
+    head_resp.headers = {"Content-MD5": "deadbeef"}
+    hatrac.head.return_value = head_resp
+
+    loader = BagCatalogLoader(
+        catalog=catalog,
+        bag=bag,
+        policy=FKTraversalPolicy(asset_mode=AssetMode.UPLOAD_IF_MISSING),
+        database_dir=tmp_path / "db",
+    )
+    loader._hatrac_store = hatrac  # bypass real construction
+    try:
+        image = loader.bag_db.model.schemas["demo"].tables["Image"]
+        rows = list(loader.bag_db.get_table_contents("Image"))
+        uploaded, deduped = asyncio.run(
+            loader._upload_assets(image, rows)
+        )
+    finally:
+        loader.dispose()
+
+    assert uploaded == 0
+    assert deduped == 1
+    hatrac.put_loc.assert_not_called()
+    hatrac.head.assert_called_once_with("/hatrac/Image/img.png")
+
+
+def test_upload_assets_uploads_when_md5_differs(tmp_path: Path) -> None:
+    """``UPLOAD_IF_MISSING`` pushes bytes when destination MD5 differs."""
+    import asyncio
+
+    bag = _build_asset_only_bag(tmp_path)
+    catalog = _mock_catalog()
+    hatrac = MagicMock()
+    head_resp = MagicMock()
+    head_resp.status_code = 200
+    head_resp.headers = {"Content-MD5": "different_md5"}
+    hatrac.head.return_value = head_resp
+
+    loader = BagCatalogLoader(
+        catalog=catalog,
+        bag=bag,
+        policy=FKTraversalPolicy(asset_mode=AssetMode.UPLOAD_IF_MISSING),
+        database_dir=tmp_path / "db",
+    )
+    loader._hatrac_store = hatrac
+    try:
+        image = loader.bag_db.model.schemas["demo"].tables["Image"]
+        rows = list(loader.bag_db.get_table_contents("Image"))
+        uploaded, deduped = asyncio.run(
+            loader._upload_assets(image, rows)
+        )
+    finally:
+        loader.dispose()
+
+    assert uploaded == 1
+    assert deduped == 0
+    hatrac.put_loc.assert_called_once()
+    # The destination Hatrac path is the source URL's path component.
+    args, kwargs = hatrac.put_loc.call_args
+    assert args[0] == "/hatrac/Image/img.png"
+    assert kwargs.get("md5") == "deadbeef"
+    assert kwargs.get("force") is False
+
+
+def test_upload_assets_force_bypasses_head(tmp_path: Path) -> None:
+    """``UPLOAD_FORCE`` skips the HEAD and pushes unconditionally."""
+    import asyncio
+
+    bag = _build_asset_only_bag(tmp_path)
+    catalog = _mock_catalog()
+    hatrac = MagicMock()
+
+    loader = BagCatalogLoader(
+        catalog=catalog,
+        bag=bag,
+        policy=FKTraversalPolicy(asset_mode=AssetMode.UPLOAD_FORCE),
+        database_dir=tmp_path / "db",
+    )
+    loader._hatrac_store = hatrac
+    try:
+        image = loader.bag_db.model.schemas["demo"].tables["Image"]
+        rows = list(loader.bag_db.get_table_contents("Image"))
+        uploaded, deduped = asyncio.run(
+            loader._upload_assets(image, rows)
+        )
+    finally:
+        loader.dispose()
+
+    assert uploaded == 1
+    assert deduped == 0
+    hatrac.head.assert_not_called()
+    _args, kwargs = hatrac.put_loc.call_args
+    assert kwargs.get("force") is True
+
+
+def test_upload_assets_skips_missing_local_file(tmp_path: Path) -> None:
+    """Rows whose Filename doesn't exist on disk are warned and skipped."""
+    import asyncio
+
+    bag = _build_asset_only_bag(tmp_path)
+    # Remove the local file so the row points at nothing.
+    (bag / "data" / "asset" / "Image" / "I1" / "img.png").unlink()
+
+    catalog = _mock_catalog()
+    hatrac = MagicMock()
+    loader = BagCatalogLoader(
+        catalog=catalog,
+        bag=bag,
+        policy=FKTraversalPolicy(asset_mode=AssetMode.UPLOAD_IF_MISSING),
+        database_dir=tmp_path / "db",
+    )
+    loader._hatrac_store = hatrac
+    try:
+        image = loader.bag_db.model.schemas["demo"].tables["Image"]
+        rows = list(loader.bag_db.get_table_contents("Image"))
+        uploaded, deduped = asyncio.run(
+            loader._upload_assets(image, rows)
+        )
+    finally:
+        loader.dispose()
+
+    assert uploaded == 0
+    assert deduped == 0
+    hatrac.put_loc.assert_not_called()


### PR DESCRIPTION
## Summary

Replaces the documented stub in `BagCatalogLoader._upload_assets` with a real implementation that pushes asset bytes to the destination Hatrac. The third and final upstream blocker preventing [deriva-ml#98](https://github.com/informatics-isi-edu/deriva-ml/pull/98)'s integration tests from going green.

## How it works

For each asset row:

- Local file path comes from `Filename` (which `BagDatabase._localize_asset_row` has already rewritten to a bag-local path on bag open).
- Destination Hatrac path comes from the row's `URL` column (its path component — source and destination share the `/hatrac/...` namespace layout).
- `UPLOAD_IF_MISSING` (default): HEAD the destination object; skip upload when `Content-MD5` matches the row's stored MD5.
- `UPLOAD_FORCE`: skip the HEAD, re-upload unconditionally.
- Rows missing a local file or URL log a warning and are skipped (counted as neither uploaded nor deduped).

The destination `HatracStore` is constructed from the catalog's own server + credentials and cached on the loader for the duration of the run. We use `HatracStore.put_loc` (via `asyncio.to_thread`) and `HatracStore.head` for dedupe — no new infrastructure, just composing existing primitives.

## Why not `DerivaUpload._uploadAsset`?

`DerivaUpload._uploadAsset` is tightly coupled to the asset-mapping annotation paradigm — regex-based directory scanning, `match_groupdict`, per-mapping config — which a programmatic bag-to-catalog upload doesn't need. Using `HatracStore` directly keeps the loader narrowly focused on the bag → Hatrac transfer.

## Tests

7 new unit tests in `test_catalog_loader.py`:

- `test_hatrac_path_for_full_url` / `_bare_path` / `_non_hatrac_returns_none` — URL parsing helper
- `test_upload_assets_dedupe_skips_when_md5_matches` — HEAD-then-skip path
- `test_upload_assets_uploads_when_md5_differs` — HEAD-then-PUT path
- `test_upload_assets_force_bypasses_head` — `UPLOAD_FORCE` skips HEAD
- `test_upload_assets_skips_missing_local_file` — defensive

`tests/deriva/bag/` goes from 197 → **204 passing**, 2 skipped.

## Sequence after merge

With this and [#215](https://github.com/informatics-isi-edu/deriva-py/pull/215) (conflict policy) and [#216](https://github.com/informatics-isi-edu/deriva-py/pull/216) (clone_catalog fix) merged, all three upstream blockers for [deriva-ml#98](https://github.com/informatics-isi-edu/deriva-ml/pull/98)'s integration tests are gone. The xfail markers there should flip to XPASS on the next CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)