### PR TITLE
fix(bag): terminal_tables block inbound only, still follow outbound

### DIFF
--- a/deriva/bag/catalog_builder.py
+++ b/deriva/bag/catalog_builder.py
@@ -389,24 +389,35 @@ class CatalogBagBuilder:
                 continue
 
             table = model.schemas[schema_name].tables[table_name]
-            # Terminal tables: traverse INTO but not OUT.
-            # - Vocabulary tables (detected by canonical column
-            #   shape) are always terminal: following inbound FKs
-            #   from a vocab term would chase every row in the
-            #   catalog that uses it.
-            # - Tables in :attr:`FKTraversalPolicy.terminal_tables`
-            #   get the same treatment. Used for "provenance" tables
-            #   like ``Execution`` that aggregate cross-anchor state
-            #   — walking *through* them mixes anchor scopes via
-            #   shared rows. Rows still land in the slice (other
-            #   rows' FKs into the terminal table resolve) but the
-            #   walker doesn't fan out from them.
-            if table.is_vocabulary():
+            is_vocab = table.is_vocabulary()
+            is_terminal = (
+                schema_name, table_name
+            ) in self.policy.terminal_tables
+            # Vocab tables are fully terminal — vocab terms are
+            # leaf nodes that don't reference further entities;
+            # the canonical vocab columns (ID/URI/Name/...) carry
+            # no outbound FKs in practice. Inbound FKs from a vocab
+            # term would chase every row in the catalog that uses
+            # it, so we don't follow those either.
+            if is_vocab:
                 continue
-            if (schema_name, table_name) in self.policy.terminal_tables:
-                continue
-
-            # Outbound: FKs we declare to other tables.
+            # Non-vocab terminal tables (declared via
+            # :attr:`FKTraversalPolicy.terminal_tables`) follow
+            # OUTBOUND FKs but not INBOUND ones.
+            #
+            # - **Outbound** (``table.foreign_keys``) = FKs the
+            #   terminal table itself declares to other tables.
+            #   These must be followed so the rows it references
+            #   land in the slice. Example: ``Execution.Workflow``
+            #   must resolve, so the walker continues to Workflow
+            #   from each in-slice Execution row.
+            # - **Inbound** (``table.referenced_by``) = FKs other
+            #   tables declare AT the terminal table. Following
+            #   these is what aggregates cross-anchor state: from
+            #   Execution, inbound goes to every ``*_Execution``
+            #   association, and from there to every other anchor
+            #   scope sharing the Execution. That's the over-fetch
+            #   the terminal-tables rule exists to prevent.
             for fk in table.foreign_keys:
                 self._enqueue_if_in_scope_with_path(
                     fk.pk_table,
@@ -417,7 +428,9 @@ class CatalogBagBuilder:
                     path_set,
                     max_paths,
                 )
-            # Inbound: FKs other tables declare to us.
+            if is_terminal:
+                # Block inbound for terminal tables.
+                continue
             for fk in table.referenced_by:
                 self._enqueue_if_in_scope_with_path(
                     fk.table,

--- a/tests/deriva/bag/test_catalog_builder.py
+++ b/tests/deriva/bag/test_catalog_builder.py
@@ -745,36 +745,48 @@ def test_spec_multipath_emits_one_processor_per_fk_route(
     assert len(image_fetches) == 0
 
 
-def test_terminal_table_enters_but_does_not_exit(tmp_path: Path) -> None:
-    """A table listed in ``policy.terminal_tables`` halts FK traversal.
+def test_terminal_table_blocks_inbound_but_follows_outbound(
+    tmp_path: Path,
+) -> None:
+    """A table in ``policy.terminal_tables`` is asymmetric:
+    OUTBOUND FKs (refs the table declares) are followed so the
+    rows it references land in the slice; INBOUND FKs (refs
+    declared at the table by others) are blocked so the slice
+    doesn't aggregate cross-anchor state.
 
     Topology::
 
+        Workflow ────────────┐
+                             │  (Execution.Workflow FK)
         Subject ─── Subject_Health ─── Execution ─── Image_Quality ─── Image
 
-    Without ``terminal_tables``, a Subject anchor walks all the way
-    to Image — and through Execution's other ``*_Execution``
-    inbound FKs it would over-fetch (Image_Quality rows from
-    Executions belonging to other Subjects). The fix: declare
-    Execution as terminal. The walker still reaches Execution
-    (so the slice has the provenance row for the Subject's
-    health record), but stops there — Image_Quality and Image
-    don't get walked through Execution.
+    Subject anchor with Execution terminal:
+    - Subject, Subject_Health, Execution reached (Subject's
+      provenance lands).
+    - Workflow reached too — outbound from Execution: an
+      Execution row's Workflow FK must resolve at load.
+    - Image_Quality and Image NOT reached — inbound from
+      Execution would over-fetch Quality rows belonging to
+      Executions of other Subjects.
     """
     sub = _make_mock_table("demo", "Subject")
     sh = _make_mock_table("demo", "Subject_Health")
     exe = _make_mock_table("demo", "Execution")
+    wf = _make_mock_table("demo", "Workflow")
     iq = _make_mock_table("demo", "Image_Quality")
     img = _make_mock_table("demo", "Image")
 
     sh_to_sub = _fk_mock(src_table=sh, pk_table=sub)
     sh_to_exe = _fk_mock(src_table=sh, pk_table=exe)
+    exe_to_wf = _fk_mock(src_table=exe, pk_table=wf)
     iq_to_exe = _fk_mock(src_table=iq, pk_table=exe)
     iq_to_img = _fk_mock(src_table=iq, pk_table=img)
 
     sub.referenced_by = [sh_to_sub]
     sh.foreign_keys = [sh_to_sub, sh_to_exe]
+    exe.foreign_keys = [exe_to_wf]
     exe.referenced_by = [sh_to_exe, iq_to_exe]
+    wf.referenced_by = [exe_to_wf]
     iq.foreign_keys = [iq_to_exe, iq_to_img]
     img.referenced_by = [iq_to_img]
 
@@ -784,6 +796,7 @@ def test_terminal_table_enters_but_does_not_exit(tmp_path: Path) -> None:
                 "Subject": sub,
                 "Subject_Health": sh,
                 "Execution": exe,
+                "Workflow": wf,
                 "Image_Quality": iq,
                 "Image": img,
             }
@@ -802,13 +815,17 @@ def test_terminal_table_enters_but_does_not_exit(tmp_path: Path) -> None:
     cb._compute_reached_tables()
 
     reached = {f"{s}.{t}" for s, t in cb._reached_tables}
-    # The terminal table itself IS in the slice (its rows ship in
-    # the bag for FK resolution at load time).
+    # The terminal table itself IS in the slice (provenance row
+    # for the Subject's health record).
     assert "demo.Subject" in reached
     assert "demo.Subject_Health" in reached
     assert "demo.Execution" in reached
-    # But the walker does NOT cross Execution to discover further
-    # tables via its other FKs.
+    # OUTBOUND from Execution still followed — Execution.Workflow
+    # FK must resolve, so Workflow lands in the slice.
+    assert "demo.Workflow" in reached, reached
+    # INBOUND to Execution blocked — Image_Quality and Image
+    # are reachable only via inbound FKs from Execution, so they
+    # stay out of the slice.
     assert "demo.Image_Quality" not in reached, reached
     assert "demo.Image" not in reached, reached
 


### PR DESCRIPTION
## Summary

Follow-up to #225. The terminal-tables rule needs to be **asymmetric**:

- **Outbound** FKs (refs the terminal table declares) must still be followed so rows it references land in the slice. Without this, a terminal Execution row's ``Workflow`` FK ends up dangling.
- **Inbound** FKs (refs declared AT the terminal table by other tables) stay blocked. This is the over-fetch direction the rule exists to prevent.

Symptom in integration testing: ``Dangling FK detected in Execution.Workflow (value='49G' not in parent set())``. The Execution row was reaching the slice (correct), but Workflow wasn't — the walker had stopped fully at Execution.

Vocab tables remain fully terminal (both directions blocked) — vocab terms are leaves by design and have no outbound FKs to worry about.

## Test plan

- [x] ``uv run pytest tests/deriva/bag/`` — 226 passed, 2 skipped
- [x] Renamed test ``test_terminal_table_blocks_inbound_but_follows_outbound`` extends the topology with an outbound FK (Execution → Workflow) plus an inbound chain (Execution ← Image_Quality → Image). Asserts Workflow lands in the slice, Image_Quality / Image do not.
- [ ] Will validate end-to-end against the deriva-ml clone-via-bag integration tests once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)