### PR TITLE
feat(bag): DanglingFKStrategy.PRESERVE — trust destination for orphans

### DIFF
--- a/deriva/bag/catalog_loader.py
+++ b/deriva/bag/catalog_loader.py
@@ -762,7 +762,22 @@ class BagCatalogLoader:
         - ``DELETE`` — drop offending rows from the survivor list.
         - ``NULLIFY`` — set the dangling FK column to ``None`` (if
           the column is nullable) and keep the row.
+        - ``PRESERVE`` — short-circuit; trust the destination
+          catalog's FK constraint. No bag-side validation, no
+          counter updates. Use when the bag deliberately ships
+          rows whose FK parents live at the destination but
+          aren't in the bag (e.g. the end-of-execution upload).
         """
+        # PRESERVE skips the whole bag-side check. The destination
+        # catalog's FK constraint is the authority; if a parent row
+        # is missing there, ERMrest's insert will fail with HTTP 409
+        # — the real error surfaces unfiltered. Returning ``rows``
+        # verbatim with zero counters matches the "no orphans found"
+        # success path so callers don't need to special-case the
+        # report numbers.
+        if self.policy.dangling_fk_strategy == DanglingFKStrategy.PRESERVE:
+            return rows, 0, 0
+
         # Build the set of valid parent RIDs per FK column once.
         # Each table.foreign_keys element points at a single
         # column (or composite); for the simple single-column

--- a/deriva/bag/traversal.py
+++ b/deriva/bag/traversal.py
@@ -113,6 +113,16 @@ class DanglingFKStrategy(StrEnum):
     - ``NULLIFY``: set the dangling FK column to ``NULL`` (only
       legal when the column is nullable). The row stays; only
       the broken reference disappears.
+    - ``PRESERVE``: skip the bag-side parent-row check entirely
+      and trust the destination catalog's FK constraint to be
+      authoritative. Bag rows are sent verbatim; if the
+      destination doesn't have the referenced parent, ERMrest's
+      insert-time FK check fires (HTTP 409). Use when the bag
+      legitimately references parents that exist at the
+      destination but were never in the bag — e.g., the
+      end-of-execution upload, where output Image rows reference
+      Subject parents that were created in an earlier execution
+      and already live in the destination catalog.
 
     Detection happens at *bag-read time* in
     :class:`BagDatabase`; application happens at *load time* in
@@ -123,6 +133,7 @@ class DanglingFKStrategy(StrEnum):
     FAIL = "fail"
     DELETE = "delete"
     NULLIFY = "nullify"
+    PRESERVE = "preserve"
 
 
 class ContentConflictStrategy(StrEnum):

--- a/tests/deriva/bag/test_catalog_loader.py
+++ b/tests/deriva/bag/test_catalog_loader.py
@@ -453,6 +453,50 @@ def test_dangling_fk_strategy_nullify_keeps_row(tmp_path: Path) -> None:
         loader.dispose()
 
 
+def test_dangling_fk_strategy_preserve_short_circuits(tmp_path: Path) -> None:
+    """``PRESERVE`` skips the bag-side check; rows pass through verbatim.
+
+    Use case: end-of-execution commit. The bag ships Image rows
+    that reference Subject FKs already at the destination (Subjects
+    were created in an earlier execution). The bag never carried
+    those Subject rows, so a bag-side check would flag them as
+    dangling. ``PRESERVE`` trusts the destination catalog's FK
+    constraint to be authoritative — the rows go in, and if a
+    parent is genuinely missing the load fails with ERMrest's
+    real HTTP 409 unfiltered.
+    """
+    bag = _build_fk_bag(tmp_path)
+    db_dir = tmp_path / "db"
+    loader = BagCatalogLoader(
+        catalog=_mock_catalog(),
+        bag=bag,
+        policy=FKTraversalPolicy(
+            asset_mode=AssetMode.ROWS_ONLY,
+            dangling_fk_strategy=DanglingFKStrategy.PRESERVE,
+        ),
+        database_dir=db_dir,
+    )
+    try:
+        image = loader.bag_db.model.schemas["demo"].tables["Image"]
+        rows_in = [
+            {"RID": "I1", "Subject": "S1"},  # parent in bag
+            {"RID": "I2", "Subject": "S2"},  # parent NOT in bag
+        ]
+        survivors, skipped, nullified = (
+            loader._apply_dangling_fk_strategy(image, rows_in)
+        )
+        # Verbatim pass-through — no rows dropped, no FK nulled.
+        assert survivors == rows_in
+        assert skipped == 0
+        assert nullified == 0
+        # The S2 reference is preserved as-is; ERMrest will be the
+        # authority at insert time.
+        i2 = [r for r in survivors if r["RID"] == "I2"][0]
+        assert i2["Subject"] == "S2"
+    finally:
+        loader.dispose()
+
+
 # ---------------------------------------------------------------------------
 # Report shape
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a fourth ``DanglingFKStrategy`` value. ``PRESERVE`` short-circuits the bag-side parent-row check entirely: bag rows pass through verbatim with their FK columns unchanged, and any genuinely-missing parent surfaces as ERMrest's HTTP 409 at insert time.

This is the deriva-py companion to [#227](https://github.com/informatics-isi-edu/deriva-py/pull/227) — together they enable the bag-based ``commit_execution`` design (see deriva-ml's [docs/design/bag-based-commit-execution.md](https://github.com/informatics-isi-edu/deriva-ml/blob/main/docs/design/bag-based-commit-execution.md)).

### Use case

End-of-execution commit. The commit bag contains output rows (Image, BoundingBox, feature rows, ``*_Execution`` associations) whose ``Subject`` / ``Observation`` / ``Workflow`` FK targets already exist at the destination — they were created in a previous execution and weren't transitively walked into the commit bag.

A bag-side ``parent_rids`` check would flag them as dangling (the bag doesn't carry the parent rows), even though the references are perfectly valid at the destination. ``PRESERVE`` is the explicit "I know my bag references rows outside itself, and I trust the destination" choice.

### Implementation

One-line short-circuit at the top of ``_apply_dangling_fk_strategy``:

```python
if self.policy.dangling_fk_strategy == DanglingFKStrategy.PRESERVE:
    return rows, 0, 0  # trust destination
```

The "no orphans found" success path is reused so the loader's report aggregation doesn't need to special-case ``PRESERVE``.

### Backward compat

``PRESERVE`` is opt-in. The existing FAIL (default), DELETE, NULLIFY semantics are unchanged.

## Test plan

- [x] ``uv run pytest tests/deriva/bag/`` — 227 passed, 2 skipped (was 226 / 2 before, +1 new test)
- [x] ``test_dangling_fk_strategy_preserve_short_circuits`` — locks in the verbatim pass-through: ``survivors == rows_in``, ``skipped == 0``, ``nullified == 0``, even when half the rows reference parents not in the bag

🤖 Generated with [Claude Code](https://claude.com/claude-code)