### PR TITLE
fix(bag): SQLite mirror relaxes NOT-NULL on non-PK columns

### DIFF
--- a/deriva/bag/schema.py
+++ b/deriva/bag/schema.py
@@ -770,13 +770,24 @@ class SchemaBuilder:
                 database_columns: list[SQLColumn] = []
 
                 for c in table.columns:
+                    # The SQLite mirror is *staging* — it holds
+                    # rows the bag wants to ship to the
+                    # destination catalog, not a fidelity copy of
+                    # the catalog's constraints. Make every non-PK
+                    # column nullable so rows that *will* have
+                    # server-set defaults (``RCT``, ``RCB``, etc.)
+                    # at the destination can land in the mirror
+                    # without violating its local NOT-NULL. The
+                    # destination's ERMrest endpoint is the
+                    # authoritative validator at insert time.
+                    is_pk = self._is_key_column(c, table)
                     database_column = SQLColumn(
                         name=c.name,
                         type_=self._sql_type(c.type),
                         comment=c.comment,
                         default=c.default,
-                        primary_key=self._is_key_column(c, table),
-                        nullable=c.nullok,
+                        primary_key=is_pk,
+                        nullable=c.nullok if is_pk else True,
                     )
                     database_columns.append(database_column)
 

--- a/tests/deriva/bag/test_schema_builder.py
+++ b/tests/deriva/bag/test_schema_builder.py
@@ -330,6 +330,93 @@ def test_schemabuilder_in_memory_resolves_cross_schema_fk_with_hyphen() -> None:
         orm.dispose()
 
 
+def test_schemabuilder_non_pk_columns_nullable_in_mirror(
+    tmp_path: Path,
+) -> None:
+    """Non-PK columns are nullable in the SQLite mirror regardless of catalog NOT-NULL.
+
+    The bag's SQLite mirror is **staging**, not a fidelity copy
+    of the destination catalog. Rows landing there may legitimately
+    lack values for columns the destination will server-default
+    (``RCT``, ``RCB``, etc.) — those columns are NOT NULL with a
+    server-side default at the catalog, but the mirror has no
+    way to compute the default and shouldn't reject the row.
+
+    This test pins the rule: every non-PK column in the mirror
+    must be nullable. The RID PK keeps the NOT-NULL constraint
+    so accidental row-construction bugs surface immediately.
+    """
+    from sqlalchemy import Column as SQLColumnRef
+    from sqlalchemy import MetaData as SQLMetadataRef
+    from sqlalchemy import String as SQLStringRef
+    from sqlalchemy import Table as SQLTableRef  # noqa: F401
+
+    # Build a model where two columns are NOT NULL in the
+    # catalog: RID (the PK) and Name (a regular content column).
+    doc = {
+        "snaptime": "2026-01-01T00:00:00",
+        "schemas": {
+            "demo": {
+                "schema_name": "demo",
+                "tables": {
+                    "T": {
+                        "schema_name": "demo",
+                        "table_name": "T",
+                        "kind": "table",
+                        "column_definitions": [
+                            {
+                                "name": "RID",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "Name",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                        ],
+                        "keys": [
+                            {
+                                "names": [["demo", "T_RID_key"]],
+                                "unique_columns": ["RID"],
+                            }
+                        ],
+                        "foreign_keys": [],
+                    },
+                },
+            }
+        },
+    }
+    import json
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".json", delete=False
+    ) as f:
+        json.dump(doc, f)
+        path = f.name
+    model = Model.fromfile("file-system", path)
+
+    builder = SchemaBuilder(model, ["demo"], database_path=tmp_path)
+    orm = builder.build()
+    try:
+        t = orm.find_table("demo.T")
+        cols = {c.name: c for c in t.columns}
+        # PK: NOT NULL preserved.
+        assert not cols["RID"].nullable
+        # Non-PK with catalog NOT-NULL: relaxed in the mirror.
+        assert cols["Name"].nullable, (
+            "non-PK columns must be nullable in the mirror so rows "
+            "that will be server-defaulted at the destination can land"
+        )
+    finally:
+        orm.dispose()
+
+
 def test_schemabuilder_uses_wal_engine(tmp_path: Path) -> None:
     """File-based builds use the WAL-pragma engine."""
     model = _build_model()


### PR DESCRIPTION
## Summary

The bag's SQLite mirror inherited every catalog column's ``nullok`` flag directly, which meant catalog NOT-NULL columns with server-side defaults (``RCT``, ``RCB``, ``RMT``, ``RMB``) showed up as NOT-NULL in the mirror too. Rows that legitimately lacked those values — because the destination ERMrest would fill them in at insert time — failed the mirror's local constraint instead of getting through.

### How I found this

The bag-based ``commit_execution`` POC, switched to use ``BagBuilder``: passed an Image row without ``RCT``/``RCB``, ``BagDatabase._load_data`` rejected the insert with ``sqlite3.IntegrityError: NOT NULL constraint failed: Image.RCT``.

### Fix

The mirror is **staging**, not a fidelity copy of catalog constraints. Make every **non-PK** column nullable so rows that will be server-defaulted can land in the mirror. The destination's ERMrest endpoint is the authoritative validator at insert time.

PK columns keep their NOT-NULL: that's a real row-construction-bug detector and PKs never have server-set defaults.

### Backward compat

The existing bag tests pass (clone bags never had this problem because clone-via-bag's source CSVs include the audit-column values). The new behavior is strictly more permissive.

## Test plan

- [x] ``uv run pytest tests/deriva/bag/`` — 239 passed, 2 skipped (was 238 / 2 before, +1 new test)
- [x] ``test_schemabuilder_non_pk_columns_nullable_in_mirror`` — pins the rule: PK NOT-NULL preserved, non-PK NOT-NULL relaxed

🤖 Generated with [Claude Code](https://claude.com/claude-code)