### PR TITLE
fix(bag): strip versioned-URL suffix; coerce date/datetime to ISO

### DIFF
--- a/deriva/bag/catalog_loader.py
+++ b/deriva/bag/catalog_loader.py
@@ -725,6 +725,27 @@ class BagCatalogLoader:
         # strings aren't produced by the current bag walker.
         return [part.strip().strip('"') for part in inner.split(",")]
 
+    @staticmethod
+    def _coerce_datetimes(row: dict[str, Any]) -> dict[str, Any]:
+        """Convert ``datetime.date`` / ``datetime.datetime`` values to ISO strings.
+
+        SQLite-mirror rows come back with Python date/datetime
+        objects (via :class:`deriva.bag.database.StringToDate` and
+        :class:`StringToDateTime`). :func:`json.dumps` can't
+        serialize those directly, and ERMrest expects ISO-8601
+        text on the wire. Walk the row, replace each date/datetime
+        with its ``isoformat()`` string, and leave other types
+        alone.
+
+        Returns a new dict so the caller's input isn't mutated.
+        """
+        import datetime
+
+        return {
+            k: (v.isoformat() if isinstance(v, (datetime.date, datetime.datetime)) else v)
+            for k, v in row.items()
+        }
+
     async def _insert_rows(
         self,
         table: DerivaTable,
@@ -761,6 +782,14 @@ class BagCatalogLoader:
                 for col in array_cols:
                     if col in row:
                         row[col] = self._coerce_pg_array(row[col])
+
+        # Coerce date/datetime values back to ISO strings. The bag's
+        # SQLite mirror returns Python ``datetime.date`` /
+        # ``datetime.datetime`` objects via the type decorators in
+        # :mod:`deriva.bag.database` (``StringToDate`` /
+        # ``StringToDateTime``); ``json.dumps`` can't serialize those
+        # directly and ERMrest expects ISO strings on the wire.
+        rows = [self._coerce_datetimes(r) for r in rows]
 
         def _do_insert() -> int:
             response = self.catalog.post(url, json=rows)
@@ -873,21 +902,37 @@ class BagCatalogLoader:
 
     @staticmethod
     def _hatrac_path_for(url: str) -> str | None:
-        """Extract the ``/hatrac/...`` path from a hatrac URL.
+        """Extract the unversioned ``/hatrac/...`` path from a hatrac URL.
 
-        Accepts both full ``https://host/hatrac/...`` and bare
-        ``/hatrac/...``. Returns ``None`` for anything else —
-        non-hatrac URLs (CDN refs, external links) aren't uploadable
-        as Hatrac objects.
+        Accepts full ``https://host/hatrac/...`` and bare
+        ``/hatrac/...``. Versioned URLs (with a trailing
+        ``:VERSIONID``) get stripped to the base path — Hatrac
+        assigns versions on PUT, and uploading directly to a
+        versioned URL returns ``405 Method Not Allowed``. The
+        source's version is preserved in the catalog row's
+        ``URL`` column, but the upload target is the unversioned
+        name.
+
+        Returns ``None`` for anything else — non-hatrac URLs (CDN
+        refs, external links) aren't uploadable as Hatrac objects.
         """
         from urllib.parse import urlparse
 
         if url.startswith("/hatrac/"):
-            return url
-        parsed = urlparse(url)
-        if parsed.path.startswith("/hatrac/"):
-            return parsed.path
-        return None
+            path = url
+        else:
+            parsed = urlparse(url)
+            if not parsed.path.startswith("/hatrac/"):
+                return None
+            path = parsed.path
+        # Strip the ``:VERSIONID`` suffix if present. Versioned
+        # objects can't be written to directly; the unversioned
+        # parent path is the upload target.
+        version_sep = path.rfind(":")
+        last_slash = path.rfind("/")
+        if version_sep > last_slash:
+            path = path[:version_sep]
+        return path
 
     async def _hatrac_already_has(
         self,

--- a/tests/deriva/bag/test_catalog_loader.py
+++ b/tests/deriva/bag/test_catalog_loader.py
@@ -915,6 +915,83 @@ def test_hatrac_path_for_non_hatrac_returns_none() -> None:
     assert BagCatalogLoader._hatrac_path_for("/other/img.png") is None
 
 
+def test_hatrac_path_for_strips_version_suffix() -> None:
+    """Versioned ``...:VERSIONID`` URLs strip to the unversioned base.
+
+    Hatrac assigns versions on PUT; trying to write to a versioned
+    URL returns ``405 Method Not Allowed``. The source catalog's
+    row carries the versioned URL (so consumers can fetch the
+    exact version), but the upload target must be the unversioned
+    name.
+    """
+    full = (
+        "https://example.org/hatrac/"
+        "Execution_Metadata/abc.json:D3EG6MCLC7Y7KDONCTVUB5EEKU"
+    )
+    assert (
+        BagCatalogLoader._hatrac_path_for(full)
+        == "/hatrac/Execution_Metadata/abc.json"
+    )
+    bare = "/hatrac/Image/I1/img.png:VERSION1"
+    assert (
+        BagCatalogLoader._hatrac_path_for(bare)
+        == "/hatrac/Image/I1/img.png"
+    )
+
+
+def test_hatrac_path_for_keeps_colon_in_path() -> None:
+    """A ``:`` in a *directory* component is not a version separator.
+
+    The version separator is the *last* colon and it must come
+    *after* the last slash. A colon embedded earlier in the path
+    (in a directory name) is left alone.
+    """
+    assert (
+        BagCatalogLoader._hatrac_path_for(
+            "/hatrac/some:dir/file.png"
+        )
+        == "/hatrac/some:dir/file.png"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Date/datetime coercion for JSON serialization
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_datetimes_handles_date_and_datetime() -> None:
+    """``datetime.date`` and ``datetime.datetime`` become ISO strings."""
+    import datetime
+
+    row = {
+        "RID": "A1",
+        "the_date": datetime.date(2026, 5, 11),
+        "the_datetime": datetime.datetime(
+            2026, 5, 11, 14, 30, 0
+        ),
+        "plain_text": "hello",
+        "an_int": 42,
+        "none_val": None,
+    }
+    coerced = BagCatalogLoader._coerce_datetimes(row)
+    assert coerced["RID"] == "A1"
+    assert coerced["the_date"] == "2026-05-11"
+    assert coerced["the_datetime"] == "2026-05-11T14:30:00"
+    assert coerced["plain_text"] == "hello"
+    assert coerced["an_int"] == 42
+    assert coerced["none_val"] is None
+
+
+def test_coerce_datetimes_does_not_mutate_input() -> None:
+    """The caller's row dict is left untouched."""
+    import datetime
+
+    row = {"RID": "A1", "d": datetime.date(2026, 5, 11)}
+    BagCatalogLoader._coerce_datetimes(row)
+    # Original still has the date object.
+    assert isinstance(row["d"], datetime.date)
+
+
 # ---------------------------------------------------------------------------
 # Asset upload — dedupe + force semantics
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two end-to-end fixes surfaced when the [deriva-ml#98](https://github.com/informatics-isi-edu/deriva-ml/pull/98) integration tests reached the actual loader path (now possible thanks to #215, #216, #217).

### Fix 1: Versioned Hatrac URLs caused 405 on PUT

The bag's CSV carries `URL = .../hatrac/path/file.ext:VERSIONID` (versioned form, so consumers can fetch the exact source snapshot). The loader's `_upload_assets` passed that URL's path straight to `HatracStore.put_loc`, but Hatrac assigns versions on PUT and returns `405 Method Not Allowed` for writes to a versioned path.

**Fix:** `_hatrac_path_for` strips the `:VERSIONID` suffix when the last colon comes after the last slash. Three new unit tests cover full URL + bare path + the "colon in directory component" non-version edge case.

### Fix 2: Date/datetime values crashed JSON serialization

Bag rows come back from the SQLite mirror as Python `datetime.date` / `datetime.datetime` objects (via the type decorators in `deriva.bag.database`). `json.dumps` can't serialize those directly, and ERMrest expects ISO-8601 strings.

**Fix:** new `_coerce_datetimes` static method walks each row before POST and converts date/datetime values to `.isoformat()` strings. Two unit tests pin the behavior.

## Tests

`tests/deriva/bag/` goes 208 → **212 passing**, 2 skipped.

## Remaining work

deriva-ml#98's integration tests now reach the **third and final** upstream gap: the bag walker over-includes when anchored at a single RID. With `RIDAnchor(table="Dataset", rids=["5HE"])` the bag includes every `Dataset_Version` row, including rows that reference *other* Datasets (5HP, 5HY, …) that aren't in the bag. The loader's default `DanglingFKStrategy.FAIL` then aborts with `Dangling FK detected in Dataset_Version.Dataset`.

That's a producer-side design question (what does anchor-scoped semantics mean for transitive FK references?) and deserves its own discussion / PR. Not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)