### PR TITLE
fix(bag): preserve Filename column; resolve bag-local path on demand

### DIFF
--- a/deriva/bag/catalog_loader.py
+++ b/deriva/bag/catalog_loader.py
@@ -1039,20 +1039,31 @@ class BagCatalogLoader:
         force = self.policy.asset_mode == AssetMode.UPLOAD_FORCE
 
         for row in rows:
-            local_path = row.get("Filename")
             url = row.get("URL")
-            if not local_path or not url:
+            if not url:
                 logger.warning(
-                    "asset row %s.%s/RID=%s missing Filename or URL; skipping",
+                    "asset row %s.%s/RID=%s missing URL; skipping",
                     table.schema.name, table.name, row.get("RID"),
                 )
                 continue
-            if not Path(local_path).is_file():
+            # Resolve the bag-local path on demand. The row's
+            # ``Filename`` column holds the catalog-facing name
+            # (which gets inserted verbatim); the actual on-disk
+            # bytes live elsewhere — either where ``fetch.txt``
+            # placed them (clone bags) or at the profile-standard
+            # embedded-asset path (constructive bags). The bag
+            # database knows both layouts.
+            local_path = self.bag_db.resolve_asset_local_path(
+                table.name, row
+            )
+            if not local_path:
                 logger.warning(
-                    "asset row %s.%s/RID=%s Filename=%r does not exist on "
-                    "disk; skipping (was the bag materialized?)",
+                    "asset row %s.%s/RID=%s has no bytes available in the "
+                    "bag (no fetch.txt match for URL=%r and no embedded "
+                    "asset at data/asset/%s/%s/%s); skipping byte upload",
                     table.schema.name, table.name, row.get("RID"),
-                    local_path,
+                    url, table.name, row.get("RID"),
+                    row.get("Filename"),
                 )
                 continue
             hatrac_path = self._hatrac_path_for(url)

--- a/deriva/bag/database.py
+++ b/deriva/bag/database.py
@@ -472,82 +472,78 @@ class BagDatabase:
         table_name: str | None = None,
         rid_index: int | None = None,
     ) -> tuple:
-        """Replace ``Filename`` with the bag-local path for an asset row.
+        """No-op for the row's column values.
 
-        Two lookup strategies, tried in order:
-
-        1. ``asset_map`` — populated from the bag's ``fetch.txt``
-           remote-file manifest (URL → local path). This is the
-           clone/MINID path: ``CatalogBagBuilder`` emits
-           ``fetch.txt`` entries, ``bdb.materialize`` downloads
-           the bytes to those paths, and the map carries the
-           result.
-
-        2. ``data/asset/{table}/{rid}/{filename_from_url}`` — the
-           profile-standard embedded-asset path that
-           :meth:`BagBuilder.add_asset` writes to. Constructive bags
-           (no ``fetch.txt``) populate this directory directly with
-           copies or hardlinks; the loader's ``_upload_assets``
-           step needs the local path to PUT bytes to the
-           destination Hatrac.
+        Historical name kept for callers in :meth:`_insert_csv`.
+        The asset-path lookup is now done lazily at upload time by
+        :meth:`resolve_asset_local_path`, which keeps the source
+        ``Filename`` value verbatim through to the destination
+        catalog (overwriting it would have inserted a long
+        bag-local absolute path).
 
         Args:
-            row: List of column values.
-            asset_indexes: ``(filename_index, url_index)`` or
-                ``None`` if not an asset table.
-            asset_map: URL → local path mapping from
-                :meth:`_build_asset_map`.
-            table_name: Asset table name. Used together with
-                ``rid_index`` to construct the embedded-asset
-                fallback path. Caller passes ``None`` when running
-                a code path that doesn't know either; the fallback
-                lookup is skipped.
-            rid_index: Index of the ``RID`` column in ``row``.
-                Required for the embedded-asset fallback.
+            row: List of column values (returned unchanged).
+            asset_indexes: Unused. Kept for signature stability.
+            asset_map: Unused. Kept for signature stability.
+            table_name: Unused. Kept for signature stability.
+            rid_index: Unused. Kept for signature stability.
 
         Returns:
-            Tuple of updated column values.
+            The row's values as a tuple, unmodified.
         """
-        if not asset_indexes:
-            return tuple(row)
+        return tuple(row)
 
-        file_column, url_column = asset_indexes
-        url = row[url_column]
-        if not url:
-            return tuple(row)
+    def resolve_asset_local_path(
+        self,
+        table_name: str,
+        row: dict[str, Any],
+    ) -> str | None:
+        """Find the bag-local path for an asset row's bytes.
 
-        # Strategy 1: fetch.txt-based remote-file manifest.
-        if url in asset_map:
-            row[file_column] = asset_map[url]
-            return tuple(row)
+        Asks two questions, in order:
 
-        # Strategy 2: embedded-asset path. The bag-relative
-        # location is ``data/asset/{table}/{rid}/{filename}``;
-        # the filename comes off the URL's path so this works
-        # whether the URL is a full ``https://.../foo.bin`` or a
-        # bare ``/hatrac/.../foo.bin``.
-        if table_name is None or rid_index is None:
-            return tuple(row)
+        1. Is the row's ``URL`` in :meth:`_build_asset_map`?
+           That map is populated from the bag's ``fetch.txt`` —
+           the clone/MINID path (bytes downloaded by
+           ``bdb.materialize`` and recorded with their bag-local
+           destination).
+        2. Otherwise, is there a file at the profile-standard
+           embedded-asset path
+           ``data/asset/{table}/{rid}/{filename}``? Constructive
+           bags built by :meth:`BagBuilder.add_asset` write
+           bytes there directly.
 
-        rid = row[rid_index]
-        if not rid:
-            return tuple(row)
+        Args:
+            table_name: Asset table name (e.g. ``"Image"``).
+            row: Row dict with at least ``URL``, ``RID``,
+                ``Filename`` keys.
 
-        # The CSV's Filename column carries the bare filename at
-        # the time of bag-build (it's what BagBuilder.add_asset
-        # used as the destination name). Use that as the embedded
-        # asset's filename.
+        Returns:
+            Absolute path to the bag-local file as a string, or
+            ``None`` if no bytes are present in the bag for this
+            row.
+        """
+        url = row.get("URL")
+        if url:
+            asset_map = self._build_asset_map()
+            if url in asset_map:
+                return asset_map[url]
+
+        rid = row.get("RID")
+        filename = row.get("Filename")
+        if not rid or not filename:
+            return None
         embedded = (
             self.bag_path
             / "data"
             / "asset"
             / table_name
             / rid
-            / row[file_column]
+            / filename
         )
         if embedded.is_file():
-            row[file_column] = str(embedded)
-        return tuple(row)
+            return str(embedded)
+        return None
 
     def _load_data(self) -> None:
         """Load CSV data files into the SQLite database in FK-safe order.

--- a/tests/deriva/bag/test_database.py
+++ b/tests/deriva/bag/test_database.py
@@ -557,13 +557,24 @@ def test_bag_database_localizes_asset_urls_path_only_form(tmp_path: Path) -> Non
     db_dir = tmp_path / "db"
     with BagDatabase(bag, db_dir, ["demo"]) as db:
         rows = list(db.get_table_contents("Image"))
-    assert len(rows) == 1
-    assert rows[0]["Filename"] == f"{bag}/{local_path}"
+        # ``Filename`` is preserved verbatim from the source CSV
+        # — what the destination catalog stores after a load.
+        assert rows[0]["Filename"] == "remote2.png"
+        # ``resolve_asset_local_path`` finds the bag-local bytes
+        # for ``_upload_assets`` via ``fetch.txt``.
+        assert db.resolve_asset_local_path("Image", rows[0]) == (
+            f"{bag}/{local_path}"
+        )
 
 
 def test_bag_database_localizes_asset_urls(tmp_path: Path) -> None:
-    """When fetch.txt maps a URL to a local file, the row's Filename column
-    gets rewritten to the local path on load."""
+    """``resolve_asset_local_path`` finds bytes via ``fetch.txt``.
+
+    The bag's ``Filename`` column is preserved verbatim through
+    to the destination catalog; the bag-local path is resolved
+    on demand at upload time by
+    :meth:`BagDatabase.resolve_asset_local_path`.
+    """
     cache_key = "asset_xyz"
     bag = tmp_path / cache_key / "bag"
     (bag / "data" / "demo").mkdir(parents=True)
@@ -596,9 +607,12 @@ def test_bag_database_localizes_asset_urls(tmp_path: Path) -> None:
     db_dir = tmp_path / "db"
     with BagDatabase(bag, db_dir, ["demo"]) as db:
         rows = list(db.get_table_contents("Image"))
-    assert len(rows) == 1
-    # Filename should now point at the localized path inside the bag.
-    assert rows[0]["Filename"] == f"{bag}/{local_path}"
+        # Filename column is the catalog-facing value, untouched.
+        assert rows[0]["Filename"] == "remote.png"
+        # The on-disk bytes are still findable via the side channel.
+        assert db.resolve_asset_local_path("Image", rows[0]) == (
+            f"{bag}/{local_path}"
+        )
 
 
 def test_bag_database_localizes_embedded_asset_without_fetch_txt(
@@ -609,15 +623,8 @@ def test_bag_database_localizes_embedded_asset_without_fetch_txt(
     Constructive bags built by :meth:`BagBuilder.add_asset` write
     asset bytes directly to the profile-standard path without
     populating ``fetch.txt`` (no remote source URL to reference).
-    The localization must still find these files so the loader's
-    ``_upload_assets`` step can PUT bytes from the bag-local
-    location.
-
-    Without this fallback, end-of-execution commit (which builds
-    bags constructively rather than from a download) would have
-    ``Filename`` columns still holding the bare filename, the
-    upload step's ``Path(local_path).is_file()`` check would fail,
-    and bytes would never reach Hatrac.
+    :meth:`BagDatabase.resolve_asset_local_path` must still find
+    these so the loader's ``_upload_assets`` can PUT bytes.
     """
     cache_key = "embedded_asset"
     bag = tmp_path / cache_key / "bag"
@@ -651,7 +658,10 @@ def test_bag_database_localizes_embedded_asset_without_fetch_txt(
     db_dir = tmp_path / "db"
     with BagDatabase(bag, db_dir, ["demo"]) as db:
         rows = list(db.get_table_contents("Image"))
-    assert len(rows) == 1
-    # Filename rewritten to the embedded-asset path even though
-    # there's no fetch.txt entry.
-    assert rows[0]["Filename"] == str(embedded_path)
+        # Filename stays at the catalog-facing value.
+        assert rows[0]["Filename"] == "embedded.bin"
+        # Resolution finds the embedded-asset path on demand.
+        assert (
+            db.resolve_asset_local_path("Image", rows[0])
+            == str(embedded_path)
+        )


### PR DESCRIPTION
## Summary

The asset-localization step in ``_localize_asset_row`` overwrote the row's ``Filename`` column in place with the bag-local path so ``_upload_assets`` could find the bytes. The rewritten path then leaked through to the catalog at insert time — destinations stored ``/private/var/.../bag/data/asset/Image/RID/file.bin`` as the Filename instead of the bare ``file.bin``.

The bug pre-existed in the clone-via-bag flow (clone tests check row counts, not Filename equality) but was newly visible in the bag-based ``commit_execution`` POC, which compares Filename against the original value the caller registered.

### Fix

Stop rewriting ``Filename``. Move the bag-local-path resolution into a new ``BagDatabase.resolve_asset_local_path(table_name, row)`` method that the loader's ``_upload_assets`` calls lazily, per asset row. The SQLite mirror preserves ``Filename`` verbatim; the destination catalog receives the catalog-facing filename; only the in-process upload step ever sees the bag-local path.

### Two lookup strategies (unchanged)

1. ``fetch.txt``-based ``asset_map`` (URL → local path) for clone/MINID bags.
2. Profile-standard embedded-asset path ``data/asset/{table}/{rid}/{filename}`` for constructive bags built via ``BagBuilder.add_asset``.

Both strategies live inside ``resolve_asset_local_path`` instead of inside ``_localize_asset_row``, which is now a documented no-op for call-site compatibility (will be pruned in a follow-up).

### Side effect on clone-via-bag

Clone targets that previously got an absolute bag-local path in their ``Filename`` column will now get the source's bare filename — the catalog-facing value. This is the correct behavior; the existing clone-via-bag integration tests in deriva-ml don't assert Filename and continue passing.

## Test plan

- [x] ``uv run pytest tests/deriva/bag/`` — 236 passed, 2 skipped (same count as before)
- [x] Three existing localization tests updated to assert the new contract: ``rows[0]["Filename"]`` equals the source value verbatim, ``db.resolve_asset_local_path("Image", rows[0])`` returns the bag-local path

🤖 Generated with [Claude Code](https://claude.com/claude-code)