### PR TITLE
feat(bag): BagBuilder.add_asset link mode (hardlinks for transient staging)

### DIFF
--- a/deriva/bag/builder.py
+++ b/deriva/bag/builder.py
@@ -57,6 +57,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import shutil
 from contextlib import ExitStack
 from pathlib import Path
@@ -309,22 +310,51 @@ class BagBuilder:
         source_path: Path,
         *,
         filename: str | None = None,
+        link: bool = False,
     ) -> None:
-        """Copy an asset file into the bag at the profile-standard path.
+        """Embed an asset file into the bag at the profile-standard path.
 
         The destination is
         ``{output_dir}/data/asset/{table}/{rid}/{filename}``,
         where ``filename`` defaults to the source file's name.
 
+        Two storage modes:
+
+        - ``link=False`` (default): copy the file (``shutil.copy2``).
+          The bag is self-contained — it can be archived
+          (zipped/tarred), moved to another machine, or kept on
+          disk after the source files are deleted. Pays 1× disk
+          and 1× I/O at ``add_asset`` time.
+        - ``link=True``: create a **hard link** (``os.link``) from
+          the source file to the bag location. The directory entry
+          inside the bag points at the same inode as the source —
+          zero bytes copied, zero I/O. bagit sees a regular file
+          with valid content; MD5 manifest is correct. The link
+          keeps the file alive even if the source is unlinked
+          (useful when post-upload cleanup removes the flat
+          asset storage). Falls back to copy when the source and
+          bag are on different filesystems (``OSError`` with
+          ``errno.EXDEV``).
+
+          Symlinks are deliberately not used: bagit's
+          ``_validate_bag_contents`` rejects manifest entries that
+          resolve outside the bag root for security reasons.
+          Hardlinks live inside the bag as regular files, so
+          bagit's safety model is satisfied while the bytes still
+          live on disk only once.
+
+          Use this mode when the bag is short-lived in-process
+          staging that wants the bag layout but doesn't need to
+          be archived to a different machine.
+
         Args:
             table: Asset table name (e.g., ``"Image"``).
             rid: RID of the asset row this file belongs to.
-            source_path: Path to the file on local disk. The
-                file is copied into the bag eagerly so the bag
-                can be archived without depending on the source
-                still being present.
+            source_path: Path to the file on local disk.
             filename: Override the destination filename. Defaults
                 to ``source_path.name``.
+            link: If ``True``, hardlink the source file instead of
+                copying. Defaults to ``False`` (copy).
 
         Raises:
             FileNotFoundError: If ``source_path`` doesn't exist.
@@ -356,7 +386,27 @@ class BagBuilder:
             return
 
         dest.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(source_path, dest)
+        if link:
+            try:
+                # Hardlink: same inode, zero bytes duplicated.
+                # bagit treats the dest as a regular file (it is —
+                # just sharing storage with the source).
+                os.link(source_path, dest)
+            except OSError as e:
+                # EXDEV (Invalid cross-device link) — source and
+                # bag on different filesystems. Fall back to copy.
+                import errno
+                if e.errno != errno.EXDEV:
+                    raise
+                logger.warning(
+                    "Cross-filesystem hardlink failed for %s -> %s; "
+                    "falling back to copy. To preserve link semantics, "
+                    "put the bag on the same filesystem as the source.",
+                    source_path, dest,
+                )
+                shutil.copy2(source_path, dest)
+        else:
+            shutil.copy2(source_path, dest)
         # Record the asset so finalize() can compute the bag's
         # checksum manifests correctly. MD5 is deferred until
         # finalize to keep add_asset fast in tight loops.
@@ -374,6 +424,7 @@ class BagBuilder:
         mapping: dict[str, Path],
         *,
         filenames: dict[str, str] | None = None,
+        link: bool = False,
     ) -> int:
         """Bulk-add assets for one table.
 
@@ -383,6 +434,8 @@ class BagBuilder:
             filenames: Optional ``{rid: filename, ...}`` overriding
                 each asset's destination filename. RIDs absent
                 from this dict default to the source path's name.
+            link: If ``True``, symlink each source file instead of
+                copying. See :meth:`add_asset` for the trade-offs.
 
         Returns:
             Number of assets added.
@@ -395,6 +448,7 @@ class BagBuilder:
                 rid,
                 Path(source),
                 filename=filenames.get(rid),
+                link=link,
             )
         return len(mapping)
 

--- a/tests/deriva/bag/test_builder.py
+++ b/tests/deriva/bag/test_builder.py
@@ -221,6 +221,165 @@ def test_builder_add_assets_bulk(tmp_path: Path) -> None:
         ).is_file()
 
 
+def test_builder_add_asset_link_mode_hardlinks_source(tmp_path: Path) -> None:
+    """``link=True`` hardlinks the source instead of copying.
+
+    Used by transient-staging callers (e.g. ``commit_execution``) that
+    want the bag layout but don't pay for an extra disk copy. The
+    bag's directory entry points at the same inode as the source —
+    zero bytes duplicated. bagit sees a regular file (which it is, by
+    every filesystem-level definition); the safety model is satisfied
+    because the link lives inside the bag tree.
+    """
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"original bytes")
+    out = tmp_path / "bag"
+    bb = BagBuilder(metadata=_two_table_metadata(), output_dir=out)
+    bb.add_asset("Image", "I1", src, link=True)
+    bb.finalize(make_bdbag=False)
+
+    dest = out / "data" / "asset" / "Image" / "I1" / "src.bin"
+    assert dest.is_file()
+    # Hardlink — not a symlink, but shares an inode with source.
+    assert not dest.is_symlink(), f"hardlink mode must not symlink: {dest}"
+    assert dest.stat().st_ino == src.stat().st_ino, (
+        f"hardlink should share an inode with source"
+    )
+    assert dest.read_bytes() == b"original bytes"
+
+
+def test_builder_add_asset_link_mode_survives_source_deletion(
+    tmp_path: Path,
+) -> None:
+    """Hardlinks keep the file alive after the source is unlinked.
+
+    Important for the ``commit_execution`` workflow: post-upload
+    cleanup may remove the flat asset storage, but the bag has
+    already been consumed by the loader. The hardlinked bag entry
+    behaves like a normal file even after the original directory
+    entry is gone — relevant if any post-finalize step still needs
+    to read from the bag.
+    """
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"keep me alive")
+    out = tmp_path / "bag"
+    bb = BagBuilder(metadata=_two_table_metadata(), output_dir=out)
+    bb.add_asset("Image", "I1", src, link=True)
+    bb.finalize(make_bdbag=False)
+
+    dest = out / "data" / "asset" / "Image" / "I1" / "src.bin"
+    src.unlink()  # remove the original directory entry
+    # Hardlink keeps the data alive — same inode, different name.
+    assert dest.is_file()
+    assert dest.read_bytes() == b"keep me alive"
+
+
+def test_builder_add_asset_link_mode_passes_bagit_validation(
+    tmp_path: Path,
+) -> None:
+    """Hardlinked bag passes ``bdb.make_bag`` validation.
+
+    bagit's ``_validate_bag_contents`` rejects manifest entries that
+    resolve outside the bag root for security reasons. Symlinks
+    pointing at external storage fail this check. Hardlinks live
+    inside the bag tree as ordinary directory entries; bagit sees
+    nothing unusual. This test pins that behavior — if a future
+    refactor switches to symlinks, ``make_bdbag=True`` will start
+    raising ``bagit.BagError("... is unsafe")`` and this test will
+    surface it.
+    """
+    src = tmp_path / "src.txt"
+    src.write_bytes(b"hello bagit\n")
+    out = tmp_path / "bag"
+    bb = BagBuilder(metadata=_two_table_metadata(), output_dir=out)
+    bb.add_asset("Image", "I1", src, link=True)
+    # make_bdbag=True invokes bagit's full validation.
+    bb.finalize(make_bdbag=True)
+
+    # If we got here, validation passed. Spot-check the manifest:
+    manifest = (out / "manifest-md5.txt").read_text()
+    assert "asset/Image/I1/src.txt" in manifest
+
+
+def test_builder_add_asset_link_mode_md5_matches_content(
+    tmp_path: Path,
+) -> None:
+    """The bag's MD5 manifest digest equals MD5 of the source content.
+
+    Hardlinks share storage, so ``hashlib`` reading the bag entry
+    digests the exact same bytes as the source. This pins the
+    contract: the manifest is authoritative for the file content
+    regardless of whether the storage came from a copy or a link.
+    """
+    import hashlib
+
+    src = tmp_path / "src.txt"
+    content = b"hello world\n"
+    src.write_bytes(content)
+    expected_md5 = hashlib.md5(content).hexdigest()
+
+    out = tmp_path / "bag"
+    bb = BagBuilder(metadata=_two_table_metadata(), output_dir=out)
+    bb.add_asset("Image", "I1", src, link=True)
+    bb.finalize(make_bdbag=True)
+
+    manifest = (out / "manifest-md5.txt").read_text()
+    asset_lines = [
+        line for line in manifest.splitlines()
+        if "asset/Image/I1/src.txt" in line
+    ]
+    assert len(asset_lines) == 1, manifest
+    digest = asset_lines[0].split()[0]
+    assert digest == expected_md5
+
+
+def test_builder_add_asset_link_mode_default_is_copy(tmp_path: Path) -> None:
+    """Without ``link=True``, ``add_asset`` still copies the file.
+
+    Backward compatibility: existing callers (clone-via-bag,
+    constructive bag-building tests) get the copy semantics they've
+    always had. Hardlinks are opt-in for transient-staging callers.
+    """
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"content")
+    out = tmp_path / "bag"
+    bb = BagBuilder(metadata=_two_table_metadata(), output_dir=out)
+    bb.add_asset("Image", "I1", src)  # link= defaults to False
+    bb.finalize(make_bdbag=False)
+
+    dest = out / "data" / "asset" / "Image" / "I1" / "src.bin"
+    assert dest.is_file()
+    # Copy mode: different inode (independent storage).
+    assert dest.stat().st_ino != src.stat().st_ino
+
+
+def test_builder_add_assets_bulk_link_mode(tmp_path: Path) -> None:
+    """``add_assets(..., link=True)`` propagates the flag to each call.
+
+    Bulk loop just delegates to per-asset ``add_asset(link=...)``;
+    this test pins the propagation so a future refactor can't drop
+    the kwarg.
+    """
+    sources: dict[str, Path] = {}
+    for rid in ("I1", "I2"):
+        p = tmp_path / f"{rid}.bin"
+        p.write_bytes(rid.encode())
+        sources[rid] = p
+
+    out = tmp_path / "bag"
+    bb = BagBuilder(metadata=_two_table_metadata(), output_dir=out)
+    bb.add_assets("Image", sources, link=True)
+    bb.finalize(make_bdbag=False)
+
+    for rid in ("I1", "I2"):
+        src = sources[rid]
+        dest = (
+            out / "data" / "asset" / "Image" / rid / f"{rid}.bin"
+        )
+        # Hardlinked — shares inode with source.
+        assert dest.stat().st_ino == src.stat().st_ino
+
+
 def test_builder_add_asset_reference_records_entry(tmp_path: Path) -> None:
     bb = BagBuilder(
         metadata=_two_table_metadata(),


### PR DESCRIPTION
## Summary

Adds ``link: bool = False`` to ``BagBuilder.add_asset`` (and ``add_assets``). When ``link=True``, source files get a hardlink (``os.link``) into the bag at the profile-standard path instead of a copy. Same inode, second directory entry — zero bytes duplicated, zero extra I/O.

This is the deriva-py half of the bag-based ``commit_execution`` design (see deriva-ml's [docs/design/bag-based-commit-execution.md](https://github.com/informatics-isi-edu/deriva-ml/blob/main/docs/design/bag-based-commit-execution.md)). The bag-based commit pipeline needs the bag layout for ``BagCatalogLoader`` to consume, but the actual durable artifact is the destination catalog — the bag itself is throwaway. Copying multi-GB execution outputs was the cost objection that previously rejected the bag-based commit; hardlinks make it free.

### Why hardlinks rather than symlinks

bagit's ``_validate_bag_contents`` rejects manifest entries that resolve outside the bag root (``BagError("... is unsafe")``). Symlinks pointing at flat asset storage fail this check. Hardlinks live inside the bag tree as ordinary directory entries; bagit sees regular files and validation passes. MD5 manifest is correct because hashlib reads through the shared inode.

Cross-filesystem hardlinks raise ``OSError(EXDEV)``; the implementation catches this and falls back to ``shutil.copy2`` with a warning. Users with bag+source on different filesystems pay the copy cost transparently rather than seeing a confusing error.

### Backward compat

Default ``link=False`` unchanged. Existing callers (clone-via-bag, constructive bag-building tests) get the copy semantics they've always had. Hardlinks are opt-in for transient-staging use cases.

## Test plan

- [x] ``uv run pytest tests/deriva/bag/`` — 232 passed, 2 skipped (was 226 / 2 before, +6 new tests)
- [x] ``test_builder_add_asset_link_mode_hardlinks_source`` — inode sharing pinned
- [x] ``test_builder_add_asset_link_mode_survives_source_deletion`` — hardlink keeps file alive after source unlink
- [x] ``test_builder_add_asset_link_mode_passes_bagit_validation`` — ``make_bdbag=True`` succeeds (this is the smoking-gun guard: symlinks fail here)
- [x] ``test_builder_add_asset_link_mode_md5_matches_content`` — manifest digest correct
- [x] ``test_builder_add_asset_link_mode_default_is_copy`` — backward-compat
- [x] ``test_builder_add_assets_bulk_link_mode`` — bulk-add propagates ``link=``

🤖 Generated with [Claude Code](https://claude.com/claude-code)