### PR TITLE
feat(bag): FKTraversalPolicy.terminal_tables for vocab-style enter-don't-exit

### DIFF
--- a/deriva/bag/catalog_builder.py
+++ b/deriva/bag/catalog_builder.py
@@ -389,11 +389,21 @@ class CatalogBagBuilder:
                 continue
 
             table = model.schemas[schema_name].tables[table_name]
-            # Vocab tables: don't follow FKs back out of them.
-            # We pulled in their referenced terms by getting here;
-            # following inbound FKs from them would chase every
-            # row that references this vocab.
+            # Terminal tables: traverse INTO but not OUT.
+            # - Vocabulary tables (detected by canonical column
+            #   shape) are always terminal: following inbound FKs
+            #   from a vocab term would chase every row in the
+            #   catalog that uses it.
+            # - Tables in :attr:`FKTraversalPolicy.terminal_tables`
+            #   get the same treatment. Used for "provenance" tables
+            #   like ``Execution`` that aggregate cross-anchor state
+            #   — walking *through* them mixes anchor scopes via
+            #   shared rows. Rows still land in the slice (other
+            #   rows' FKs into the terminal table resolve) but the
+            #   walker doesn't fan out from them.
             if table.is_vocabulary():
+                continue
+            if (schema_name, table_name) in self.policy.terminal_tables:
                 continue
 
             # Outbound: FKs we declare to other tables.

--- a/deriva/bag/traversal.py
+++ b/deriva/bag/traversal.py
@@ -196,6 +196,18 @@ class FKTraversalPolicy(BaseModel):
             ``{(schema, table), ...}`` tuples. Useful for
             domain-specific filtering (e.g., dataset associations
             for element types with no members).
+        terminal_tables: Tables the walker enters but does **not**
+            exit, as ``{(schema, table), ...}`` tuples. The
+            walker emits rows for the table (so other rows' FKs
+            into it resolve at load time) but does not follow
+            its outbound or inbound FKs to discover further
+            tables. Same semantics as vocabulary tables, applied
+            to non-vocab "provenance" tables that aggregate
+            cross-anchor state — e.g. ``Execution`` and
+            ``Workflow`` in the deriva-ml schema, where walking
+            *through* them pulls in unrelated anchor scopes via
+            shared rows. Empty by default; callers opt in based
+            on schema-domain knowledge.
         max_depth: Maximum FK hops from the anchor set. ``None``
             (default) means unbounded.
         vocab_export: How vocabularies are exported. See
@@ -240,6 +252,7 @@ class FKTraversalPolicy(BaseModel):
         default_factory=lambda: set(DEFAULT_EXCLUDE_SCHEMAS)
     )
     exclude_tables: set[tuple[str, str]] = Field(default_factory=set)
+    terminal_tables: set[tuple[str, str]] = Field(default_factory=set)
     max_depth: int | None = None
     vocab_export: VocabExport = VocabExport.REFERENCED_ONLY
     asset_mode: AssetMode = AssetMode.UPLOAD_IF_MISSING

--- a/tests/deriva/bag/test_catalog_builder.py
+++ b/tests/deriva/bag/test_catalog_builder.py
@@ -745,6 +745,131 @@ def test_spec_multipath_emits_one_processor_per_fk_route(
     assert len(image_fetches) == 0
 
 
+def test_terminal_table_enters_but_does_not_exit(tmp_path: Path) -> None:
+    """A table listed in ``policy.terminal_tables`` halts FK traversal.
+
+    Topology::
+
+        Subject ─── Subject_Health ─── Execution ─── Image_Quality ─── Image
+
+    Without ``terminal_tables``, a Subject anchor walks all the way
+    to Image — and through Execution's other ``*_Execution``
+    inbound FKs it would over-fetch (Image_Quality rows from
+    Executions belonging to other Subjects). The fix: declare
+    Execution as terminal. The walker still reaches Execution
+    (so the slice has the provenance row for the Subject's
+    health record), but stops there — Image_Quality and Image
+    don't get walked through Execution.
+    """
+    sub = _make_mock_table("demo", "Subject")
+    sh = _make_mock_table("demo", "Subject_Health")
+    exe = _make_mock_table("demo", "Execution")
+    iq = _make_mock_table("demo", "Image_Quality")
+    img = _make_mock_table("demo", "Image")
+
+    sh_to_sub = _fk_mock(src_table=sh, pk_table=sub)
+    sh_to_exe = _fk_mock(src_table=sh, pk_table=exe)
+    iq_to_exe = _fk_mock(src_table=iq, pk_table=exe)
+    iq_to_img = _fk_mock(src_table=iq, pk_table=img)
+
+    sub.referenced_by = [sh_to_sub]
+    sh.foreign_keys = [sh_to_sub, sh_to_exe]
+    exe.referenced_by = [sh_to_exe, iq_to_exe]
+    iq.foreign_keys = [iq_to_exe, iq_to_img]
+    img.referenced_by = [iq_to_img]
+
+    model = _make_mock_model(
+        {
+            "demo": {
+                "Subject": sub,
+                "Subject_Health": sh,
+                "Execution": exe,
+                "Image_Quality": iq,
+                "Image": img,
+            }
+        }
+    )
+    catalog = _make_mock_catalog(model)
+    cb = CatalogBagBuilder(
+        catalog=catalog,
+        anchors=[RIDAnchor(table="Subject", rids=["4AE"])],
+        output_dir=tmp_path,
+        policy=FKTraversalPolicy(
+            terminal_tables={("demo", "Execution")},
+        ),
+    )
+    cb._validate_anchors = lambda: None
+    cb._compute_reached_tables()
+
+    reached = {f"{s}.{t}" for s, t in cb._reached_tables}
+    # The terminal table itself IS in the slice (its rows ship in
+    # the bag for FK resolution at load time).
+    assert "demo.Subject" in reached
+    assert "demo.Subject_Health" in reached
+    assert "demo.Execution" in reached
+    # But the walker does NOT cross Execution to discover further
+    # tables via its other FKs.
+    assert "demo.Image_Quality" not in reached, reached
+    assert "demo.Image" not in reached, reached
+
+
+def test_terminal_table_query_path_terminates_at_table(
+    tmp_path: Path,
+) -> None:
+    """The CSV processor for a terminal table ends *at* the table.
+
+    Verifies the export-spec side: the query path for a terminal
+    table is anchored-and-joined-to it, not joined-through it.
+    The bag's Execution.csv will carry rows reachable from the
+    Subject anchor via the Subject_Health → Execution path,
+    nothing further.
+    """
+    sub = _make_mock_table("demo", "Subject")
+    sh = _make_mock_table("demo", "Subject_Health")
+    exe = _make_mock_table("demo", "Execution")
+
+    sh_to_sub = _fk_mock(src_table=sh, pk_table=sub)
+    sh_to_exe = _fk_mock(src_table=sh, pk_table=exe)
+    sub.referenced_by = [sh_to_sub]
+    sh.foreign_keys = [sh_to_sub, sh_to_exe]
+    exe.referenced_by = [sh_to_exe]
+
+    model = _make_mock_model(
+        {
+            "demo": {
+                "Subject": sub,
+                "Subject_Health": sh,
+                "Execution": exe,
+            }
+        }
+    )
+    catalog = _make_mock_catalog(model)
+    cb = CatalogBagBuilder(
+        catalog=catalog,
+        anchors=[RIDAnchor(table="Subject", rids=["4AE"])],
+        output_dir=tmp_path,
+        policy=FKTraversalPolicy(
+            terminal_tables={("demo", "Execution")},
+        ),
+    )
+    cb._validate_anchors = lambda: None
+    cb._compute_reached_tables()
+    spec = cb._build_export_spec()
+
+    exe_procs = [
+        p
+        for p in spec["catalog"]["query_processors"]
+        if p["processor"] == "csv"
+        and p["processor_params"]["output_path"].endswith("/Execution")
+    ]
+    assert len(exe_procs) >= 1
+    # Each Execution processor ends at ``demo:Execution`` — no
+    # join continues past it.
+    for p in exe_procs:
+        qpath = p["processor_params"]["query_path"]
+        assert qpath.endswith("/demo:Execution"), qpath
+
+
 # ---------------------------------------------------------------------------
 # Resolve helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

New ``FKTraversalPolicy.terminal_tables: set[tuple[str, str]]``
field. The walker treats listed tables the same way it already
treats vocabulary tables: enters them (so their rows ship in
the slice and downstream FKs resolve), but does **not** follow
outbound or inbound FKs from them.

This generalizes the vocab-terminal rule to non-vocab tables
that aggregate cross-anchor state. In the deriva-ml schema,
``Execution`` and ``Workflow`` are the canonical examples: a
single Execution row is referenced by every Subject, Image,
Dataset, and BoundingBox the workflow run touched. Without
terminal treatment, the walker entering Execution from one
anchor's path then walks out through every other anchor's
\*_Execution association — silently polluting the slice. The
legacy ``_schema_to_paths`` walker in deriva-ml has carried a
``_DEFAULT_SKIP_TABLES`` heuristic for years to handle this;
this PR lifts the idea into the bag walker's policy as a
first-class field.

Empty by default — callers opt in based on schema-domain
knowledge. The deriva-ml ``clone_via_bag`` will set ``Execution``
and ``Workflow`` as terminal in a follow-up deriva-ml PR.

## Test plan

- [x] ``uv run pytest tests/deriva/bag/`` — 226 passed, 2 skipped (was 224/2)
- [x] New unit test ``test_terminal_table_enters_but_does_not_exit`` — Subject anchor with Execution as terminal: walker reaches Execution (provenance preserved) but does not continue through it to Image_Quality / Image (over-fetch prevented)
- [x] New unit test ``test_terminal_table_query_path_terminates_at_table`` — the CSV processor's query path for a terminal table ends at the table, never joins through it
- [ ] Will validate against the deriva-ml clone-via-bag integration tests once this lands and the deriva-ml lock is bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)