### PR TITLE
feat(bag): multi-path emission — union FK routes to each target table

### DIFF
--- a/deriva/bag/catalog_builder.py
+++ b/deriva/bag/catalog_builder.py
@@ -144,8 +144,20 @@ class CatalogBagBuilder:
         # :class:`TableAnchor` (the whole-table anchor), the path
         # is recorded but the query is left unfiltered — every row
         # is in scope by construction.
+        #
+        # ``_table_paths`` records the *first* (BFS-shortest) path
+        # discovered per target; ``_table_path_set`` records every
+        # path discovered, so :meth:`_build_export_spec` can emit
+        # one query_processor per FK route. Multi-path emission is
+        # required when the BFS-shortest path goes through a table
+        # that has no rows for the slice (e.g.,
+        # Dataset → Dataset_File → File → Image when the actual
+        # Image rows live on Dataset → Subject → Image).
         self._table_paths: dict[
             tuple[str, str], list[tuple[str, str]]
+        ] = {}
+        self._table_path_set: dict[
+            tuple[str, str], list[tuple[tuple[str, str], ...]]
         ] = {}
         # Anchor-table set: which entries in ``_table_paths`` are
         # themselves anchors (vs. reached via the FK walk). The
@@ -324,16 +336,32 @@ class CatalogBagBuilder:
 
         model = self._get_model()
 
-        # Track per-anchor scope: each anchor seeds its own walk,
-        # but they share the visited set so we don't double-walk.
-        # The path recorded for a reached table is the first one
-        # discovered (BFS-shortest from one of the anchors).
+        # Walk strategy:
+        #
+        # - The queue carries one (table, path) entry per FK route
+        #   we've discovered to that table. We dequeue *all* routes
+        #   to a given table even when the table itself is already
+        #   in ``reached_tables`` — that's the whole point of
+        #   multi-path emission. The simple-path guard in
+        #   :meth:`_enqueue_if_in_scope_with_path` (drops a path
+        #   that would re-enter a table it already visits) prevents
+        #   infinite walks on cycles.
+        # - ``paths`` records the BFS-shortest path discovered per
+        #   reached table (backwards-compat with single-path callers).
+        # - ``path_set`` records every distinct simple path
+        #   discovered per reached table so
+        #   :meth:`_build_export_spec` can emit one query_processor
+        #   per FK route. Bounded by ``max_paths`` to keep the spec
+        #   finite on densely-connected catalogs.
         queue: deque[
-            tuple[str, str, int, list[tuple[str, str]]]
+            tuple[str, str, int, tuple[tuple[str, str], ...]]
         ] = deque()
-        visited: set[tuple[str, str]] = set()
+        reached: set[tuple[str, str]] = set()
         anchor_tables: set[tuple[str, str]] = set()
         paths: dict[tuple[str, str], list[tuple[str, str]]] = {}
+        path_set: dict[
+            tuple[str, str], list[tuple[tuple[str, str], ...]]
+        ] = {}
 
         for anchor in self.anchors:
             schema_name, table_name = self._resolve_table(
@@ -343,15 +371,18 @@ class CatalogBagBuilder:
             anchor_tables.add(key)
             if key not in paths:
                 paths[key] = [key]
-            queue.append((schema_name, table_name, 0, paths[key]))
+            path_set.setdefault(key, [])
+            anchor_path: tuple[tuple[str, str], ...] = (key,)
+            if anchor_path not in path_set[key]:
+                path_set[key].append(anchor_path)
+            queue.append((schema_name, table_name, 0, anchor_path))
 
         max_depth = self.policy.max_depth
+        max_paths = self._max_paths_per_table()
         while queue:
             schema_name, table_name, depth, current_path = queue.popleft()
             key = (schema_name, table_name)
-            if key in visited:
-                continue
-            visited.add(key)
+            reached.add(key)
 
             # Depth bound (None = unbounded).
             if max_depth is not None and depth >= max_depth:
@@ -372,8 +403,9 @@ class CatalogBagBuilder:
                     depth + 1,
                     current_path,
                     queue,
-                    visited,
                     paths,
+                    path_set,
+                    max_paths,
                 )
             # Inbound: FKs other tables declare to us.
             for fk in table.referenced_by:
@@ -382,35 +414,55 @@ class CatalogBagBuilder:
                     depth + 1,
                     current_path,
                     queue,
-                    visited,
                     paths,
+                    path_set,
+                    max_paths,
                 )
 
-        self._reached_tables = visited
+        self._reached_tables = reached
         self._anchor_tables = anchor_tables
         self._table_paths = paths
+        self._table_path_set = path_set
+
+    def _max_paths_per_table(self) -> int:
+        """Cap on distinct FK paths emitted per target table.
+
+        Multi-path emission walks every simple route; densely
+        connected schemas (m FKs between n tables) can in theory
+        produce many. The cap is a finiteness guard, not a tuning
+        knob — in practice every catalog we've seen tops out at
+        2–3 paths to any given table. The default is generous so
+        the cap is never the explanation for missing rows.
+        """
+        return 16
 
     def _enqueue_if_in_scope_with_path(
         self,
         table: DerivaTable,
         depth: int,
-        prefix_path: list[tuple[str, str]],
-        queue: "deque[tuple[str, str, int, list[tuple[str, str]]]]",
-        visited: set[tuple[str, str]],
+        prefix_path: tuple[tuple[str, str], ...],
+        queue: "deque[tuple[str, str, int, tuple[tuple[str, str], ...]]]",
         paths: dict[tuple[str, str], list[tuple[str, str]]],
+        path_set: dict[
+            tuple[str, str], list[tuple[tuple[str, str], ...]]
+        ],
+        max_paths: int,
     ) -> None:
         """Queue a candidate with its FK-path prefix, if policy allows.
 
-        Records the FK path the *first* time this table is seen
-        (BFS-shortest). Subsequent paths to the same table are
-        ignored — we already have a usable scope and ERMrest has
-        deterministic join semantics either way.
+        Records the BFS-shortest path on first sight (in ``paths``)
+        plus every distinct simple path discovered (in ``path_set``,
+        bounded by ``max_paths``). The caller's BFS still gates
+        the *expansion* of each table by ``visited``; this helper
+        only records the route the walk arrived by.
+
+        Cycles are guarded by the simple-path test (``key in
+        prefix_path``): a path that would re-enter a table it
+        already visits is dropped.
         """
         schema_name = table.schema.name
         table_name = table.name
         key = (schema_name, table_name)
-        if key in visited:
-            return
         if self._is_excluded_schema(schema_name):
             return
         if self._is_excluded_table(schema_name, table_name):
@@ -420,9 +472,31 @@ class CatalogBagBuilder:
             and schema_name not in self.policy.schemas
         ):
             return
+        if key in prefix_path:
+            # Simple-path guard: don't walk back into a table we've
+            # already used on this path. ERMrest joins on natural
+            # FK relationships and the same join twice would be a
+            # loop in the query.
+            return
+        candidate_path: tuple[tuple[str, str], ...] = prefix_path + (key,)
         if key not in paths:
-            paths[key] = list(prefix_path) + [key]
-        queue.append((schema_name, table_name, depth, paths[key]))
+            paths[key] = list(candidate_path)
+        bucket = path_set.setdefault(key, [])
+        if candidate_path in bucket:
+            # We've already enqueued this exact path; the dequeue
+            # will walk its descendants once. Re-enqueueing would
+            # do redundant work.
+            return
+        if len(bucket) >= max_paths:
+            # Path budget exhausted; record the new path is dropped
+            # rather than silently emitting an over-large spec.
+            logger.debug(
+                "max_paths=%d reached for %s.%s; dropping path %s",
+                max_paths, schema_name, table_name, candidate_path,
+            )
+            return
+        bucket.append(candidate_path)
+        queue.append((schema_name, table_name, depth, candidate_path))
 
     def _is_excluded_schema(self, schema_name: str) -> bool:
         return (
@@ -488,43 +562,74 @@ class CatalogBagBuilder:
 
         for schema_name, table_name in sorted(self._reached_tables):
             table_obj = model.schemas[schema_name].tables[table_name]
-            dest = f"{schema_name}/{table_name}"
+            key = (schema_name, table_name)
 
             # Vocabulary tables with ``vocab_export == FULL`` get
             # the unfiltered ``/entity/{schema}:{table}`` query —
             # the full controlled vocabulary regardless of which
             # terms the slice happens to reference. This is what
             # a clone-style consumer wants: every FK reference into
-            # a vocab table must resolve at the destination, and
-            # the BFS-shortest path the walker discovered may not
-            # be the same path the actual rows use. The
-            # ``REFERENCED_ONLY`` default keeps the slice tight
-            # (only terms the slice cites land in the bag).
+            # a vocab table must resolve at the destination. One
+            # processor, no per-path branching.
             is_vocab_full = (
                 table_obj.is_vocabulary()
                 and self.policy.vocab_export == VocabExport.FULL
             )
             if is_vocab_full:
-                qpath = f"/entity/{schema_name}:{table_name}"
-            else:
-                qpath = self._table_query_path(
-                    schema_name, table_name, anchor_rid_filter
+                query_processors.append(
+                    {
+                        "processor": "csv",
+                        "processor_params": {
+                            "query_path": (
+                                f"/entity/{schema_name}:{table_name}"
+                            ),
+                            "output_path": (
+                                f"{schema_name}/{table_name}"
+                            ),
+                            "paged_query": True,
+                        },
+                    }
                 )
-
-            query_processors.append(
-                {
-                    "processor": "csv",
-                    "processor_params": {
-                        "query_path": qpath,
-                        "output_path": dest,
-                        "paged_query": True,
-                    },
-                }
-            )
+            else:
+                # Non-vocab (or REFERENCED_ONLY vocab): emit one
+                # processor per FK path discovered by the walker.
+                # The bag's loader (BagDatabase._load_data) reads
+                # every file that resolves to ``{schema}.{table}``
+                # and unions rows by RID — see deriva/bag/database.py.
+                #
+                # ``output_path`` carries the path's table chain so
+                # multi-path CSVs land at distinct on-disk locations
+                # under ``data/{schema}/``. The loader's index is
+                # keyed by CSV stem only, so a per-route subdirectory
+                # is the natural separator.
+                for fk_path in self._fk_paths_for(key):
+                    qpath = self._table_query_path(
+                        schema_name,
+                        table_name,
+                        anchor_rid_filter,
+                        fk_path,
+                    )
+                    dest = self._output_path_for(
+                        schema_name, table_name, fk_path
+                    )
+                    query_processors.append(
+                        {
+                            "processor": "csv",
+                            "processor_params": {
+                                "query_path": qpath,
+                                "output_path": dest,
+                                "paged_query": True,
+                            },
+                        }
+                    )
             if table_obj.is_asset():
                 # The engine's ``fetch`` processor reads URL/length/
                 # filename/md5 columns from each asset row and
                 # downloads the bytes to the templated output_path.
+                # One fetch processor per table is enough — assets
+                # are addressed by RID at the destination so the
+                # rows the multi-path CSVs landed already carry
+                # everything ``fetch`` needs.
                 query_processors.append(
                     {
                         "processor": "fetch",
@@ -594,11 +699,52 @@ class CatalogBagBuilder:
             for key, rids in filters.items()
         }
 
+    def _fk_paths_for(
+        self, key: tuple[str, str]
+    ) -> list[tuple[tuple[str, str], ...]]:
+        """Return the FK paths the walker discovered to ``key``.
+
+        Falls back to ``[(key,)]`` for callers (mainly tests) that
+        invoke export-spec generation without having recorded any
+        paths — produces the legacy single-path full-table query.
+        """
+        bucket = self._table_path_set.get(key)
+        if bucket:
+            return bucket
+        # Fall back to the BFS-shortest path or the table itself.
+        fallback = self._table_paths.get(key)
+        if fallback:
+            return [tuple(fallback)]
+        return [(key,)]
+
+    @staticmethod
+    def _output_path_for(
+        schema_name: str,
+        table_name: str,
+        fk_path: tuple[tuple[str, str], ...],
+    ) -> str:
+        """Build a per-path on-disk subdirectory under ``data/``.
+
+        Single-element paths (anchor tables) land at
+        ``{schema}/{table}``; multi-element paths land at
+        ``{schema}/{p1}_..._{pn-1}/{table}`` so two routes to the
+        same target table land in distinct files. The bag DB's
+        loader keys by CSV stem (``{table}.csv``), so per-route
+        subdirectories are enough to keep file paths unique.
+        """
+        if len(fk_path) <= 1:
+            return f"{schema_name}/{table_name}"
+        intermediate = "_".join(
+            seg_table for _seg_schema, seg_table in fk_path[:-1]
+        )
+        return f"{schema_name}/{intermediate}/{table_name}"
+
     def _table_query_path(
         self,
         schema_name: str,
         table_name: str,
         anchor_filters: dict[tuple[str, str], list[str]],
+        fk_path: tuple[tuple[str, str], ...] | None = None,
     ) -> str:
         """Build the ERMrest query path for a reached table.
 
@@ -612,7 +758,7 @@ class CatalogBagBuilder:
         3. **Non-anchor table reached via the FK walk.** Build a
            chained ERMrest path that scopes the rows to those
            reachable from the anchor's filter through the FK path
-           BFS discovered:
+           the caller specifies:
            ``/entity/{anchor}/RID=any(...)/{step2}/{step3}/...``.
            ERMrest's natural-FK join semantics handle the joins.
 
@@ -623,12 +769,14 @@ class CatalogBagBuilder:
         on the rows whose parents aren't in the slice.
         """
         key = (schema_name, table_name)
-        path = self._table_paths.get(key, [key])
+        if fk_path is None:
+            fk_path = tuple(self._table_paths.get(key, [key]))
 
         # Case 1/2: this *is* an anchor table. Use the existing
         # anchor-RID filter (or fall back to the full-table query
-        # for TableAnchor / non-RID anchors).
-        if key in self._anchor_tables:
+        # for TableAnchor / non-RID anchors). Path length 1 means
+        # the caller supplied just the anchor itself.
+        if key in self._anchor_tables and len(fk_path) <= 1:
             rids = anchor_filters.get(key)
             if rids:
                 joined = ",".join(rids)
@@ -644,7 +792,7 @@ class CatalogBagBuilder:
         # is a RIDAnchor/PathAnchor); subsequent segments are
         # bare ``{schema}:{table}`` joins that ERMrest resolves via
         # the natural FK relationship.
-        anchor_key = path[0]
+        anchor_key = fk_path[0]
         anchor_schema, anchor_table = anchor_key
         rids = anchor_filters.get(anchor_key)
         if rids:
@@ -657,7 +805,7 @@ class CatalogBagBuilder:
             head = f"/entity/{anchor_schema}:{anchor_table}"
         # Append the rest of the path (skipping the anchor itself).
         tail = "".join(
-            f"/{seg_schema}:{seg_table}" for seg_schema, seg_table in path[1:]
+            f"/{seg_schema}:{seg_table}" for seg_schema, seg_table in fk_path[1:]
         )
         return head + tail
 

--- a/deriva/bag/database.py
+++ b/deriva/bag/database.py
@@ -525,7 +525,15 @@ class BagDatabase:
 
         # Index the bag's CSVs by qualified table name so we can
         # walk them in the order ForeignKeyOrderer dictates.
-        csv_by_qualified: dict[str, Path] = {}
+        #
+        # A producer that emits one CSV per FK path to a target
+        # table (the multi-path emission pattern; see
+        # CatalogBagBuilder) will deposit several files for the
+        # same logical table at different ``output_path``s.
+        # Group them so the load step unions rows across paths
+        # — RID dedup happens at the SQLite insert layer via
+        # ``ON CONFLICT DO NOTHING``.
+        csv_by_qualified: dict[str, list[Path]] = {}
         for csv_file in data_path.rglob("*.csv"):
             schema_name = self._get_table_schema(csv_file.stem)
             if schema_name is None:
@@ -534,7 +542,9 @@ class BagDatabase:
                     csv_file.stem,
                 )
                 continue
-            csv_by_qualified[f"{schema_name}.{csv_file.stem}"] = csv_file
+            csv_by_qualified.setdefault(
+                f"{schema_name}.{csv_file.stem}", []
+            ).append(csv_file)
 
         if not csv_by_qualified:
             return
@@ -591,18 +601,25 @@ class BagDatabase:
         self,
         conn: "Connection",
         ordered_tables: list[DerivaTable],
-        csv_by_qualified: dict[str, Path],
+        csv_by_qualified: dict[str, list[Path]],
         asset_map: dict[str, str],
     ) -> None:
         """Insert each CSV's rows into its mirror table.
 
         Extracted from :meth:`_load_data` so the FK-pragma restore
         can wrap the body in ``try/finally`` cleanly.
+
+        When a producer emits multiple CSVs for the same table
+        (one per FK path; see :class:`CatalogBagBuilder` multi-
+        path emission), the files are loaded sequentially in
+        ``sorted`` order — RID dedup happens at the SQLite
+        layer via ``ON CONFLICT DO NOTHING``. Sorting keeps
+        load order deterministic across filesystems.
         """
         for table in ordered_tables:
             qualified = f"{table.schema.name}.{table.name}"
-            csv_file = csv_by_qualified.get(qualified)
-            if csv_file is None:
+            csv_files = csv_by_qualified.get(qualified)
+            if not csv_files:
                 continue
             sql_table = self.metadata.tables.get(qualified)
             if sql_table is None:
@@ -611,35 +628,53 @@ class BagDatabase:
                 )
                 continue
 
-            with csv_file.open(newline="") as csvfile:
-                csv_reader = reader(csvfile)
-                column_names = next(csv_reader)
+            for csv_file in sorted(csv_files):
+                self._insert_csv(
+                    conn, table, sql_table, csv_file, asset_map
+                )
 
-                # Get asset column indexes if this is an asset table
-                asset_indexes = None
-                if self._is_asset_table(table.name):
-                    try:
-                        asset_indexes = (
-                            column_names.index("Filename"),
-                            column_names.index("URL"),
-                        )
-                    except ValueError:
-                        pass
+    def _insert_csv(
+        self,
+        conn: "Connection",
+        table: DerivaTable,
+        sql_table: SQLTable,
+        csv_file: Path,
+        asset_map: dict[str, str],
+    ) -> None:
+        """Load one CSV into ``sql_table``.
 
-                rows = [
-                    self._localize_asset_row(
-                        list(row), asset_indexes, asset_map
+        Factored out of :meth:`_insert_rows_in_order` so the
+        multi-CSV-per-table loop has a clean per-file unit.
+        """
+        with csv_file.open(newline="") as csvfile:
+            csv_reader = reader(csvfile)
+            column_names = next(csv_reader)
+
+            # Get asset column indexes if this is an asset table
+            asset_indexes = None
+            if self._is_asset_table(table.name):
+                try:
+                    asset_indexes = (
+                        column_names.index("Filename"),
+                        column_names.index("URL"),
                     )
-                    for row in csv_reader
-                ]
-                if rows:
-                    conn.execute(
-                        sqlite_insert(sql_table).on_conflict_do_nothing(),
-                        [
-                            dict(zip(column_names, row))
-                            for row in rows
-                        ],
-                    )
+                except ValueError:
+                    pass
+
+            rows = [
+                self._localize_asset_row(
+                    list(row), asset_indexes, asset_map
+                )
+                for row in csv_reader
+            ]
+            if rows:
+                conn.execute(
+                    sqlite_insert(sql_table).on_conflict_do_nothing(),
+                    [
+                        dict(zip(column_names, row))
+                        for row in rows
+                    ],
+                )
 
     def dispose(self) -> None:
         """Dispose of SQLAlchemy resources.

--- a/tests/deriva/bag/test_catalog_builder.py
+++ b/tests/deriva/bag/test_catalog_builder.py
@@ -370,8 +370,12 @@ def test_spec_includes_csv_processor_for_each_reached_table(
     output_paths = {
         p["processor_params"]["output_path"] for p in csv_procs
     }
+    # Anchor table A: direct ``{schema}/{table}`` dest.
+    # Non-anchor table B (reached via FK from A): per-route dest
+    # ``{schema}/{intermediate-chain}/{table}``. The chain is the
+    # path's tables minus the terminal, joined by ``_``.
     assert "demo/A" in output_paths
-    assert "demo/B" in output_paths
+    assert "demo/A/B" in output_paths
 
 
 def test_spec_includes_fetch_processor_for_asset_table(
@@ -469,11 +473,13 @@ def test_spec_rid_anchor_chains_path_to_fk_reachable_tables(
         == "/entity/demo:Dataset/RID=any(5HE)"
     )
     # Dataset_Version chains through Dataset, restricting to rows
-    # that reference the anchored Dataset RID.
+    # that reference the anchored Dataset RID. Per-route dest:
+    # ``{schema}/{intermediate-chain}/{table}`` — intermediate chain
+    # is just "Dataset" since the path is Dataset → Dataset_Version.
     assert (
-        by_output["demo/Dataset_Version"]["processor_params"][
-            "query_path"
-        ]
+        by_output["demo/Dataset/Dataset_Version"][
+            "processor_params"
+        ]["query_path"]
         == "/entity/demo:Dataset/RID=any(5HE)/demo:Dataset_Version"
     )
 
@@ -521,9 +527,14 @@ def test_spec_rid_anchor_chains_through_intermediate_table(
         for p in spec["catalog"]["query_processors"]
         if p["processor"] == "csv"
     }
-    # BFS: Dataset → Dataset_Image → Image.
+    # BFS: Dataset → Dataset_Image → Image. Per-route dest path:
+    # ``{schema}/{intermediate-chain}/{table}`` with the chain
+    # ``Dataset_Dataset_Image`` (the path's tables minus the
+    # terminal, joined by ``_``).
     assert (
-        by_output["demo/Image"]["processor_params"]["query_path"]
+        by_output["demo/Dataset_Dataset_Image/Image"][
+            "processor_params"
+        ]["query_path"]
         == "/entity/demo:Dataset/RID=any(5HE)/demo:Dataset_Image/demo:Image"
     )
 
@@ -616,6 +627,122 @@ def test_spec_vocab_referenced_only_emits_single_processor(
         p["processor_params"]["output_path"] for p in csv_procs
     ]
     assert output_paths.count("demo/Species") == 1
+
+
+def test_spec_multipath_emits_one_processor_per_fk_route(
+    tmp_path: Path,
+) -> None:
+    """A target table reachable via two FK routes gets two csv processors.
+
+    Topology::
+
+        Dataset ─── Dataset_Image ──┐
+            │                       │
+            └── Dataset_Subject ─── Subject ─── Subject_Image ─── Image
+
+    From a Dataset anchor, ``Image`` is reachable two ways:
+
+    1. Dataset → Dataset_Image → Image (short route).
+    2. Dataset → Dataset_Subject → Subject → Subject_Image → Image
+       (long route).
+
+    Only one of these routes carries rows in any given catalog
+    (Dataset_Image vs Subject_Image association tables are
+    mutually exclusive deployments in practice), but the builder
+    can't tell up front. Emitting both lets the loader union
+    whatever rows each path produces, with RID dedup at insert
+    time. The BFS-shortest-only approach silently drops rows
+    that live only on the long route.
+    """
+    ds = _make_mock_table("demo", "Dataset")
+    di = _make_mock_table("demo", "Dataset_Image")
+    ds_sub = _make_mock_table("demo", "Dataset_Subject")
+    sub = _make_mock_table("demo", "Subject")
+    si = _make_mock_table("demo", "Subject_Image")
+    img = _make_mock_table("demo", "Image")
+
+    di_to_ds = _fk_mock(src_table=di, pk_table=ds)
+    di_to_img = _fk_mock(src_table=di, pk_table=img)
+    dssub_to_ds = _fk_mock(src_table=ds_sub, pk_table=ds)
+    dssub_to_sub = _fk_mock(src_table=ds_sub, pk_table=sub)
+    si_to_sub = _fk_mock(src_table=si, pk_table=sub)
+    si_to_img = _fk_mock(src_table=si, pk_table=img)
+
+    ds.referenced_by = [di_to_ds, dssub_to_ds]
+    di.foreign_keys = [di_to_ds, di_to_img]
+    ds_sub.foreign_keys = [dssub_to_ds, dssub_to_sub]
+    sub.referenced_by = [dssub_to_sub, si_to_sub]
+    si.foreign_keys = [si_to_sub, si_to_img]
+    img.referenced_by = [di_to_img, si_to_img]
+
+    model = _make_mock_model(
+        {
+            "demo": {
+                "Dataset": ds,
+                "Dataset_Image": di,
+                "Dataset_Subject": ds_sub,
+                "Subject": sub,
+                "Subject_Image": si,
+                "Image": img,
+            }
+        }
+    )
+    catalog = _make_mock_catalog(model)
+    cb = CatalogBagBuilder(
+        catalog=catalog,
+        anchors=[RIDAnchor(table="Dataset", rids=["5HE"])],
+        output_dir=tmp_path,
+    )
+    cb._validate_anchors = lambda: None
+    cb._compute_reached_tables()
+    spec = cb._build_export_spec()
+
+    # Count csv processors whose ``output_path`` ends in ``/Image``.
+    # Two FK routes → two processors, each at a distinct on-disk
+    # location.
+    image_procs = [
+        p
+        for p in spec["catalog"]["query_processors"]
+        if p["processor"] == "csv"
+        and p["processor_params"]["output_path"].endswith("/Image")
+    ]
+    assert len(image_procs) == 2, [
+        p["processor_params"]["output_path"] for p in image_procs
+    ]
+    query_paths = {
+        p["processor_params"]["query_path"] for p in image_procs
+    }
+    # Short route.
+    assert (
+        "/entity/demo:Dataset/RID=any(5HE)/demo:Dataset_Image/demo:Image"
+        in query_paths
+    )
+    # Long route through Subject.
+    assert (
+        "/entity/demo:Dataset/RID=any(5HE)"
+        "/demo:Dataset_Subject/demo:Subject"
+        "/demo:Subject_Image/demo:Image"
+        in query_paths
+    )
+
+    # Asset fetch processors are not per-path: one ``fetch`` per
+    # asset table is sufficient because each fetch addresses by
+    # asset RID and any RID landed by either CSV processor is
+    # fetchable.
+    fetch_procs = [
+        p
+        for p in spec["catalog"]["query_processors"]
+        if p["processor"] == "fetch"
+    ]
+    image_fetches = [
+        p
+        for p in fetch_procs
+        if "Image" in p["processor_params"]["output_path"]
+    ]
+    # (Image isn't marked is_asset in this fixture so 0 is expected;
+    # the assertion is that we don't accidentally emit per-path
+    # fetch processors.)
+    assert len(image_fetches) == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/deriva/bag/test_database.py
+++ b/tests/deriva/bag/test_database.py
@@ -390,6 +390,58 @@ def test_bag_database_loads_child_after_parent(tmp_path: Path) -> None:
     }
 
 
+def test_bag_database_unions_multipath_csvs(tmp_path: Path) -> None:
+    """Multi-path emission: two CSVs for the same table land
+    side-by-side under different output_paths and the loader
+    unions their rows.
+
+    Producers like :class:`CatalogBagBuilder` can emit one CSV
+    per FK path to a target table (e.g., ``Dataset/Subject/Subject_Image/Image.csv``
+    and ``Dataset/Dataset_Image/Image.csv``). The bag's data
+    directory then contains multiple files with the same stem
+    at different paths. The loader must read **every** such
+    file and union the rows; RID collisions are resolved by
+    SQLite's ``ON CONFLICT DO NOTHING``.
+
+    Without the union, ``rglob`` order picks one file and rows
+    that live only in the other path silently disappear.
+    """
+    bag = tmp_path / "multipath_bag" / "bag"
+    (bag / "data" / "demo" / "PathA").mkdir(parents=True)
+    (bag / "data" / "demo" / "PathB").mkdir(parents=True)
+    (bag / "data" / "schema.json").write_text(
+        json.dumps(_two_table_fk_schema())
+    )
+
+    # Parent CSV under PathA — supplies P1, P2 plus an overlapping P3.
+    with (bag / "data" / "demo" / "PathA" / "Parent.csv").open(
+        "w", newline=""
+    ) as f:
+        w = csv.writer(f)
+        w.writerow(["RID"])
+        w.writerow(["P1"])
+        w.writerow(["P2"])
+        w.writerow(["P3"])
+
+    # Parent CSV under PathB — supplies P3 (dup), P4, P5.
+    with (bag / "data" / "demo" / "PathB" / "Parent.csv").open(
+        "w", newline=""
+    ) as f:
+        w = csv.writer(f)
+        w.writerow(["RID"])
+        w.writerow(["P3"])
+        w.writerow(["P4"])
+        w.writerow(["P5"])
+
+    db_dir = tmp_path / "db"
+    with BagDatabase(bag, db_dir, ["demo"]) as db:
+        parents = list(db.get_table_contents("Parent"))
+
+    # Union of both CSVs, with the duplicate P3 resolved by
+    # ``ON CONFLICT DO NOTHING``.
+    assert {r["RID"] for r in parents} == {"P1", "P2", "P3", "P4", "P5"}
+
+
 # ---------------------------------------------------------------------------
 # Asset / fetch.txt integration
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Multi-path emission for `CatalogBagBuilder` plus consumer-side
union in `BagDatabase._load_data`. Together these unblock the
deriva-ml `clone-via-bag` integration tests that fail today
with `Dataset_Image.Image` dangling FKs: rows live on a long
FK route (`Dataset → Subject → Subject_Image → Image`) that
the BFS-shortest walker was silently dropping in favor of an
unpopulated short route (`Dataset → Dataset_File → File → Image`).

Two coherent commits, in this order:

1. **`fix(bag): BagDatabase unions multi-CSV-per-table at load time`** — index CSVs by qualified table name as `dict[str, list[Path]]` rather than `dict[str, Path]`. Multiple files per table are loaded sequentially with the existing `ON CONFLICT DO NOTHING` providing RID dedup. The legacy deriva-ml export spec generator has been emitting multi-CSV bags for years; this fixes the latent loader bug that picked one CSV per stem via `rglob` order.
2. **`feat(bag): CatalogBagBuilder emits one query_processor per FK route`** — walker records every distinct simple FK path per target (in a new `_table_path_set`, bounded by `_max_paths_per_table` = 16). `_build_export_spec` emits one CSV processor per `(table, path)` at a distinct `output_path` of the form `{schema}/{intermediate_chain}/{table}`. Vocab `FULL` and asset `fetch` processors remain single-emit per table — vocab is path-independent and fetch is RID-addressed.

## Test plan

- [x] `uv run pytest tests/deriva/bag/` — 224 passed, 2 skipped (same as `deriva-ml` baseline before this branch)
- [x] New unit test `test_bag_database_unions_multipath_csvs` — two `Parent.csv` files under different subdirs land all unique RIDs with the dup resolved
- [x] New unit test `test_spec_multipath_emits_one_processor_per_fk_route` — diamond topology emits two CSV processors with distinct query paths, plus zero per-route fetch processors
- [x] Existing tests updated for the new per-route `output_path` form (`demo/A/B` instead of `demo/B`)
- [ ] Will validate end-to-end against the deriva-ml `tests/catalog/test_clone_via_bag_integration.py` xfailed tests once this lands and the deriva-ml `uv.lock` is bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)