### PR TITLE
feat(bag): BagCatalogLoader.run() handles notebook event loops

### DIFF
--- a/deriva/bag/catalog_loader.py
+++ b/deriva/bag/catalog_loader.py
@@ -292,10 +292,35 @@ class BagCatalogLoader:
     def run(self) -> LoadReport:
         """Synchronously load the bag and return the :class:`LoadReport`.
 
-        Thin wrapper around :meth:`arun`. Callers in already-async
-        contexts should call ``arun`` directly to avoid the
-        nested-loop overhead.
+        Thin wrapper around :meth:`arun`. Detects whether the caller
+        is already inside a running event loop — that's the common
+        case in Jupyter/papermill kernels, where the kernel itself
+        owns the main-thread loop — and re-enters it via
+        :mod:`nest_asyncio`. Outside a loop, falls back to
+        :func:`asyncio.run`.
+
+        Callers in already-async contexts should call :meth:`arun`
+        directly to avoid the nested-loop overhead.
+
+        Raises:
+            ImportError: only when running inside a notebook kernel
+                **and** :mod:`nest_asyncio` is not installed.
+                ``nest_asyncio`` is a runtime soft dependency — the
+                bag-loader is import-safe without it; the cost only
+                appears for in-notebook callers.
         """
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if loop and loop.is_running():
+            # Notebook context: re-enter the active loop.
+            # ``nest_asyncio`` is imported lazily so the module
+            # stays importable without it.
+            import nest_asyncio
+
+            nest_asyncio.apply()
+            return loop.run_until_complete(self.arun())
         return asyncio.run(self.arun())
 
     async def arun(self) -> LoadReport:

--- a/tests/deriva/bag/test_catalog_loader.py
+++ b/tests/deriva/bag/test_catalog_loader.py
@@ -1681,3 +1681,100 @@ def test_loader_defers_cycle_fks_and_patches_in_second_pass(
         # deferred column.
         for row in call["json"]:
             assert "RID" in row
+
+
+# =============================================================================
+# run() entry-point — notebook-loop fallback
+# =============================================================================
+#
+# BagCatalogLoader.run() bridges the async arun() pipeline into
+# sync callers. When invoked from inside an already-running event
+# loop (Jupyter / papermill kernels), bare asyncio.run() raises
+# "cannot be called from a running event loop". The fallback uses
+# nest_asyncio to re-enter the active loop.
+#
+# Both code paths are exercised below. The tests stub arun() to a
+# trivial coroutine so the run-time logic stays focused on the
+# scheduling shim, not the load pipeline.
+
+
+def test_run_outside_event_loop_uses_asyncio_run(tmp_path: Path) -> None:
+    """``run()`` from a plain sync caller drives ``arun`` to completion.
+
+    The pre-fallback behaviour. Verifies the no-loop path still
+    works after the nest_asyncio addition.
+    """
+    import asyncio as _asyncio
+
+    bag = _build_fk_bag(tmp_path)
+    catalog = _mock_catalog()
+    loader = BagCatalogLoader(
+        catalog=catalog,
+        bag=bag,
+        policy=FKTraversalPolicy(asset_mode=AssetMode.ROWS_ONLY),
+        database_dir=tmp_path / "db",
+    )
+
+    sentinel = LoadReport(bag_path=bag, catalog_id="42")
+
+    async def _fake_arun() -> LoadReport:
+        return sentinel
+
+    try:
+        # Sanity: no loop is running at this point.
+        with pytest.raises(RuntimeError):
+            _asyncio.get_running_loop()
+        loader.arun = _fake_arun  # type: ignore[method-assign]
+        result = loader.run()
+    finally:
+        loader.dispose()
+
+    assert result is sentinel
+
+
+def test_run_inside_event_loop_uses_nest_asyncio(tmp_path: Path) -> None:
+    """``run()`` from inside a running loop re-enters via ``nest_asyncio``.
+
+    Drive the loader's ``run()`` from inside an ``async def``
+    function so a loop is active. Without the fallback this
+    would raise ``RuntimeError: asyncio.run() cannot be called
+    from a running event loop``.
+
+    ``nest_asyncio`` is a soft dependency of deriva-py — only
+    notebook callers need it, the bag module itself is import-safe
+    without it. Skip cleanly when the test environment doesn't
+    have it installed.
+    """
+    pytest.importorskip(
+        "nest_asyncio",
+        reason="soft dep; only notebook callers need it",
+    )
+    import asyncio as _asyncio
+
+    bag = _build_fk_bag(tmp_path)
+    catalog = _mock_catalog()
+    loader = BagCatalogLoader(
+        catalog=catalog,
+        bag=bag,
+        policy=FKTraversalPolicy(asset_mode=AssetMode.ROWS_ONLY),
+        database_dir=tmp_path / "db",
+    )
+
+    sentinel = LoadReport(bag_path=bag, catalog_id="42")
+
+    async def _fake_arun() -> LoadReport:
+        return sentinel
+
+    loader.arun = _fake_arun  # type: ignore[method-assign]
+
+    async def _from_inside_a_running_loop() -> LoadReport:
+        # ``loop.is_running()`` is True here; loader.run() must
+        # detect that and use nest_asyncio instead of asyncio.run.
+        return loader.run()
+
+    try:
+        result = _asyncio.run(_from_inside_a_running_loop())
+    finally:
+        loader.dispose()
+
+    assert result is sentinel


### PR DESCRIPTION
## Summary

- ``run()`` is the sync entry point into ``BagCatalogLoader``. The previous one-line ``return asyncio.run(self.arun())`` raised ``RuntimeError: asyncio.run() cannot be called from a running event loop`` when invoked from Jupyter / papermill kernels (the kernel owns the main-thread loop). Sync callers had to wrap ``arun`` themselves with ``nest_asyncio`` + loop detection.
- Now ``run()`` does the loop detection itself: outside a loop, plain ``asyncio.run`` (unchanged); inside a loop, ``nest_asyncio.apply()`` + ``loop.run_until_complete``. ``nest_asyncio`` is imported lazily — the bag module stays import-safe without it; the cost only appears for in-notebook callers and is documented in the ``run()`` docstring.

This obsoletes a helper in deriva-ml that does the same dance manually. Filed as part of an audit-driven series of upstream fixes that came out of [deriva-ml#104](https://github.com/informatics-isi-edu/deriva-ml/pull/104).

## Test plan

- [x] ``test_run_outside_event_loop_uses_asyncio_run`` — plain sync caller; ``arun`` stubbed to a coroutine returning a sentinel ``LoadReport``; verifies ``run()`` returns it. Confirms the no-loop path is unchanged.
- [x] ``test_run_inside_event_loop_uses_nest_asyncio`` — drives ``run()`` from inside ``async def`` so ``loop.is_running()`` is True; verifies the sentinel comes back. Skips when ``nest_asyncio`` isn't installed (it's a soft dep, same pattern as the rest of the bag module's runtime imports).
- [x] Full ``test_catalog_loader.py`` suite — 45/45 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)