### PR TITLE
feat(bag): hatrac_url_for helper for canonical asset URLs

### DIFF
--- a/deriva/bag/builder.py
+++ b/deriva/bag/builder.py
@@ -104,6 +104,45 @@ def _file_md5(path: Path, chunk_size: int = 1024 * 1024) -> str:
     return md5.hexdigest()
 
 
+def hatrac_url_for(table: str, md5: str, filename: str) -> str:
+    """Build the canonical hatrac URL for an asset row.
+
+    The convention — ``/hatrac/{table}/{md5}.{filename}`` — is
+    implicit but fixed across deriva-py's upload pipeline and
+    deriva-ml's bag-commit path. Callers that need to write a
+    consistent ``URL`` column for an asset row (so the loader's
+    later HEAD/PUT against Hatrac targets the right object)
+    previously hand-rolled this f-string. This helper centralises
+    the convention so a future tweak (e.g. URI-encoding the
+    filename, or adding a hostname prefix) happens in one place.
+
+    The path mirrors the default ``hatrac_uri`` template used by
+    :class:`~deriva.transfer.upload.deriva_upload.GenericUploader`
+    via the upload-spec dict: ``/hatrac/{TableName}/{md5}.{filename}``.
+
+    Args:
+        table: Asset-table name (without schema prefix). The
+            convention puts each asset table's bytes under its own
+            hatrac namespace.
+        md5: Lowercase hex MD5 of the file bytes. Used as the
+            content-addressed object name, so dedup works
+            server-side (different rows pointing at the same
+            bytes share the URL).
+        filename: The original file name. Preserved as a suffix on
+            the hatrac object so a content-disposition header can
+            reconstruct it on download.
+
+    Returns:
+        The unversioned hatrac path, leading slash included.
+        Suitable for writing into an asset row's ``URL`` column.
+
+    Example:
+        >>> hatrac_url_for("Image", "abc123", "scan.png")
+        '/hatrac/Image/abc123.scan.png'
+    """
+    return f"/hatrac/{table}/{md5}.{filename}"
+
+
 class BagBuilder:
     """Build a deriva-bag profile bag from in-memory inputs.
 

--- a/tests/deriva/bag/test_builder.py
+++ b/tests/deriva/bag/test_builder.py
@@ -574,3 +574,47 @@ def test_builder_finalize_make_bdbag_preserves_data_layout(
     assert (out / "bagit.txt").is_file()
     assert (out / "bag-info.txt").is_file()
     assert (out / "manifest-md5.txt").is_file()
+
+
+# =============================================================================
+# hatrac_url_for — canonical asset URL builder
+# =============================================================================
+
+
+def test_hatrac_url_for_canonical_shape():
+    """The helper produces ``/hatrac/{table}/{md5}.{filename}``.
+
+    This is the convention the upload pipeline + bag-commit path
+    both follow when writing an asset row's ``URL`` column.
+    """
+    from deriva.bag.builder import hatrac_url_for
+
+    url = hatrac_url_for("Image", "abc123", "scan.png")
+    assert url == "/hatrac/Image/abc123.scan.png"
+
+
+def test_hatrac_url_for_preserves_filename_dots():
+    """Filenames with multiple dots (e.g. ``uv.lock``) round-trip cleanly.
+
+    The convention puts the MD5 first and the filename second,
+    joined by ``.``. A filename like ``uv.lock`` has its own
+    internal dot — the helper must preserve it so the upload's
+    content-disposition reconstructs the original name.
+    """
+    from deriva.bag.builder import hatrac_url_for
+
+    url = hatrac_url_for("Execution_Metadata", "deadbeef", "uv.lock")
+    assert url == "/hatrac/Execution_Metadata/deadbeef.uv.lock"
+
+
+def test_hatrac_url_for_table_with_underscores():
+    """Asset-table names with underscores aren't quoted/escaped.
+
+    The path is built positionally; no URL-encoding is applied to
+    the table name. Tables named ``Execution_Asset``, ``Image_File``
+    etc. should pass through unchanged.
+    """
+    from deriva.bag.builder import hatrac_url_for
+
+    url = hatrac_url_for("Execution_Asset", "abc", "f.txt")
+    assert url == "/hatrac/Execution_Asset/abc.f.txt"


### PR DESCRIPTION
## Summary

The convention ``/hatrac/{table}/{md5}.{filename}`` is implicit but fixed across deriva-py's upload pipeline and deriva-ml's bag-commit path. Multiple callers — the per-execution bag commit, the localization fallback, the upload-spec defaults — currently hand-roll the same f-string. This PR promotes it to a public ``hatrac_url_for(table, md5, filename)`` in ``deriva.bag.builder`` so a future tweak (URI-encoding, hostname prefix, scheme switch) happens in one place.

The shape mirrors the default ``hatrac_uri`` template used by ``GenericUploader`` via the upload-spec dict.

Companion to [#241](https://github.com/informatics-isi-edu/deriva-py/pull/241) (loader nest_asyncio fallback) and [#242](https://github.com/informatics-isi-edu/deriva-py/pull/242) (datapath ``_ColumnWrapper.in_``) — same audit-driven series following [deriva-ml#104](https://github.com/informatics-isi-edu/deriva-ml/pull/104).

## Test plan

- [x] ``test_hatrac_url_for_canonical_shape`` — basic table/md5/filename.
- [x] ``test_hatrac_url_for_preserves_filename_dots`` — ``uv.lock`` and similar dotted names round-trip cleanly. The convention puts MD5 first, filename second, joined by ``.``, and filenames with their own internal dots must pass through unchanged so the upload's content-disposition reconstructs the original name.
- [x] ``test_hatrac_url_for_table_with_underscores`` — asset-table names like ``Execution_Asset`` don't get URL-encoded.

All 3 new tests pass. Full ``test_builder.py`` suite: 32 pass, 1 skipped (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)