### PR TITLE
fix(bag): schema_io preserves int2/int4/int8 distinction on round-trip

### DIFF
--- a/deriva/bag/schema_io.py
+++ b/deriva/bag/schema_io.py
@@ -355,13 +355,27 @@ def ermrest_json_to_metadata(
                 #   ``nullable`` we use in the mirror; see
                 #   :func:`metadata_to_ermrest_json` for the
                 #   read-back logic).
+                # - ``ermrest_typename``: the original ERMrest
+                #   typename. Several ERMrest types
+                #   (``int2``/``int4``/``int8`` → ``Integer``,
+                #   ``timestamptz`` and ``timestamp`` →
+                #   ``StringToDateTime``, etc.) map to one
+                #   SQLAlchemy type, so a metadata → json
+                #   round-trip without this stash would lose the
+                #   distinction. Consumers like
+                #   :meth:`Table.is_asset` exact-match the
+                #   typename, so ``int8`` rounded down to ``int4``
+                #   would mis-classify asset tables.
                 # - ``annotations``, ``acls``, ``acl_bindings``:
                 #   ERMrest-specific column-level metadata.
                 #   Stashed here so consumers like
                 #   :meth:`Table.is_asset` (which looks for
                 #   ``tag.asset`` on the URL column) see them
                 #   after a json → metadata → json round-trip.
-                col_info: dict[str, Any] = {"nullok": nullok}
+                col_info: dict[str, Any] = {
+                    "nullok": nullok,
+                    "ermrest_typename": ermrest_type,
+                }
                 for key in ("annotations", "acls", "acl_bindings"):
                     if key in col_def:
                         col_info[key] = col_def[key]
@@ -469,10 +483,19 @@ def metadata_to_ermrest_json(metadata: MetaData) -> dict[str, Any]:
                 nullok = bool(col.info["nullok"])
             else:
                 nullok = bool(col.nullable)
+            # Prefer the stashed ERMrest typename so a round-trip
+            # preserves the source's int2/int4/int8 distinction
+            # (and similar). Fall back to the SQLAlchemy → ERMrest
+            # mapping for callers that built the metadata
+            # directly (no info stash).
+            if col.info and "ermrest_typename" in col.info:
+                typename = col.info["ermrest_typename"]
+            else:
+                typename = sql_type_to_ermrest_name(col.type)
             col_doc: dict[str, Any] = {
                 "name": col.name,
                 "type": {
-                    "typename": sql_type_to_ermrest_name(col.type),
+                    "typename": typename,
                 },
                 "nullok": nullok,
                 "default": _serialize_default(col),

--- a/deriva/bag/schema_io.py
+++ b/deriva/bag/schema_io.py
@@ -250,6 +250,26 @@ def ermrest_json_to_metadata(
     all_schemas = schema_dict.get("schemas", {})
     selected = list(all_schemas.keys()) if schemas is None else schemas
 
+    # Stash document-level metadata that has no SQLAlchemy
+    # equivalent (snaptime, per-schema annotations / ACLs) on
+    # ``MetaData.info`` so the write path can emit it back. Each
+    # selected ERMrest schema gets its own info bucket keyed by
+    # schema name.
+    metadata.info["snaptime"] = schema_dict.get("snaptime")
+    schema_meta: dict[str, dict[str, Any]] = {}
+    for schema_name in selected:
+        if schema_name not in all_schemas:
+            continue
+        schema = all_schemas[schema_name]
+        bucket: dict[str, Any] = {}
+        for key in ("annotations", "acls", "acl_bindings", "comment"):
+            if key in schema:
+                bucket[key] = schema[key]
+        if bucket:
+            schema_meta[schema_name] = bucket
+    if schema_meta:
+        metadata.info["schemas"] = schema_meta
+
     # We build the FK-target map up front so columns can be born
     # with their ForeignKey constraints attached. Attaching FKs
     # post-hoc (via ``column.foreign_keys.add(...)``) doesn't bind
@@ -327,6 +347,24 @@ def ermrest_json_to_metadata(
                 # ``nullok`` is preserved in ``info["nullok"]`` so
                 # round-trips through :func:`metadata_to_ermrest_json`
                 # carry the original constraint back out.
+                # ``info`` carries metadata the SQLAlchemy column
+                # type can't represent natively but which the
+                # ERMrest JSON round-trip needs:
+                # - ``nullok``: the catalog's authoritative
+                #   not-null flag (separate from the relaxed
+                #   ``nullable`` we use in the mirror; see
+                #   :func:`metadata_to_ermrest_json` for the
+                #   read-back logic).
+                # - ``annotations``, ``acls``, ``acl_bindings``:
+                #   ERMrest-specific column-level metadata.
+                #   Stashed here so consumers like
+                #   :meth:`Table.is_asset` (which looks for
+                #   ``tag.asset`` on the URL column) see them
+                #   after a json → metadata → json round-trip.
+                col_info: dict[str, Any] = {"nullok": nullok}
+                for key in ("annotations", "acls", "acl_bindings"):
+                    if key in col_def:
+                        col_info[key] = col_def[key]
                 col = SQLColumn(
                     col_def["name"],
                     sql_type_cls(),
@@ -335,12 +373,22 @@ def ermrest_json_to_metadata(
                     primary_key=is_pk,
                     default=col_def.get("default"),
                     comment=col_def.get("comment"),
-                    info={"nullok": nullok},
+                    info=col_info,
                 )
                 columns.append(col)
 
+            # Stash table-level annotations / ACLs on the SQLAlchemy
+            # ``Table.info`` so the write path can emit them.
+            table_info: dict[str, Any] = {}
+            for key in ("annotations", "acls", "acl_bindings", "comment"):
+                if key in table_def:
+                    table_info[key] = table_def[key]
             sql_table = SQLTable(
-                table_name, metadata, *columns, schema=schema_name
+                table_name,
+                metadata,
+                *columns,
+                schema=schema_name,
+                info=table_info,
             )
 
             # Non-RID unique constraints.
@@ -377,16 +425,21 @@ def metadata_to_ermrest_json(metadata: MetaData) -> dict[str, Any]:
     Returns:
         A JSON-serializable dict.
 
+    Annotations, ACLs, and comments round-trip when the metadata
+    came from :func:`ermrest_json_to_metadata`: that function
+    stashes those values on ``info`` (column-level on
+    ``col.info``, table-level on ``Table.info``, document- and
+    schema-level on ``MetaData.info``). Metadata built directly
+    via SQLAlchemy without going through the reader emits an
+    annotation-less, ACL-less JSON document — the same behavior
+    as before this support was added.
+
     Limitations:
-        - ``snaptime`` is set to ``None`` (constructive bags have no
-          source-catalog snapshot). Callers that want a real
-          snaptime stamp can post-process the dict.
-        - Annotations and ACLs are not propagated. SQLAlchemy
-          columns can carry ``info={...}`` but the mapping to
-          ERMrest annotations is application-specific; we keep this
-          function generic. Round-trippers needing annotations should
-          go through :func:`ermrest_model_to_metadata` instead
-          (live model preserves them) or post-process the output.
+        - ``snaptime`` defaults to ``None`` unless the source went
+          through :func:`ermrest_json_to_metadata` (which stashes
+          the source's snaptime on ``metadata.info``). Constructive
+          bags built directly via SQLAlchemy have no source
+          snapshot.
     """
     # Bucket tables by schema name.
     schemas: dict[str, dict[str, Any]] = {}
@@ -416,17 +469,23 @@ def metadata_to_ermrest_json(metadata: MetaData) -> dict[str, Any]:
                 nullok = bool(col.info["nullok"])
             else:
                 nullok = bool(col.nullable)
-            column_definitions.append(
-                {
-                    "name": col.name,
-                    "type": {
-                        "typename": sql_type_to_ermrest_name(col.type),
-                    },
-                    "nullok": nullok,
-                    "default": _serialize_default(col),
-                    "comment": col.comment,
-                }
-            )
+            col_doc: dict[str, Any] = {
+                "name": col.name,
+                "type": {
+                    "typename": sql_type_to_ermrest_name(col.type),
+                },
+                "nullok": nullok,
+                "default": _serialize_default(col),
+                "comment": col.comment,
+            }
+            # Propagate ERMrest-specific metadata stashed by the
+            # reader (annotations, ACLs, ACL bindings). Missing
+            # keys mean the metadata didn't come through the
+            # reader and there's nothing to emit.
+            for key in ("annotations", "acls", "acl_bindings"):
+                if col.info and key in col.info:
+                    col_doc[key] = col.info[key]
+            column_definitions.append(col_doc)
 
         keys: list[dict[str, Any]] = []
         # Primary key (typically RID).
@@ -482,7 +541,7 @@ def metadata_to_ermrest_json(metadata: MetaData) -> dict[str, Any]:
                     }
                 )
 
-        schemas[schema_name]["tables"][sql_table.name] = {
+        table_doc: dict[str, Any] = {
             "schema_name": schema_name,
             "table_name": sql_table.name,
             # ERMrest's Model parser expects ``kind`` to identify
@@ -497,11 +556,27 @@ def metadata_to_ermrest_json(metadata: MetaData) -> dict[str, Any]:
             "keys": keys,
             "foreign_keys": foreign_keys,
         }
+        # Propagate table-level ERMrest metadata stashed by the
+        # reader. Missing keys mean the table didn't come through
+        # the reader (or the source doc didn't carry them).
+        for key in ("annotations", "acls", "acl_bindings", "comment"):
+            if sql_table.info and key in sql_table.info:
+                table_doc[key] = sql_table.info[key]
+        schemas[schema_name]["tables"][sql_table.name] = table_doc
+
+    # Stamp per-schema metadata (annotations, ACLs, comment) that the
+    # reader stashed on ``metadata.info["schemas"][schema_name]``.
+    schema_meta = (metadata.info or {}).get("schemas", {})
+    for schema_name, bucket in schema_meta.items():
+        if schema_name in schemas:
+            for key, value in bucket.items():
+                schemas[schema_name][key] = value
 
     return {
-        # No source catalog → no real snaptime. Callers that built a
-        # bag from a live catalog can overwrite this.
-        "snaptime": None,
+        # If the metadata went through ``ermrest_json_to_metadata``,
+        # the source's snaptime is on ``metadata.info``; otherwise
+        # None for constructive bags.
+        "snaptime": (metadata.info or {}).get("snaptime"),
         "schemas": schemas,
     }
 

--- a/tests/deriva/bag/test_schema_io.py
+++ b/tests/deriva/bag/test_schema_io.py
@@ -302,6 +302,73 @@ def test_ermrest_json_to_metadata_preserves_column_annotations() -> None:
     assert "annotations" not in cols["RID"].info
 
 
+def test_ermrest_json_to_metadata_roundtrip_preserves_int8() -> None:
+    """``int8`` round-trips losslessly via the stashed ERMrest typename.
+
+    Multiple ERMrest types map to one SQLAlchemy type
+    (``int2``/``int4``/``int8`` all map to ``StringToInteger``),
+    so a naive write path would round-trip them all as ``int4``.
+    :meth:`Table.is_asset` exact-matches ``int8`` for the
+    ``Length`` column — losing the distinction mis-classifies
+    asset tables.
+    """
+    from deriva.bag.schema_io import metadata_to_ermrest_json
+
+    doc = {
+        "snaptime": "2026-01-01T00:00:00",
+        "schemas": {
+            "demo": {
+                "schema_name": "demo",
+                "tables": {
+                    "T": {
+                        "schema_name": "demo",
+                        "table_name": "T",
+                        "kind": "table",
+                        "column_definitions": [
+                            {
+                                "name": "RID",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "Length",
+                                "type": {"typename": "int8"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "Small",
+                                "type": {"typename": "int2"},
+                                "nullok": True,
+                                "default": None,
+                                "comment": None,
+                            },
+                        ],
+                        "keys": [
+                            {
+                                "names": [["demo", "T_RID_key"]],
+                                "unique_columns": ["RID"],
+                            }
+                        ],
+                        "foreign_keys": [],
+                    }
+                },
+            }
+        },
+    }
+    md = ermrest_json_to_metadata(doc)
+    out = metadata_to_ermrest_json(md)
+    out_cols = {
+        c["name"]: c
+        for c in out["schemas"]["demo"]["tables"]["T"]["column_definitions"]
+    }
+    assert out_cols["Length"]["type"]["typename"] == "int8"
+    assert out_cols["Small"]["type"]["typename"] == "int2"
+
+
 def test_ermrest_json_to_metadata_roundtrip_preserves_annotations() -> None:
     """A json → metadata → json round-trip preserves column annotations.
 

--- a/tests/deriva/bag/test_schema_io.py
+++ b/tests/deriva/bag/test_schema_io.py
@@ -243,6 +243,136 @@ def test_ermrest_json_to_metadata_relaxes_non_pk_not_null() -> None:
     assert cols["Name"].info["nullok"] is True
 
 
+def test_ermrest_json_to_metadata_preserves_column_annotations() -> None:
+    """Column-level ERMrest annotations land on ``col.info["annotations"]``.
+
+    The bag's downstream consumers (e.g.
+    :meth:`Table.is_asset`) rely on column annotations like
+    ``tag.asset`` to recognize asset tables. Without preserving
+    annotations through the json → metadata path, every
+    round-tripped schema doc loses those tags and asset tables
+    look like ordinary content tables.
+    """
+    asset_tag = "tag:isrd.isi.edu,2017:asset"
+    doc = {
+        "snaptime": "2026-01-01T00:00:00",
+        "schemas": {
+            "demo": {
+                "schema_name": "demo",
+                "tables": {
+                    "Image": {
+                        "schema_name": "demo",
+                        "table_name": "Image",
+                        "kind": "table",
+                        "column_definitions": [
+                            {
+                                "name": "RID",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "URL",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": "Asset URL",
+                                "annotations": {asset_tag: {}},
+                            },
+                        ],
+                        "keys": [
+                            {
+                                "names": [["demo", "Image_RID_key"]],
+                                "unique_columns": ["RID"],
+                            }
+                        ],
+                        "foreign_keys": [],
+                    }
+                },
+            }
+        },
+    }
+    md = ermrest_json_to_metadata(doc)
+    cols = {c.name: c for c in md.tables["demo.Image"].columns}
+    # URL column carries the tag.asset annotation in its info.
+    assert cols["URL"].info["annotations"] == {asset_tag: {}}
+    # Column without an ``annotations`` key in the source has no
+    # annotations in info either.
+    assert "annotations" not in cols["RID"].info
+
+
+def test_ermrest_json_to_metadata_roundtrip_preserves_annotations() -> None:
+    """A json → metadata → json round-trip preserves column annotations.
+
+    The downstream model parser (``Model.fromfile``) needs the
+    annotations to be present in the document to populate
+    ``column.annotations``. Without this round-trip, asset
+    columns in a constructed bag's schema.json wouldn't carry
+    ``tag.asset`` and consumers would miscategorize the table.
+    """
+    from deriva.bag.schema_io import metadata_to_ermrest_json
+
+    asset_tag = "tag:isrd.isi.edu,2017:asset"
+    doc = {
+        "snaptime": "2026-01-01T00:00:00",
+        "schemas": {
+            "demo": {
+                "schema_name": "demo",
+                "annotations": {"tag:demo,2026:purpose": "test"},
+                "tables": {
+                    "Image": {
+                        "schema_name": "demo",
+                        "table_name": "Image",
+                        "kind": "table",
+                        "annotations": {"tag:demo,2026:role": "asset"},
+                        "column_definitions": [
+                            {
+                                "name": "RID",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "URL",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": "Asset URL",
+                                "annotations": {asset_tag: {}},
+                            },
+                        ],
+                        "keys": [
+                            {
+                                "names": [["demo", "Image_RID_key"]],
+                                "unique_columns": ["RID"],
+                            }
+                        ],
+                        "foreign_keys": [],
+                    }
+                },
+            }
+        },
+    }
+    md = ermrest_json_to_metadata(doc)
+    out = metadata_to_ermrest_json(md)
+    # snaptime preserved.
+    assert out["snaptime"] == "2026-01-01T00:00:00"
+    # Schema-level annotation preserved.
+    assert out["schemas"]["demo"]["annotations"] == {
+        "tag:demo,2026:purpose": "test"
+    }
+    # Table-level annotation preserved.
+    out_image = out["schemas"]["demo"]["tables"]["Image"]
+    assert out_image["annotations"] == {"tag:demo,2026:role": "asset"}
+    # Column-level annotation preserved.
+    out_cols = {c["name"]: c for c in out_image["column_definitions"]}
+    assert out_cols["URL"]["annotations"] == {asset_tag: {}}
+    # Column without source annotations doesn't get an empty dict.
+    assert "annotations" not in out_cols["RID"]
+
+
 def test_ermrest_json_to_metadata_roundtrip_preserves_nullok() -> None:
     """``metadata_to_ermrest_json`` reads ``nullok`` from ``col.info``.
 


### PR DESCRIPTION
## Summary

ERMrest's ``int2``, ``int4``, and ``int8`` all map to one SQLAlchemy column type (``StringToInteger``), so a naive ``metadata_to_ermrest_json`` emits ``int4`` for any of them. ``int8`` becomes ``int4`` and the distinction is lost.

### How I found this

After #238 landed the bag's ``schema.json`` carried the ``tag.asset`` annotation correctly, but the bag-based ``commit_execution`` POC still saw ``_upload_assets`` skip. Trace: ``Table.is_asset()`` exact-matches ``int8`` for the ``Length`` column. After a json → metadata → json round-trip, ``Length`` came out as ``int4``, ``is_asset`` returned False.

### Fix

Stash the original ERMrest typename on ``col.info["ermrest_typename"]`` at read time; prefer it at write time. Falls back to the existing ``sql_type_to_ermrest_name`` for callers that built metadata directly (no info stash).

### Backward compat

Default callers (no info stash) see exactly the previous behavior. Round-trippers through ``ermrest_json_to_metadata`` get type fidelity.

## Test plan

- [x] ``uv run pytest tests/deriva/bag/`` — 247 passed, 2 skipped (was 246 / 2 before, +1 new)
- [x] ``test_ermrest_json_to_metadata_roundtrip_preserves_int8`` — pins ``int8`` and ``int2`` round-trip correctly (not downgraded to ``int4``)

🤖 Generated with [Claude Code](https://claude.com/claude-code)