### PR TITLE
fix(bag): BagDatabase mirror also relaxes non-PK NOT-NULL

### DIFF
--- a/deriva/bag/database.py
+++ b/deriva/bag/database.py
@@ -290,13 +290,27 @@ class BagDatabase:
                 database_columns: list[SQLColumn] = []
 
                 for c in table.columns:
+                    # The SQLite mirror is *staging* — it holds
+                    # rows the bag wants to ship to the
+                    # destination catalog, not a fidelity copy
+                    # of the catalog's constraints. Make every
+                    # non-PK column nullable so rows that *will*
+                    # have server-set defaults (``RCT``, ``RCB``,
+                    # ``RMT``, ``RMB``) at the destination can
+                    # land in the mirror without violating its
+                    # local NOT-NULL. The destination's ERMrest
+                    # endpoint is the authoritative validator at
+                    # insert time. Same rule as
+                    # ``SchemaBuilder._create_tables`` and
+                    # ``ermrest_json_to_metadata``.
+                    is_pk = self._is_key_column(c, table)
                     database_column = SQLColumn(
                         name=c.name,
                         type_=self._sql_type(c.type),
                         comment=c.comment,
                         default=c.default,
-                        primary_key=self._is_key_column(c, table),
-                        nullable=c.nullok,
+                        primary_key=is_pk,
+                        nullable=c.nullok if is_pk else True,
                     )
                     database_columns.append(database_column)
 

--- a/tests/deriva/bag/test_database.py
+++ b/tests/deriva/bag/test_database.py
@@ -143,6 +143,90 @@ def test_bag_database_converts_types(minimal_bag: Path, tmp_path: Path) -> None:
     assert ages["Bob"] is None
 
 
+def test_bag_database_relaxes_non_pk_not_null(tmp_path: Path) -> None:
+    """Non-PK columns are nullable in the mirror regardless of catalog NOT-NULL.
+
+    The SQLite mirror is *staging* — it holds rows the bag wants
+    to ship to the destination, not a fidelity copy of catalog
+    constraints. Rows that *will* have server-set defaults at the
+    destination (``RCT``, ``RCB``, ``RMT``, ``RMB``) need to land
+    in the mirror without violating its local NOT-NULL. The
+    destination's ERMrest endpoint is the authoritative validator
+    at insert time.
+
+    This test pins the rule for ``BagDatabase`` — the on-disk
+    SQLite mirror that backs already-built bags. Companion to
+    the same rule in ``SchemaBuilder._create_tables`` and
+    ``ermrest_json_to_metadata`` (PRs #234 / #235).
+    """
+    bag = tmp_path / "rct_bag" / "bag"
+    (bag / "data" / "demo").mkdir(parents=True)
+    doc = {
+        "snaptime": "2026-01-01T00:00:00",
+        "schemas": {
+            "demo": {
+                "schema_name": "demo",
+                "tables": {
+                    "T": {
+                        "schema_name": "demo",
+                        "table_name": "T",
+                        "kind": "table",
+                        "column_definitions": [
+                            {
+                                "name": "RID",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "RCT",
+                                "type": {"typename": "timestamptz"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "Name",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                        ],
+                        "keys": [
+                            {
+                                "names": [["demo", "T_RID_key"]],
+                                "unique_columns": ["RID"],
+                            }
+                        ],
+                        "foreign_keys": [],
+                    }
+                },
+            }
+        },
+    }
+    (bag / "data" / "schema.json").write_text(json.dumps(doc))
+    # Empty CSV — the test is about column nullability, not row
+    # contents.
+    with (bag / "data" / "demo" / "T.csv").open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["RID", "RCT", "Name"])
+
+    db_dir = tmp_path / "db"
+    with BagDatabase(bag, db_dir, ["demo"]) as db:
+        t = db.metadata.tables["demo.T"]
+        cols = {c.name: c for c in t.columns}
+    # PK column keeps its NOT-NULL constraint (real
+    # row-construction-bug detector).
+    assert not cols["RID"].nullable
+    # Non-PK NOT-NULL columns are relaxed to nullable so rows
+    # missing them (legitimately, because the destination will
+    # supply server-set defaults) can land in the mirror.
+    assert cols["RCT"].nullable
+    assert cols["Name"].nullable
+
+
 def test_bag_database_orm_class_query(minimal_bag: Path, tmp_path: Path) -> None:
     """The automap-built ORM class is queryable via SQLAlchemy."""
     db_dir = tmp_path / "db"


### PR DESCRIPTION
## Summary

Completes the trio with #234 (``SchemaBuilder``) and #235 (``ermrest_json_to_metadata``). ``BagDatabase._create_tables`` has its own column-construction loop — duplicated logic that each location maintained separately. After #234 / #235 the in-memory and SchemaBuilder paths were fixed, but ``BagDatabase`` (the path that loads already-built bags from disk) still inherited the catalog's ``nullok`` verbatim.

### How I found this

Re-running the bag-based ``commit_execution`` POC after #235 still failed with ``sqlite3.IntegrityError: NOT NULL constraint failed: Image.RCT`` — but the failing INSERT was inside ``BagDatabase._load_data``, not the BagBuilder side. Three duplicated implementations; this PR is the last one.

### Fix

Same rule as #234 / #235:
- PK column keeps its NOT-NULL constraint.
- Non-PK columns nullable in the mirror regardless of catalog ``nullok``.

## Test plan

- [x] ``uv run pytest tests/deriva/bag/`` — 242 passed, 2 skipped (was 241 / 2 before, +1 new test)
- [x] ``test_bag_database_relaxes_non_pk_not_null`` — RID NOT-NULL preserved, RCT/Name (catalog ``nullok=False``) come out nullable

🤖 Generated with [Claude Code](https://claude.com/claude-code)