### PR TITLE
fix(bag): SchemaBuilder.make_table_name normalises hyphens

### DIFF
--- a/deriva/bag/schema.py
+++ b/deriva/bag/schema.py
@@ -742,11 +742,22 @@ class SchemaBuilder:
             return col_name[:-3] if col_name.lower().endswith("_id") else col_name
 
         def make_table_name(schema_name: str, table_name: str) -> str:
-            """Compute the SQLAlchemy table name for a (schema, table)."""
+            """Compute the SQLAlchemy table name for a (schema, table).
+
+            In-memory mode folds the schema into a single SQLAlchemy
+            table name and applies ``replace("-", "_")`` so schemas
+            like ``test-schema`` (hyphenated) produce valid Python
+            identifiers — the same transform the table-creation
+            site does. Without this, a cross-schema FK lookup of
+            ``test-schema_Image_Asset_Type`` misses the actually-
+            stored ``test_schema_Image_Asset_Type``.
+            """
             if self._use_schemas:
                 return f"{schema_name}.{table_name}"
-            # In-memory: fold schema into the name.
-            return f"{schema_name}_{table_name}"
+            # In-memory: fold schema into the name and normalise
+            # hyphens. Must match the transform applied to the
+            # SQLTable name at creation time (a few lines below).
+            return f"{schema_name}_{table_name}".replace("-", "_")
 
         database_tables: list[SQLTable] = []
 

--- a/tests/deriva/bag/test_schema_builder.py
+++ b/tests/deriva/bag/test_schema_builder.py
@@ -171,6 +171,165 @@ def test_schemabuilder_propagates_fks(tmp_path: Path) -> None:
         orm.dispose()
 
 
+def _build_cross_schema_model_with_hyphen(
+    snaptime: str = "2026-01-01T00:00:00",
+) -> Model:
+    """Two schemas, one hyphenated, with a cross-schema FK.
+
+    Topology::
+
+        deriva-ml.Type ─── test-schema.Image.Type
+
+    Both schema names contain a hyphen (matching deriva-ml's
+    ``deriva-ml`` and the demo catalog's ``test-schema``) so the
+    SchemaBuilder's name-folding pass has to apply
+    ``replace("-", "_")`` consistently at both the table-creation
+    site and the cross-schema FK lookup site.
+    """
+    doc = {
+        "snaptime": snaptime,
+        "schemas": {
+            "deriva-ml": {
+                "schema_name": "deriva-ml",
+                "tables": {
+                    "Type": {
+                        "schema_name": "deriva-ml",
+                        "table_name": "Type",
+                        "kind": "table",
+                        "column_definitions": [
+                            {
+                                "name": "RID",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "Name",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                        ],
+                        "keys": [
+                            {
+                                "names": [
+                                    ["deriva-ml", "Type_RID_key"]
+                                ],
+                                "unique_columns": ["RID"],
+                            },
+                            {
+                                "names": [
+                                    ["deriva-ml", "Type_Name_key"]
+                                ],
+                                "unique_columns": ["Name"],
+                            },
+                        ],
+                        "foreign_keys": [],
+                    },
+                },
+            },
+            "test-schema": {
+                "schema_name": "test-schema",
+                "tables": {
+                    "Image": {
+                        "schema_name": "test-schema",
+                        "table_name": "Image",
+                        "kind": "table",
+                        "column_definitions": [
+                            {
+                                "name": "RID",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "Type",
+                                "type": {"typename": "text"},
+                                "nullok": True,
+                                "default": None,
+                                "comment": None,
+                            },
+                        ],
+                        "keys": [
+                            {
+                                "names": [
+                                    ["test-schema", "Image_RID_key"]
+                                ],
+                                "unique_columns": ["RID"],
+                            }
+                        ],
+                        "foreign_keys": [
+                            {
+                                "names": [
+                                    [
+                                        "test-schema",
+                                        "Image_Type_fkey",
+                                    ]
+                                ],
+                                "foreign_key_columns": [
+                                    {
+                                        "schema_name": "test-schema",
+                                        "table_name": "Image",
+                                        "column_name": "Type",
+                                    }
+                                ],
+                                "referenced_columns": [
+                                    {
+                                        "schema_name": "deriva-ml",
+                                        "table_name": "Type",
+                                        "column_name": "Name",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                },
+            },
+        },
+    }
+    import json
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".json", delete=False
+    ) as f:
+        json.dump(doc, f)
+        path = f.name
+    return Model.fromfile("file-system", path)
+
+
+def test_schemabuilder_in_memory_resolves_cross_schema_fk_with_hyphen() -> None:
+    """In-memory build with hyphenated schemas wires the cross-schema FK.
+
+    The build folds schema names into table names via underscore
+    AND applies ``replace("-", "_")`` so SQLAlchemy gets valid
+    identifiers. The cross-schema FK wiring step has to apply the
+    same transform when looking up the source/target tables —
+    otherwise lookup of ``test-schema_Image`` fails because the
+    table was stored as ``test_schema_Image``.
+    """
+    model = _build_cross_schema_model_with_hyphen()
+    # Build does not raise — the cross-schema FK wiring resolved
+    # both endpoints.
+    builder = SchemaBuilder(
+        model,
+        ["deriva-ml", "test-schema"],
+        database_path=":memory:",
+    )
+    orm = builder.build()
+    try:
+        names = orm.list_tables()
+        # Hyphenated names land as underscore-normalized in
+        # in-memory mode.
+        assert "test_schema_Image" in names
+        assert "deriva_ml_Type" in names
+    finally:
+        orm.dispose()
+
+
 def test_schemabuilder_uses_wal_engine(tmp_path: Path) -> None:
     """File-based builds use the WAL-pragma engine."""
     model = _build_model()


### PR DESCRIPTION
## Summary

In in-memory mode (``database_path=":memory:"``, used by ``BagBuilder``), ``SchemaBuilder`` folds schema names into the SQLAlchemy table name and applies ``replace("-", "_")`` so the result is a valid Python identifier. But the cross-schema FK wiring pass uses ``make_table_name`` for the lookup, and that helper did NOT apply the transform — schemas like ``test-schema`` and ``deriva-ml`` (real names in deriva-ml's schema) generated SQLTables under ``test_schema_Image`` but the FK wiring tried to look up ``test-schema_Image``. KeyError, automap aborts mid-build.

This blocked using ``BagBuilder`` with deriva-ml's schema document. Hand-built bags work; this PR makes ``BagBuilder`` work too, which is the cleaner abstraction for the upcoming bag-based ``commit_execution``.

### Fix

One-line: apply the same ``replace("-", "_")`` transform inside ``make_table_name`` that the SQLTable-creation site does. All three name-construction sites in ``schema.py`` (line 760 new, line 791 SQLTable name, line 822 FK ref column) now agree.

## Test plan

- [x] ``uv run pytest tests/deriva/bag/`` — 237 passed, 2 skipped (was 236 / 2 before, +1 new test)
- [x] ``test_schemabuilder_in_memory_resolves_cross_schema_fk_with_hyphen`` — hyphenated source + destination schemas plus a cross-schema FK; the build completes and both folded table names land in ``orm.list_tables()``

🤖 Generated with [Claude Code](https://claude.com/claude-code)