### PR TITLE
fix(bag): _make_bdbag pre-seeds bagit scaffolding to avoid double-data/

### DIFF
--- a/deriva/bag/builder.py
+++ b/deriva/bag/builder.py
@@ -699,11 +699,52 @@ class BagBuilder:
         )
 
     def _make_bdbag(self) -> None:
-        """Invoke ``bdb.make_bag`` to add manifest scaffolding."""
+        """Invoke ``bdb.make_bag`` to add manifest scaffolding.
+
+        Pre-condition: :meth:`_write_pending_rows` and
+        :meth:`_write_schema_json` have already populated
+        ``output_dir/data/`` with the bag payload. Asset bytes are
+        either embedded under ``output_dir/data/asset/`` (via
+        :meth:`add_asset`) or referenced in the remote-file
+        manifest (via :meth:`add_asset_reference`).
+
+        The trick: ``bdb.make_bag`` treats the path as a fresh
+        directory when there's no ``bagit.txt`` and moves
+        everything into ``data/``. Since we already wrote to
+        ``data/``, that would produce a doubly-nested
+        ``data/data/`` layout. To trigger bdbag's update-existing
+        path instead, write a minimal ``bagit.txt`` first so
+        bdbag's :class:`BDBag` constructor detects an existing
+        bag. The update path then regenerates manifests in place
+        without reshuffling the payload tree.
+        """
         # Local import — bdbag is a non-trivial dependency, and
         # callers using ``finalize(make_bdbag=False)`` shouldn't
         # have to install it.
         from bdbag import bdbag_api as bdb
+
+        # Minimal bagit.txt sufficient for ``BDBag(path)`` to
+        # parse as an existing bag. The full content is rewritten
+        # by ``bdb.make_bag``'s update path.
+        bagit_txt = self.output_dir / "bagit.txt"
+        if not bagit_txt.exists():
+            bagit_txt.write_text(
+                "BagIt-Version: 0.97\nTag-File-Character-Encoding: UTF-8\n"
+            )
+        # bag-info.txt: required by bagit.Bag's open path. Empty
+        # is fine — bdbag's update path will populate it with the
+        # metadata we pass and the standard Bagging-Date etc.
+        # fields.
+        bag_info_txt = self.output_dir / "bag-info.txt"
+        if not bag_info_txt.exists():
+            bag_info_txt.write_text("")
+        # Manifest stubs so the update path treats the payload as
+        # already present. Empty files force a full recompute,
+        # which is exactly what we want for newly-constructed bags.
+        for algo in ("md5", "sha256"):
+            manifest = self.output_dir / f"manifest-{algo}.txt"
+            if not manifest.exists():
+                manifest.write_text("")
 
         remote_manifest_path = self._write_remote_manifest_if_any()
 

--- a/tests/deriva/bag/test_builder.py
+++ b/tests/deriva/bag/test_builder.py
@@ -530,3 +530,47 @@ def test_builder_finalize_archive(tmp_path: Path) -> None:
     bb = BagBuilder(metadata=_two_table_metadata(), output_dir=out)
     bb.finalize(make_bdbag=False, archive=True)
     assert (tmp_path / "bag.zip").is_file()
+
+
+def test_builder_finalize_make_bdbag_preserves_data_layout(
+    tmp_path: Path,
+) -> None:
+    """``make_bdbag=True`` adds scaffolding without doubly-nesting ``data/``.
+
+    bdbag's ``make_bag(update=False)`` path moves *everything* in
+    the directory into a fresh ``data/``. BagBuilder writes
+    ``data/schema.json``, ``data/{schema}/...csv``, and
+    ``data/asset/{table}/{rid}/{filename}`` directly, so naively
+    letting bdbag run its create path produces ``data/data/...``.
+    The fix: pre-seed minimal ``bagit.txt``, ``bag-info.txt``,
+    and ``manifest-*.txt`` so bdbag detects the directory as an
+    existing bag and runs the update path (which doesn't move
+    files around).
+
+    This test pins the layout — if anything regresses, the bag's
+    schema.json moves to the wrong place and the downstream
+    loader can't find it.
+    """
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"asset bytes\n")
+    out = tmp_path / "bag"
+    with BagBuilder(metadata=_two_table_metadata(), output_dir=out) as bb:
+        bb.add_row("Subject", {"RID": "S1", "Name": "Alice"})
+        bb.add_asset("Image", "I1", src)
+        bb.finalize(make_bdbag=True)
+
+    # Schema.json lands at data/schema.json — NOT data/data/schema.json.
+    assert (out / "data" / "schema.json").is_file()
+    assert not (out / "data" / "data" / "schema.json").exists(), (
+        "bdbag's create path moved everything into data/data/"
+    )
+    # Asset bytes land at data/asset/Image/I1/src.bin.
+    assert (
+        out / "data" / "asset" / "Image" / "I1" / "src.bin"
+    ).is_file()
+    # CSV lands at data/demo/Subject.csv.
+    assert (out / "data" / "demo" / "Subject.csv").is_file()
+    # bagit scaffolding is at the bag root.
+    assert (out / "bagit.txt").is_file()
+    assert (out / "bag-info.txt").is_file()
+    assert (out / "manifest-md5.txt").is_file()


### PR DESCRIPTION
## Summary

``BagBuilder.finalize(make_bdbag=True)`` produced a doubly-nested ``data/data/`` payload tree because bdbag's ``make_bag(update=False)`` (create path) moves everything into a fresh ``data/`` via ``bagit.make_bag``. ``BagBuilder`` already writes ``data/schema.json`` and ``data/asset/...`` directly, so when bdbag's create path ran on top, the existing ``data/`` ended up at ``data/data/``.

The ``update=True`` kwarg we were already passing only enters the update branch when ``BDBag(path)`` constructs successfully — which requires ``bagit.txt`` to exist. ``BagBuilder`` didn't write that, so ``BDBag`` raised, ``bag = None``, and the code fell through to the create branch.

### Fix

``_make_bdbag`` now pre-seeds the minimal bagit scaffolding (``bagit.txt``, ``bag-info.txt``, ``manifest-{md5,sha256}.txt`` all empty) before calling ``bdb.make_bag``. ``BDBag(path)`` succeeds, bdbag takes the update path, and the payload tree stays where ``BagBuilder`` put it. The update path's ``bag.save()`` then regenerates manifests with real content.

### How I found this

Proof-of-concept for bag-based ``commit_execution``: hand-built bags worked, but switching to ``BagBuilder.finalize(make_bdbag=True)`` produced an asset at ``bag/data/data/asset/Image/RID/file.bin`` that the post-finalize hardlink-existence assertion couldn't find.

Surprisingly, the pre-existing ``test_builder_finalize_make_bdbag=True`` tests didn't catch this — they only check ``manifest-md5.txt`` content, never the actual payload-tree layout.

## Test plan

- [x] ``uv run pytest tests/deriva/bag/`` — 238 passed, 2 skipped (was 237 / 2 before, +1 new test)
- [x] ``test_builder_finalize_make_bdbag_preserves_data_layout`` — schema.json at ``data/schema.json``, no ``data/data/`` subdir, bagit scaffolding at the bag root

🤖 Generated with [Claude Code](https://claude.com/claude-code)