### PR TITLE
fix(bag): _localize_asset_row falls back to embedded-asset path

### DIFF
--- a/deriva/bag/database.py
+++ b/deriva/bag/database.py
@@ -469,25 +469,84 @@ class BagDatabase:
         row: list,
         asset_indexes: tuple[int, int] | None,
         asset_map: dict[str, str],
+        table_name: str | None = None,
+        rid_index: int | None = None,
     ) -> tuple:
-        """Replace URL with local path in asset table row.
+        """Replace ``Filename`` with the bag-local path for an asset row.
+
+        Two lookup strategies, tried in order:
+
+        1. ``asset_map`` — populated from the bag's ``fetch.txt``
+           remote-file manifest (URL → local path). This is the
+           clone/MINID path: ``CatalogBagBuilder`` emits
+           ``fetch.txt`` entries, ``bdb.materialize`` downloads
+           the bytes to those paths, and the map carries the
+           result.
+
+        2. ``data/asset/{table}/{rid}/{filename_from_url}`` — the
+           profile-standard embedded-asset path that
+           :meth:`BagBuilder.add_asset` writes to. Constructive bags
+           (no ``fetch.txt``) populate this directory directly with
+           copies or hardlinks; the loader's ``_upload_assets``
+           step needs the local path to PUT bytes to the
+           destination Hatrac.
 
         Args:
             row: List of column values.
-            asset_indexes: (filename_index, url_index) or None if not asset table.
-            asset_map: URL to local path mapping.
+            asset_indexes: ``(filename_index, url_index)`` or
+                ``None`` if not an asset table.
+            asset_map: URL → local path mapping from
+                :meth:`_build_asset_map`.
+            table_name: Asset table name. Used together with
+                ``rid_index`` to construct the embedded-asset
+                fallback path. Caller passes ``None`` when running
+                a code path that doesn't know either; the fallback
+                lookup is skipped.
+            rid_index: Index of the ``RID`` column in ``row``.
+                Required for the embedded-asset fallback.
 
         Returns:
             Tuple of updated column values.
         """
-        if asset_indexes:
-            file_column, url_column = asset_indexes
-            url = row[url_column]
-            if url and url in asset_map:
-                row[file_column] = asset_map[url]
-            elif url:
-                # Keep original if not in map
-                pass
+        if not asset_indexes:
+            return tuple(row)
+
+        file_column, url_column = asset_indexes
+        url = row[url_column]
+        if not url:
+            return tuple(row)
+
+        # Strategy 1: fetch.txt-based remote-file manifest.
+        if url in asset_map:
+            row[file_column] = asset_map[url]
+            return tuple(row)
+
+        # Strategy 2: embedded-asset path. The bag-relative
+        # location is ``data/asset/{table}/{rid}/{filename}``;
+        # the filename comes off the URL's path so this works
+        # whether the URL is a full ``https://.../foo.bin`` or a
+        # bare ``/hatrac/.../foo.bin``.
+        if table_name is None or rid_index is None:
+            return tuple(row)
+
+        rid = row[rid_index]
+        if not rid:
+            return tuple(row)
+
+        # The CSV's Filename column carries the bare filename at
+        # the time of bag-build (it's what BagBuilder.add_asset
+        # used as the destination name). Use that as the embedded
+        # asset's filename.
+        embedded = (
+            self.bag_path
+            / "data"
+            / "asset"
+            / table_name
+            / rid
+            / row[file_column]
+        )
+        if embedded.is_file():
+            row[file_column] = str(embedded)
         return tuple(row)
 
     def _load_data(self) -> None:
@@ -650,20 +709,31 @@ class BagDatabase:
             csv_reader = reader(csvfile)
             column_names = next(csv_reader)
 
-            # Get asset column indexes if this is an asset table
+            # Get asset column indexes if this is an asset table.
+            # ``rid_index`` is needed for the embedded-asset
+            # fallback path inside ``_localize_asset_row``; it
+            # constructs ``data/asset/{table}/{rid}/{filename}`` for
+            # bags built by :meth:`BagBuilder.add_asset` (no
+            # fetch.txt — bytes live at the profile-standard path).
             asset_indexes = None
+            rid_index: int | None = None
             if self._is_asset_table(table.name):
                 try:
                     asset_indexes = (
                         column_names.index("Filename"),
                         column_names.index("URL"),
                     )
+                    rid_index = column_names.index("RID")
                 except ValueError:
                     pass
 
             rows = [
                 self._localize_asset_row(
-                    list(row), asset_indexes, asset_map
+                    list(row),
+                    asset_indexes,
+                    asset_map,
+                    table_name=table.name,
+                    rid_index=rid_index,
                 )
                 for row in csv_reader
             ]

--- a/tests/deriva/bag/test_database.py
+++ b/tests/deriva/bag/test_database.py
@@ -599,3 +599,59 @@ def test_bag_database_localizes_asset_urls(tmp_path: Path) -> None:
     assert len(rows) == 1
     # Filename should now point at the localized path inside the bag.
     assert rows[0]["Filename"] == f"{bag}/{local_path}"
+
+
+def test_bag_database_localizes_embedded_asset_without_fetch_txt(
+    tmp_path: Path,
+) -> None:
+    """Embedded-asset fallback: ``data/asset/{table}/{rid}/{filename}``.
+
+    Constructive bags built by :meth:`BagBuilder.add_asset` write
+    asset bytes directly to the profile-standard path without
+    populating ``fetch.txt`` (no remote source URL to reference).
+    The localization must still find these files so the loader's
+    ``_upload_assets`` step can PUT bytes from the bag-local
+    location.
+
+    Without this fallback, end-of-execution commit (which builds
+    bags constructively rather than from a download) would have
+    ``Filename`` columns still holding the bare filename, the
+    upload step's ``Path(local_path).is_file()`` check would fail,
+    and bytes would never reach Hatrac.
+    """
+    cache_key = "embedded_asset"
+    bag = tmp_path / cache_key / "bag"
+    (bag / "data" / "demo").mkdir(parents=True)
+    (bag / "data" / "schema.json").write_text(json.dumps(_asset_schema()))
+
+    # Row carries the bare filename (what BagBuilder.add_asset
+    # writes to the CSV — the filename in the bag's asset path is
+    # the same).
+    with (bag / "data" / "demo" / "Image.csv").open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["RID", "Filename", "URL", "Length", "MD5", "Description"])
+        w.writerow(
+            [
+                "I3",
+                "embedded.bin",
+                "/hatrac/Image/abc123.embedded.bin",
+                "13",
+                "abc123",
+                "embedded",
+            ]
+        )
+
+    # Asset bytes live at the profile-standard embedded path.
+    # No fetch.txt.
+    embedded_dir = bag / "data" / "asset" / "Image" / "I3"
+    embedded_dir.mkdir(parents=True)
+    embedded_path = embedded_dir / "embedded.bin"
+    embedded_path.write_bytes(b"embedded bag")
+
+    db_dir = tmp_path / "db"
+    with BagDatabase(bag, db_dir, ["demo"]) as db:
+        rows = list(db.get_table_contents("Image"))
+    assert len(rows) == 1
+    # Filename rewritten to the embedded-asset path even though
+    # there's no fetch.txt entry.
+    assert rows[0]["Filename"] == str(embedded_path)


### PR DESCRIPTION
## Summary

``BagBuilder.add_asset`` writes asset bytes to ``data/asset/{table}/{rid}/{filename}`` (the deriva-bag profile-standard embedded-asset path) but doesn't populate ``fetch.txt`` — there's no remote source URL for embedded bytes. The loader's ``_localize_asset_row`` only consulted ``fetch.txt`` via ``_build_asset_map``, so for constructive bags it left the ``Filename`` column holding the bare filename. ``_upload_assets`` then saw ``Path("bare-name.bin").is_file() == False`` and silently skipped the upload.

This is the broken half of the ``BagBuilder``↔``BagCatalogLoader`` round trip for embedded assets. Clone-via-bag works because ``CatalogBagBuilder`` writes ``fetch.txt`` entries; constructive bags built for end-of-execution commit don't have remote URLs and fail this lookup.

### The fix

When the URL isn't in ``asset_map`` but the row has a RID, try ``data/asset/{table}/{rid}/{filename}``. If the file exists, rewrite ``Filename`` to that absolute path.

### How I found this

Proof-of-concept for bag-based ``commit_execution`` in deriva-ml: the loader inserted the Image row successfully (#229 made that work), but the HEAD against the expected hatrac URL returned 404. Tracing showed ``_upload_assets`` saw a bare filename and skipped — the localization step had never replaced it.

### Backward compat

The new fallback only fires when ``asset_map`` doesn't have the URL. Existing clone-via-bag tests continue passing — they always have ``fetch.txt``, so the new code path is never reached.

## Test plan

- [x] ``uv run pytest tests/deriva/bag/`` — 236 passed, 2 skipped (was 235 / 2 before, +1 new test)
- [x] ``test_bag_database_localizes_embedded_asset_without_fetch_txt`` — no ``fetch.txt``, bytes at ``data/asset/Image/I3/embedded.bin``, ``Filename`` comes out absolute-path-rewritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)