### PR TITLE
fix(bag): schema_io preserves int2/int4/int8 distinction on round-trip

### DIFF
--- a/deriva/bag/schema_io.py
+++ b/deriva/bag/schema_io.py
@@ -355,13 +355,27 @@ def ermrest_json_to_metadata(
                 #   ``nullable`` we use in the mirror; see
                 #   :func:`metadata_to_ermrest_json` for the
                 #   read-back logic).
+                # - ``ermrest_typename``: the original ERMrest
+                #   typename. Several ERMrest types
+                #   (``int2``/``int4``/``int8`` → ``Integer``,
+                #   ``timestamptz`` and ``timestamp`` →
+                #   ``StringToDateTime``, etc.) map to one
+                #   SQLAlchemy type, so a metadata → json
+                #   round-trip without this stash would lose the
+                #   distinction. Consumers like
+                #   :meth:`Table.is_asset` exact-match the
+                #   typename, so ``int8`` rounded down to ``int4``
+                #   would mis-classify asset tables.
                 # - ``annotations``, ``acls``, ``acl_bindings``:
                 #   ERMrest-specific column-level metadata.
                 #   Stashed here so consumers like
                 #   :meth:`Table.is_asset` (which looks for
                 #   ``tag.asset`` on the URL column) see them
                 #   after a json → metadata → json round-trip.
-                col_info: dict[str, Any] = {"nullok": nullok}
+                col_info: dict[str, Any] = {
+                    "nullok": nullok,
+                    "ermrest_typename": ermrest_type,
+                }
                 for key in ("annotations", "acls", "acl_bindings"):
                     if key in col_def:
                         col_info[key] = col_def[key]
@@ -469,10 +483,19 @@ def metadata_to_ermrest_json(metadata: MetaData) -> dict[str, Any]:
                 nullok = bool(col.info["nullok"])
             else:
                 nullok = bool(col.nullable)
+            # Prefer the stashed ERMrest typename so a round-trip
+            # preserves the source's int2/int4/int8 distinction
+            # (and similar). Fall back to the SQLAlchemy → ERMrest
+            # mapping for callers that built the metadata
+            # directly (no info stash).
+            if col.info and "ermrest_typename" in col.info:
+                typename = col.info["ermrest_typename"]
+            else:
+                typename = sql_type_to_ermrest_name(col.type)
             col_doc: dict[str, Any] = {
                 "name": col.name,
                 "type": {
-                    "typename": sql_type_to_ermrest_name(col.type),
+                    "typename": typename,
                 },
                 "nullok": nullok,
                 "default": _serialize_default(col),

--- a/tests/deriva/bag/test_schema_io.py
+++ b/tests/deriva/bag/test_schema_io.py
@@ -302,6 +302,73 @@ def test_ermrest_json_to_metadata_preserves_column_annotations() -> None:
     assert "annotations" not in cols["RID"].info
 
 
+def test_ermrest_json_to_metadata_roundtrip_preserves_int8() -> None:
+    """``int8`` round-trips losslessly via the stashed ERMrest typename.
+
+    Multiple ERMrest types map to one SQLAlchemy type
+    (``int2``/``int4``/``int8`` all map to ``StringToInteger``),
+    so a naive write path would round-trip them all as ``int4``.
+    :meth:`Table.is_asset` exact-matches ``int8`` for the
+    ``Length`` column — losing the distinction mis-classifies
+    asset tables.
+    """
+    from deriva.bag.schema_io import metadata_to_ermrest_json
+
+    doc = {
+        "snaptime": "2026-01-01T00:00:00",
+        "schemas": {
+            "demo": {
+                "schema_name": "demo",
+                "tables": {
+                    "T": {
+                        "schema_name": "demo",
+                        "table_name": "T",
+                        "kind": "table",
+                        "column_definitions": [
+                            {
+                                "name": "RID",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "Length",
+                                "type": {"typename": "int8"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "Small",
+                                "type": {"typename": "int2"},
+                                "nullok": True,
+                                "default": None,
+                                "comment": None,
+                            },
+                        ],
+                        "keys": [
+                            {
+                                "names": [["demo", "T_RID_key"]],
+                                "unique_columns": ["RID"],
+                            }
+                        ],
+                        "foreign_keys": [],
+                    }
+                },
+            }
+        },
+    }
+    md = ermrest_json_to_metadata(doc)
+    out = metadata_to_ermrest_json(md)
+    out_cols = {
+        c["name"]: c
+        for c in out["schemas"]["demo"]["tables"]["T"]["column_definitions"]
+    }
+    assert out_cols["Length"]["type"]["typename"] == "int8"
+    assert out_cols["Small"]["type"]["typename"] == "int2"
+
+
 def test_ermrest_json_to_metadata_roundtrip_preserves_annotations() -> None:
     """A json → metadata → json round-trip preserves column annotations.
 


### PR DESCRIPTION
## Summary

ERMrest's ``int2``, ``int4``, and ``int8`` all map to one SQLAlchemy column type (``StringToInteger``), so a naive ``metadata_to_ermrest_json`` emits ``int4`` for any of them. ``int8`` becomes ``int4`` and the distinction is lost.

### How I found this

After #238 landed, the bag's ``schema.json`` carried the ``tag.asset`` annotation correctly, but the bag-based ``commit_execution`` POC still saw ``_upload_assets`` skip. Trace: ``Table.is_asset()`` exact-matches ``int8`` for the ``Length`` column. After a json → metadata → json round-trip, ``Length`` came out as ``int4``, ``is_asset`` returned False.

### Fix

Stash the original ERMrest typename on ``col.info["ermrest_typename"]`` at read time; prefer it at write time. Falls back to the existing ``sql_type_to_ermrest_name`` for callers that built metadata directly (no info stash).

### Backward compat

Default callers (no info stash) see exactly the previous behavior. Round-trippers through ``ermrest_json_to_metadata`` get type fidelity.

This PR replaces #239 (which was based on a pre-#238 HEAD and showed phantom conflicts after #238 squash-merged with a different hash). Same content, fresh cherry-pick onto current deriva-ml.

## Test plan

- [x] ``uv run pytest tests/deriva/bag/`` — 247 passed, 2 skipped (was 246 / 2 before, +1 new)
- [x] ``test_ermrest_json_to_metadata_roundtrip_preserves_int8`` — pins ``int8`` and ``int2`` round-trip correctly (not downgraded to ``int4``)

🤖 Generated with [Claude Code](https://claude.com/claude-code)