### PR TITLE
fix(bag): preserve_provenance=False strips RCT/RCB/RMT/RMB from row body

### DIFF
--- a/deriva/bag/catalog_loader.py
+++ b/deriva/bag/catalog_loader.py
@@ -973,6 +973,22 @@ class BagCatalogLoader:
             url = f"/entity/{qname}?nondefaults=RID,RCT,RCB"
         else:
             url = f"/entity/{qname}?nondefaults=RID"
+            # Commit semantics: strip RCT/RCB/RMT/RMB from the row
+            # dict entirely. The bag built them via
+            # ``BagBuilder.add_row`` from a row that didn't supply
+            # these system columns, so they're either absent
+            # (already fine) or empty strings (the bag's SQLite
+            # mirror serializes NULL as ``""`` via CSV — and
+            # ERMrest rejects empty strings for timestamp /
+            # ERMrest_Client columns with a 400). Removing them
+            # lets the server's defaults populate ``RCT`` (now())
+            # and ``RCB`` (current user) at insert time, which is
+            # the whole point of ``preserve_provenance=False``.
+            _SYSTEM_COLUMNS = ("RCT", "RCB", "RMT", "RMB")
+            rows = [
+                {k: v for k, v in row.items() if k not in _SYSTEM_COLUMNS}
+                for row in rows
+            ]
 
         # Coerce array-typed columns from PostgreSQL literal form
         # (``{a,b}``) into real JSON arrays for the wire.

--- a/tests/deriva/bag/test_catalog_loader.py
+++ b/tests/deriva/bag/test_catalog_loader.py
@@ -600,6 +600,120 @@ def test_insert_rows_preserve_provenance_false_sends_only_rid(
     )
 
 
+def test_insert_rows_preserve_provenance_false_strips_system_columns(
+    tmp_path: Path,
+) -> None:
+    """``preserve_provenance=False`` strips RCT/RCB/RMT/RMB from the JSON body.
+
+    Bag CSVs serialize NULL as ``""`` (CSV has no NULL sentinel).
+    ERMrest rejects ``""`` for the timestamp ``RCT`` / ``RMT``
+    columns and the FK-typed ``RCB`` / ``RMB`` columns with a
+    400 ``invalid input syntax`` error. Stripping these columns
+    from the row dict entirely (relying on the server's defaults
+    to populate them) is the symmetrical counterpart of the
+    ``nondefaults=RID`` URL — the wire-format contract for
+    commit-style inserts.
+    """
+    import asyncio as _asyncio
+
+    bag = _build_fk_bag(tmp_path)
+    catalog = _mock_catalog()
+    response = MagicMock()
+    response.json.return_value = [{"RID": "I1"}]
+    catalog.post.return_value = response
+
+    loader = BagCatalogLoader(
+        catalog=catalog,
+        bag=bag,
+        policy=FKTraversalPolicy(preserve_provenance=False),
+        database_dir=tmp_path / "db",
+    )
+    try:
+        _asyncio.run(
+            loader._insert_rows(
+                _make_fake_table(),
+                [
+                    {
+                        "RID": "I1",
+                        "Filename": "a.bin",
+                        # System columns the bag carries as empty
+                        # strings from its CSV — must be stripped
+                        # before reaching ERMrest.
+                        "RCT": "",
+                        "RCB": "",
+                        "RMT": "",
+                        "RMB": "",
+                    }
+                ],
+            )
+        )
+    finally:
+        loader.dispose()
+
+    # The JSON body posted to ERMrest excludes the system columns.
+    posted_rows = catalog.post.call_args.kwargs.get("json") or (
+        catalog.post.call_args[1].get("json")
+    )
+    assert posted_rows is not None, catalog.post.call_args
+    row = posted_rows[0]
+    assert "RID" in row
+    assert "Filename" in row
+    for col in ("RCT", "RCB", "RMT", "RMB"):
+        assert col not in row, (
+            f"system column {col} should have been stripped under "
+            f"preserve_provenance=False; got {row}"
+        )
+
+
+def test_insert_rows_preserve_provenance_true_keeps_system_columns(
+    tmp_path: Path,
+) -> None:
+    """Clone semantics keep RCT/RCB in the JSON body verbatim.
+
+    Backward-compat guard: the strip behavior is opt-in via
+    ``preserve_provenance=False``. Default callers see the
+    bag's audit data ride through.
+    """
+    import asyncio as _asyncio
+
+    bag = _build_fk_bag(tmp_path)
+    catalog = _mock_catalog()
+    response = MagicMock()
+    response.json.return_value = [{"RID": "I1"}]
+    catalog.post.return_value = response
+
+    loader = BagCatalogLoader(
+        catalog=catalog,
+        bag=bag,
+        policy=FKTraversalPolicy(),  # preserve_provenance=True default
+        database_dir=tmp_path / "db",
+    )
+    try:
+        _asyncio.run(
+            loader._insert_rows(
+                _make_fake_table(),
+                [
+                    {
+                        "RID": "I1",
+                        "Filename": "a.bin",
+                        "RCT": "2026-01-01T00:00:00+00:00",
+                        "RCB": "https://idp/user1",
+                    }
+                ],
+            )
+        )
+    finally:
+        loader.dispose()
+
+    posted_rows = catalog.post.call_args.kwargs.get("json") or (
+        catalog.post.call_args[1].get("json")
+    )
+    row = posted_rows[0]
+    # Audit data preserved verbatim.
+    assert row["RCT"] == "2026-01-01T00:00:00+00:00"
+    assert row["RCB"] == "https://idp/user1"
+
+
 # ---------------------------------------------------------------------------
 # Report shape
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Symmetrical counterpart to the ``nondefaults=RID`` URL change in #229. Commit-mode inserts now strip the system-audit columns from the row dict entirely so empty-string values the bag's CSV carried (the BDBag/CSV NULL sentinel) don't reach ERMrest as ``""``, which would 400 with ``invalid input syntax for type timestamp with time zone: ""``.

### The wire-format contract for ``preserve_provenance=False``

- **URL**: ``?nondefaults=RID`` (only RID is caller-supplied; RCT/RCB/RMT/RMB get server defaults).
- **Body**: rows have no RCT/RCB/RMT/RMB keys at all. ERMrest populates ``RCT`` (``now()``), ``RCB`` (current user), and the RMT/RMB defaults from the server.

### How I found this

Bag-based ``commit_execution`` POC: after the SQLite mirror's NOT-NULL relaxation (#234–#236) let rows land in the mirror, the wire body still carried ``"RCT": ""`` and ``"RCB": ""`` from the CSV-empty-string serialization, and the destination's ERMrest rejected them with a 400.

### Backward compat

Default behavior (``preserve_provenance=True``) unchanged — audit columns ride through verbatim for clone semantics.

## Test plan

- [x] ``uv run pytest tests/deriva/bag/`` — 244 passed, 2 skipped (was 242 / 2 before, +2 new)
- [x] ``test_insert_rows_preserve_provenance_false_strips_system_columns`` — system columns stripped from POSTed body
- [x] ``test_insert_rows_preserve_provenance_true_keeps_system_columns`` — clone-mode keeps RCT/RCB verbatim

🤖 Generated with [Claude Code](https://claude.com/claude-code)