### PR TITLE
fix(bag): ermrest_json_to_metadata also relaxes non-PK NOT-NULL

### DIFF
--- a/deriva/bag/schema_io.py
+++ b/deriva/bag/schema_io.py
@@ -301,6 +301,18 @@ def ermrest_json_to_metadata(
                 # matching SchemaBuilder._is_key_column. Other unique
                 # keys become UniqueConstraints below.
                 is_pk = col_def["name"] == "RID"
+                # The metadata produced here drives in-memory bag
+                # staging (``BagBuilder``'s pending-rows writer
+                # uses it). Non-PK columns are relaxed to nullable
+                # so rows that *will* have server-set defaults at
+                # the destination (``RCT``, ``RCB``, ``RMT``,
+                # ``RMB``) can land in the bag without violating
+                # the local mirror's NOT-NULL — same rule
+                # ``SchemaBuilder._create_tables`` applies for the
+                # on-disk SQLite mirror that backs already-built
+                # bags. The destination ERMrest endpoint is the
+                # authoritative validator at insert time.
+                mirror_nullable = True if not is_pk else nullok
                 col_args: list[Any] = []
                 # If this column is the source of an FK, hand the
                 # ForeignKey in as a positional argument so it's
@@ -310,17 +322,22 @@ def ermrest_json_to_metadata(
                 )
                 if target is not None:
                     col_args.append(ForeignKey(target))
-                columns.append(
-                    SQLColumn(
-                        col_def["name"],
-                        sql_type_cls(),
-                        *col_args,
-                        nullable=nullok,
-                        primary_key=is_pk,
-                        default=col_def.get("default"),
-                        comment=col_def.get("comment"),
-                    )
+                # The mirror's ``nullable`` is relaxed for staging
+                # (see comment above), but the catalog's authoritative
+                # ``nullok`` is preserved in ``info["nullok"]`` so
+                # round-trips through :func:`metadata_to_ermrest_json`
+                # carry the original constraint back out.
+                col = SQLColumn(
+                    col_def["name"],
+                    sql_type_cls(),
+                    *col_args,
+                    nullable=mirror_nullable,
+                    primary_key=is_pk,
+                    default=col_def.get("default"),
+                    comment=col_def.get("comment"),
+                    info={"nullok": nullok},
                 )
+                columns.append(col)
 
             sql_table = SQLTable(
                 table_name, metadata, *columns, schema=schema_name
@@ -387,13 +404,25 @@ def metadata_to_ermrest_json(metadata: MetaData) -> dict[str, Any]:
         )
         column_definitions: list[dict[str, Any]] = []
         for col in sql_table.columns:
+            # ``ermrest_json_to_metadata`` relaxes non-PK columns to
+            # nullable in the mirror but preserves the catalog's
+            # authoritative ``nullok`` in ``col.info``. Prefer the
+            # stashed value so a round-trip through this function
+            # carries the original constraint forward; fall back to
+            # the SQLAlchemy ``nullable`` flag for callers that
+            # never went through ``ermrest_json_to_metadata`` (in
+            # which case the two values are the same anyway).
+            if col.info and "nullok" in col.info:
+                nullok = bool(col.info["nullok"])
+            else:
+                nullok = bool(col.nullable)
             column_definitions.append(
                 {
                     "name": col.name,
                     "type": {
                         "typename": sql_type_to_ermrest_name(col.type),
                     },
-                    "nullok": bool(col.nullable),
+                    "nullok": nullok,
                     "default": _serialize_default(col),
                     "comment": col.comment,
                 }

--- a/tests/deriva/bag/test_schema_io.py
+++ b/tests/deriva/bag/test_schema_io.py
@@ -170,6 +170,151 @@ def test_ermrest_json_to_metadata_filters_schemas() -> None:
     assert len(md.tables) == 0
 
 
+def test_ermrest_json_to_metadata_relaxes_non_pk_not_null() -> None:
+    """Non-PK columns with catalog ``nullok=False`` are nullable in the mirror.
+
+    The mirror is staging — it holds rows the bag wants to ship to
+    the destination catalog, not a fidelity copy of the catalog's
+    constraints. Rows that *will* have server-set defaults at the
+    destination (``RCT``, ``RCB``, ``RMT``, ``RMB``) need to land
+    in the mirror without violating its local NOT-NULL. The
+    destination's ERMrest endpoint is the authoritative validator
+    at insert time.
+    """
+    doc = {
+        "snaptime": "2026-01-01T00:00:00",
+        "schemas": {
+            "demo": {
+                "schema_name": "demo",
+                "tables": {
+                    "T": {
+                        "schema_name": "demo",
+                        "table_name": "T",
+                        "kind": "table",
+                        "column_definitions": [
+                            {
+                                "name": "RID",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "RCT",
+                                "type": {"typename": "timestamptz"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "Name",
+                                "type": {"typename": "text"},
+                                "nullok": True,
+                                "default": None,
+                                "comment": None,
+                            },
+                        ],
+                        "keys": [
+                            {
+                                "names": [["demo", "T_RID_key"]],
+                                "unique_columns": ["RID"],
+                            }
+                        ],
+                        "foreign_keys": [],
+                    }
+                },
+            }
+        },
+    }
+    md = ermrest_json_to_metadata(doc)
+    cols = {c.name: c for c in md.tables["demo.T"].columns}
+    # PK NOT-NULL preserved (catches accidental row-construction
+    # bugs at the mirror layer).
+    assert not cols["RID"].nullable
+    # Non-PK NOT-NULL relaxed — would have been a NOT NULL
+    # ``RCT`` in the mirror without this rule.
+    assert cols["RCT"].nullable
+    assert cols["Name"].nullable
+    # The catalog's authoritative nullok is preserved on
+    # ``col.info`` so ``metadata_to_ermrest_json`` can round-trip
+    # it back out.
+    assert cols["RID"].info["nullok"] is False
+    assert cols["RCT"].info["nullok"] is False
+    assert cols["Name"].info["nullok"] is True
+
+
+def test_ermrest_json_to_metadata_roundtrip_preserves_nullok() -> None:
+    """``metadata_to_ermrest_json`` reads ``nullok`` from ``col.info``.
+
+    Without this, a round-trip
+    ``ermrest_json_to_metadata`` → ``metadata_to_ermrest_json``
+    would lose the catalog's authoritative ``nullok=False`` for
+    non-PK NOT-NULL columns (since the mirror relaxes them to
+    nullable). Reading from ``col.info["nullok"]`` instead of
+    ``col.nullable`` keeps the round-trip honest.
+    """
+    from deriva.bag.schema_io import metadata_to_ermrest_json
+
+    doc = {
+        "snaptime": "2026-01-01T00:00:00",
+        "schemas": {
+            "demo": {
+                "schema_name": "demo",
+                "tables": {
+                    "T": {
+                        "schema_name": "demo",
+                        "table_name": "T",
+                        "kind": "table",
+                        "column_definitions": [
+                            {
+                                "name": "RID",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "RCT",
+                                "type": {"typename": "timestamptz"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "Name",
+                                "type": {"typename": "text"},
+                                "nullok": True,
+                                "default": None,
+                                "comment": None,
+                            },
+                        ],
+                        "keys": [
+                            {
+                                "names": [["demo", "T_RID_key"]],
+                                "unique_columns": ["RID"],
+                            }
+                        ],
+                        "foreign_keys": [],
+                    }
+                },
+            }
+        },
+    }
+    md = ermrest_json_to_metadata(doc)
+    round_tripped = metadata_to_ermrest_json(md)
+    out_cols = {
+        c["name"]: c
+        for c in round_tripped["schemas"]["demo"]["tables"]["T"][
+            "column_definitions"
+        ]
+    }
+    # Round-trip preserves the catalog's original nullok flags,
+    # even though the mirror relaxed non-PK NOT-NULL to nullable.
+    assert out_cols["RID"]["nullok"] is False
+    assert out_cols["RCT"]["nullok"] is False
+    assert out_cols["Name"]["nullok"] is True
+
+
 # ---------------------------------------------------------------------------
 # MetaData → ERMrest JSON
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Companion to #234 (``SchemaBuilder`` mirror relaxation). ``BagBuilder`` uses ``ermrest_json_to_metadata`` to build the in-memory ``SchemaORM`` that backs ``_write_pending_rows`` — NOT ``SchemaBuilder``. The two factories produce SQLAlchemy metadata for the same purpose (bag staging) but #234 only fixed one of them. Result: even after #234, ``BagBuilder.add_row`` calls for rows missing ``RCT``/``RCB`` still failed with ``sqlite3.IntegrityError: NOT NULL constraint failed``.

### Fix

Apply the same rule to ``ermrest_json_to_metadata``:
- PK columns keep their NOT-NULL constraint.
- Non-PK columns are nullable in the mirror regardless of the catalog's ``nullok`` flag.

Plus a round-trip-preservation safeguard: stash the catalog's authoritative ``nullok`` in ``col.info["nullok"]`` at construction; read from there in ``metadata_to_ermrest_json`` instead of from ``col.nullable``. Without this, a doc → metadata → doc round-trip would lose the catalog's NOT-NULL for non-PK columns.

## Test plan

- [x] ``uv run pytest tests/deriva/bag/`` — 241 passed, 2 skipped (was 239 / 2 before, +2 new)
- [x] ``test_ermrest_json_to_metadata_relaxes_non_pk_not_null`` — PK NOT-NULL preserved, non-PK relaxed, ``col.info["nullok"]`` carries original
- [x] ``test_ermrest_json_to_metadata_roundtrip_preserves_nullok`` — doc → metadata → doc preserves the catalog's NOT-NULL on non-PK columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)