### PR TITLE
fix(bag): vocab FULL emits one unfiltered processor; coerce empty strings to NULL

### DIFF
--- a/deriva/bag/catalog_builder.py
+++ b/deriva/bag/catalog_builder.py
@@ -485,13 +485,29 @@ class CatalogBagBuilder:
 
         for schema_name, table_name in sorted(self._reached_tables):
             table_obj = model.schemas[schema_name].tables[table_name]
-            # Asset tables get an extra ``fetch`` processor that
-            # downloads the bytes to data/asset/{table}/{rid}/...
-            # alongside their row CSV.
-            qpath = self._table_query_path(
-                schema_name, table_name, anchor_rid_filter
-            )
             dest = f"{schema_name}/{table_name}"
+
+            # Vocabulary tables with ``vocab_export == FULL`` get
+            # the unfiltered ``/entity/{schema}:{table}`` query —
+            # the full controlled vocabulary regardless of which
+            # terms the slice happens to reference. This is what
+            # a clone-style consumer wants: every FK reference into
+            # a vocab table must resolve at the destination, and
+            # the BFS-shortest path the walker discovered may not
+            # be the same path the actual rows use. The
+            # ``REFERENCED_ONLY`` default keeps the slice tight
+            # (only terms the slice cites land in the bag).
+            is_vocab_full = (
+                table_obj.is_vocabulary()
+                and self.policy.vocab_export == VocabExport.FULL
+            )
+            if is_vocab_full:
+                qpath = f"/entity/{schema_name}:{table_name}"
+            else:
+                qpath = self._table_query_path(
+                    schema_name, table_name, anchor_rid_filter
+                )
+
             query_processors.append(
                 {
                     "processor": "csv",
@@ -519,29 +535,6 @@ class CatalogBagBuilder:
                             "output_path": (
                                 f"asset/{{asset_rid}}/{table_name}"
                             ),
-                        },
-                    }
-                )
-
-            # vocab_export=FULL: emit a standalone CSV of every
-            # term in the vocab, separate from the FK-bounded
-            # query above. CatalogGraph._export_vocabulary today
-            # does this for dataset bags.
-            if (
-                table_obj.is_vocabulary()
-                and self.policy.vocab_export == VocabExport.FULL
-            ):
-                query_processors.append(
-                    {
-                        "processor": "csv",
-                        "processor_params": {
-                            "query_path": (
-                                f"/entity/{schema_name}:{table_name}"
-                            ),
-                            "output_path": (
-                                f"{schema_name}/{table_name}"
-                            ),
-                            "paged_query": True,
                         },
                     }
                 )

--- a/deriva/bag/catalog_loader.py
+++ b/deriva/bag/catalog_loader.py
@@ -385,6 +385,15 @@ class BagCatalogLoader:
         if not rows:
             return stats
 
+        # Normalize empty-string nullable values to ``None``. The
+        # bag's CSVs serialize NULL as the empty string (BDBag/CSV
+        # convention); SQLite preserves the empty string verbatim,
+        # which then trips the dangling-FK check ("'' not in
+        # parent {...}") and produces ERMrest 400s on insert.
+        # Convert at the row boundary so downstream code sees real
+        # ``None`` for unset FKs.
+        rows = [self._coerce_empty_to_null(table, row) for row in rows]
+
         # Apply dangling-FK strategy before any other handling.
         # Rows with missing parents are either dropped (DELETE),
         # patched (NULLIFY), or cause us to bail (FAIL).
@@ -724,6 +733,36 @@ class BagCatalogLoader:
         # identifiers, int[] of digits). Embedded commas in quoted
         # strings aren't produced by the current bag walker.
         return [part.strip().strip('"') for part in inner.split(",")]
+
+    @staticmethod
+    def _coerce_empty_to_null(
+        table: DerivaTable, row: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Convert empty-string values on nullable columns to ``None``.
+
+        The bag's CSVs serialize NULL as the empty string (BDBag/CSV
+        convention has no native NULL sentinel). SQLite preserves
+        the empty string; downstream consumers — the dangling-FK
+        check, ERMrest's JSON ingest, the vocab match-by-name path
+        — all expect real ``None`` for unset values. Coerce at the
+        row boundary so we don't have to special-case the empty
+        string in every consumer.
+
+        Only columns that are declared nullable in the schema are
+        coerced; an empty string on a NOT-NULL column is left alone
+        (and will fail ERMrest's validation, which is the right
+        behavior — it signals a real data problem).
+        """
+        nullable_cols = {
+            c.name for c in table.column_definitions if c.nullok
+        }
+        if not nullable_cols:
+            return row
+        out = dict(row)
+        for col in nullable_cols:
+            if col in out and out[col] == "":
+                out[col] = None
+        return out
 
     @staticmethod
     def _coerce_datetimes(row: dict[str, Any]) -> dict[str, Any]:

--- a/tests/deriva/bag/test_catalog_builder.py
+++ b/tests/deriva/bag/test_catalog_builder.py
@@ -552,9 +552,17 @@ def test_spec_table_anchor_no_filter(tmp_path: Path) -> None:
     )
 
 
-def test_spec_vocab_full_export_emits_extra_processor(
+def test_spec_vocab_full_export_uses_unfiltered_query(
     tmp_path: Path,
 ) -> None:
+    """``vocab_export=FULL``: one unfiltered processor for the vocab.
+
+    Previously the builder emitted **two** processors with the same
+    ``output_path`` (FK-bounded + unfiltered), which the export
+    engine resolved unpredictably. The fix: one processor per
+    vocab, switched on the policy — ``FULL`` → ``/entity/{vocab}``,
+    ``REFERENCED_ONLY`` → FK-chained path.
+    """
     species = _make_mock_table(
         "demo", "Species", is_vocabulary=True
     )
@@ -573,14 +581,13 @@ def test_spec_vocab_full_export_emits_extra_processor(
         p
         for p in spec["catalog"]["query_processors"]
         if p["processor"] == "csv"
+        and p["processor_params"]["output_path"] == "demo/Species"
     ]
-    # One processor for the FK-bounded query (which for a vocab
-    # we're treating as anchor-filtered) plus one for the full
-    # vocab export = 2.
-    output_paths = [
-        p["processor_params"]["output_path"] for p in csv_procs
-    ]
-    assert output_paths.count("demo/Species") == 2
+    assert len(csv_procs) == 1
+    assert (
+        csv_procs[0]["processor_params"]["query_path"]
+        == "/entity/demo:Species"
+    )
 
 
 def test_spec_vocab_referenced_only_emits_single_processor(

--- a/tests/deriva/bag/test_catalog_loader.py
+++ b/tests/deriva/bag/test_catalog_loader.py
@@ -1179,3 +1179,59 @@ def test_upload_assets_skips_missing_local_file(tmp_path: Path) -> None:
     assert uploaded == 0
     assert deduped == 0
     hatrac.put_loc.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Empty-string → NULL coercion on nullable columns
+# ---------------------------------------------------------------------------
+
+
+def _table_with_columns(*specs: tuple[str, bool]) -> Any:
+    """Build a Table-shaped MagicMock from ``(name, nullable)`` pairs."""
+    table = MagicMock()
+    cols = []
+    for name, nullable in specs:
+        col = MagicMock()
+        col.name = name
+        col.nullok = nullable
+        cols.append(col)
+    table.column_definitions = cols
+    return table
+
+
+def test_coerce_empty_to_null_nullable_empty_string() -> None:
+    """``''`` on a nullable column becomes ``None``."""
+    table = _table_with_columns(
+        ("RID", False), ("optional_fk", True)
+    )
+    row = {"RID": "A1", "optional_fk": ""}
+    result = BagCatalogLoader._coerce_empty_to_null(table, row)
+    assert result["optional_fk"] is None
+
+
+def test_coerce_empty_to_null_skips_non_null_columns() -> None:
+    """``''`` on a NOT-NULL column is left alone (real data error)."""
+    table = _table_with_columns(
+        ("RID", False), ("required_col", False)
+    )
+    row = {"RID": "A1", "required_col": ""}
+    result = BagCatalogLoader._coerce_empty_to_null(table, row)
+    assert result["required_col"] == ""
+
+
+def test_coerce_empty_to_null_leaves_real_values() -> None:
+    """Non-empty values pass through unchanged."""
+    table = _table_with_columns(
+        ("RID", False), ("optional", True)
+    )
+    row = {"RID": "A1", "optional": "value"}
+    result = BagCatalogLoader._coerce_empty_to_null(table, row)
+    assert result == {"RID": "A1", "optional": "value"}
+
+
+def test_coerce_empty_to_null_does_not_mutate_input() -> None:
+    """Caller's row dict is preserved."""
+    table = _table_with_columns(("opt", True))
+    row = {"opt": ""}
+    BagCatalogLoader._coerce_empty_to_null(table, row)
+    assert row["opt"] == ""


### PR DESCRIPTION
## Summary

Two more fixes from the deriva-ml#98 integration run, both in the same area (loader+builder behavior the live tests surface).

## Fix 1: `vocab_export=FULL` was emitting duplicate processors

`CatalogBagBuilder._build_export_spec` always emitted the FK-bounded CSV processor for every reached table — and *additionally* emitted a full-table processor for vocab tables when `policy.vocab_export == FULL`. Both processors wrote to the same `output_path`; the export engine's resolution between them was unpredictable.

The intent of `FULL` is "the bag carries every term in this vocab, regardless of which the slice cites." Duplicate processors don't deliver that guarantee.

**Fix:** vocab + `FULL` → one unfiltered processor; vocab + `REFERENCED_ONLY` (default) → one FK-chained processor. No duplicates either way.

The clone-style use case wants `FULL` because the destination's child rows may reference any vocab term, not just the ones the BFS-shortest path happens to walk. The existing test that asserted "2 processors for the same vocab" was rewritten to assert the new (correct) "1 unfiltered processor" semantics.

## Fix 2: Empty-string FK values blocked the loader

The bag's CSVs serialize NULL as the empty string (BDBag/CSV convention has no native NULL sentinel). SQLite preserves the empty string verbatim, which then tripped:

- `_apply_dangling_fk_strategy`: `"'' not in parent {'X'}"` (FAIL)
- ERMrest's JSON ingest: it expects real NULL on nullable cols

**Fix:** new `_coerce_empty_to_null(table, row)` static method walks each row before the dangling-FK check, converting empty strings on nullable columns to `None`. Non-nullable columns are left alone — an empty string there is a real data error that should surface, not get silently nullified.

## Tests

Four new unit tests in `test_catalog_loader.py`:
- `test_coerce_empty_to_null_nullable_empty_string`
- `test_coerce_empty_to_null_skips_non_null_columns`
- `test_coerce_empty_to_null_leaves_real_values`
- `test_coerce_empty_to_null_does_not_mutate_input`

Plus the rewritten `test_spec_vocab_full_export_uses_unfiltered_query` in `test_catalog_builder.py` asserting the new vocab semantics.

`tests/deriva/bag/` goes **214 → 218** passing.

## Remaining work for the deriva-ml#98 integration tests

This unblocks two of the earlier dangling-FK failures (vocab and empty-string). The next layer is the **content-table FK cycle**: `Dataset ↔ Dataset_Version` form a real two-way cycle. `ForeignKeyOrderer` breaks it but the inserts then hit ERMrest with the cycle-FK pointing at a not-yet-inserted parent. That's a deferred-constraint / two-phase-insert design conversation, not a one-line fix. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)