### PR TITLE
feat(bag): FKTraversalPolicy.preserve_provenance — clone vs commit semantics

### DIFF
--- a/deriva/bag/catalog_loader.py
+++ b/deriva/bag/catalog_loader.py
@@ -953,15 +953,26 @@ class BagCatalogLoader:
         loader can be embedded in async pipelines without
         blocking the event loop.
         """
-        # Preserve provenance for creation (RID, RCT, RCB) and let
-        # the destination set modification (RMT, RMB) on insert.
-        # This matches deriva-py's canonical catalog-clone paths
-        # (``ErmrestCatalog.clone_catalog`` and ``asyncio/clone.py``):
-        # creation timestamps and user are real audit data worth
-        # preserving; modification timestamps would be overwritten
-        # on the very next update anyway.
+        # Two insert modes, picked by ``policy.preserve_provenance``:
+        #
+        # - **True** (default — clone semantics): preserve creation
+        #   provenance from the bag's source catalog by passing
+        #   ``?nondefaults=RID,RCT,RCB``. Matches the canonical
+        #   clone paths (``ErmrestCatalog.clone_catalog``,
+        #   ``asyncio/clone.py``). Audit data from the source is
+        #   real history worth keeping; modification timestamps
+        #   would be overwritten on the next update anyway.
+        # - **False** (commit semantics): only ``RID`` is preserved;
+        #   ``RCT`` / ``RCB`` get server-set values. Required when
+        #   the bag carries newly-minted rows the destination is
+        #   generating — e.g. end-of-execution commit. Without
+        #   this, NULL ``RCB`` violates the
+        #   ``{Table}_RCB_fkey → public.ERMrest_Client`` constraint.
         qname = f"{table.schema.name}:{table.name}"
-        url = f"/entity/{qname}?nondefaults=RID,RCT,RCB"
+        if self.policy.preserve_provenance:
+            url = f"/entity/{qname}?nondefaults=RID,RCT,RCB"
+        else:
+            url = f"/entity/{qname}?nondefaults=RID"
 
         # Coerce array-typed columns from PostgreSQL literal form
         # (``{a,b}``) into real JSON arrays for the wire.

--- a/deriva/bag/traversal.py
+++ b/deriva/bag/traversal.py
@@ -233,6 +233,20 @@ class FKTraversalPolicy(BaseModel):
             See :class:`ContentConflictStrategy`. Default ``FAIL``.
             Vocabulary tables use match-by-name regardless of this
             setting.
+        preserve_provenance: Whether to preserve the bag's source
+            audit columns (``RCT`` creation time, ``RCB`` creating
+            user) at insert time. ``True`` (default) sends the bag
+            row's values verbatim using ERMrest's
+            ``?nondefaults=RID,RCT,RCB`` — the clone-style
+            semantics where audit data from the source catalog is
+            real history worth keeping. Set ``False`` when the bag
+            carries *new* rows the destination is generating
+            (e.g. end-of-execution commit): only ``RID`` is
+            preserved, ``RCT`` and ``RCB`` are server-defaulted to
+            the current timestamp and the current user. Without
+            this, new rows whose bag carries no ``RCB`` value get
+            sent with NULL ``RCB`` and ERMrest rejects them with
+            ``Image_RCB_fkey`` constraint failures.
 
     Example:
         >>> # Default — works for any producer case.
@@ -269,6 +283,7 @@ class FKTraversalPolicy(BaseModel):
     asset_mode: AssetMode = AssetMode.UPLOAD_IF_MISSING
     dangling_fk_strategy: DanglingFKStrategy = DanglingFKStrategy.FAIL
     content_on_conflict: ContentConflictStrategy = ContentConflictStrategy.FAIL
+    preserve_provenance: bool = True
 
     @field_validator("max_depth")
     @classmethod

--- a/tests/deriva/bag/test_catalog_loader.py
+++ b/tests/deriva/bag/test_catalog_loader.py
@@ -498,6 +498,109 @@ def test_dangling_fk_strategy_preserve_short_circuits(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# preserve_provenance — nondefaults URL shape
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_table() -> MagicMock:
+    """Minimal DerivaTable mock that satisfies ``_insert_rows``.
+
+    We only need ``schema.name``, ``name``, and a column list with
+    no array-typed columns (the wire serializer special-cases
+    those). Everything else routes through ``catalog.post``, which
+    is what the test inspects.
+    """
+    table = MagicMock(name="Table[demo.Image]")
+    table.name = "Image"
+    table.schema = MagicMock()
+    table.schema.name = "demo"
+    table.column_definitions = []
+    return table
+
+
+def test_insert_rows_preserve_provenance_default_sends_rct_rcb(
+    tmp_path: Path,
+) -> None:
+    """Default ``preserve_provenance=True`` sends ``RID,RCT,RCB`` in nondefaults.
+
+    Clone semantics: the bag's source audit columns are real
+    history worth keeping at the destination. The wire URL
+    explicitly opts those columns out of ERMrest's default-fill.
+    """
+    import asyncio as _asyncio
+
+    bag = _build_fk_bag(tmp_path)
+    catalog = _mock_catalog()
+    response = MagicMock()
+    response.json.return_value = [{"RID": "I1"}]
+    catalog.post.return_value = response
+
+    loader = BagCatalogLoader(
+        catalog=catalog,
+        bag=bag,
+        policy=FKTraversalPolicy(),  # preserve_provenance default = True
+        database_dir=tmp_path / "db",
+    )
+    try:
+        _asyncio.run(
+            loader._insert_rows(
+                _make_fake_table(),
+                [{"RID": "I1", "Filename": "a.bin"}],
+            )
+        )
+    finally:
+        loader.dispose()
+
+    # The URL ERMrest received carries all three audit columns.
+    posted_url = catalog.post.call_args[0][0]
+    assert posted_url == "/entity/demo:Image?nondefaults=RID,RCT,RCB", (
+        posted_url
+    )
+
+
+def test_insert_rows_preserve_provenance_false_sends_only_rid(
+    tmp_path: Path,
+) -> None:
+    """``preserve_provenance=False`` sends only ``RID`` in nondefaults.
+
+    Commit semantics: the bag carries newly-minted rows. Only
+    ``RID`` is preserved (the caller leased it ahead of time);
+    ``RCT`` and ``RCB`` get the destination's current-timestamp /
+    current-user defaults. Without this, NULL ``RCB`` would
+    violate the ``{Table}_RCB_fkey`` FK constraint at insert
+    time.
+    """
+    import asyncio as _asyncio
+
+    bag = _build_fk_bag(tmp_path)
+    catalog = _mock_catalog()
+    response = MagicMock()
+    response.json.return_value = [{"RID": "I1"}]
+    catalog.post.return_value = response
+
+    loader = BagCatalogLoader(
+        catalog=catalog,
+        bag=bag,
+        policy=FKTraversalPolicy(preserve_provenance=False),
+        database_dir=tmp_path / "db",
+    )
+    try:
+        _asyncio.run(
+            loader._insert_rows(
+                _make_fake_table(),
+                [{"RID": "I1", "Filename": "a.bin"}],
+            )
+        )
+    finally:
+        loader.dispose()
+
+    posted_url = catalog.post.call_args[0][0]
+    assert posted_url == "/entity/demo:Image?nondefaults=RID", (
+        posted_url
+    )
+
+
+# ---------------------------------------------------------------------------
 # Report shape
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds ``preserve_provenance: bool = True`` to ``FKTraversalPolicy``. Controls whether ``_insert_rows`` opts out of ERMrest's default-fill for the source audit columns (``RCT``, ``RCB``).

This is the third deriva-py piece needed for bag-based ``commit_execution`` in deriva-ml (companion to #227 hardlink mode and #228 PRESERVE strategy).

### Two modes

- **True** (default — clone semantics): wire URL is ``?nondefaults=RID,RCT,RCB``. The bag's audit columns ride through to the destination. Matches the canonical clone paths.
- **False** (commit semantics): wire URL is ``?nondefaults=RID``. ``RID`` is preserved (callers lease it ahead of time); ``RCT`` and ``RCB`` get the destination's server-set defaults. Required when the bag carries newly-minted rows.

### How I found this

A proof-of-concept for bag-based ``commit_execution`` hit a ``409 Conflict`` inserting an Image row:

```
Image_RCB_fkey ... Key (RCB)=(_ermrest.current_client()) is not present in table "ERMrest_Client"
```

The bag had no ``RCB``/``RCT`` for the new row (they're not known at bag-build time), so the loader sent NULL with the clone-style ``nondefaults=RID,RCT,RCB`` URL — which blocked ERMrest from filling defaults, and the NULL ``RCB`` violated the FK constraint against ``public.ERMrest_Client``.

The existing FAIL/DELETE/NULLIFY/PRESERVE strategies don't touch insert semantics, only dangling-FK validation. ``preserve_provenance`` separates the two policy axes cleanly.

### Backward compat

Default behavior unchanged. The existing clone path (and all 233 existing tests) continue passing.

## Test plan

- [x] ``uv run pytest tests/deriva/bag/`` — 235 passed, 2 skipped (was 233 / 2 before, +2 new tests)
- [x] ``test_insert_rows_preserve_provenance_default_sends_rct_rcb`` — backward-compat guard via mocked ``catalog.post`` URL inspection
- [x] ``test_insert_rows_preserve_provenance_false_sends_only_rid`` — commit mode emits the truncated nondefaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)