### PR TITLE
feat(bag): FKTraversalPolicy.match_by_columns

### DIFF
--- a/deriva/bag/catalog_loader.py
+++ b/deriva/bag/catalog_loader.py
@@ -64,7 +64,7 @@ class _TableClass(StrEnum):
     """How :class:`BagCatalogLoader` should treat each in-scope table.
 
     Determined at the start of the load by :meth:`_classify_table`
-    from the bag's schema model:
+    from the bag's schema model and the active policy:
 
     - ``VOCABULARY``: table looks like a controlled vocabulary
       (has the canonical ``ID``/``URI``/``Name``/``Description``/
@@ -73,14 +73,28 @@ class _TableClass(StrEnum):
       Reconciled by ``Name`` against the destination; existing rows
       contribute a source-RID → destination-RID entry to the
       loader's remap so child rows can be rewritten.
+    - ``MATCH_BY_COLUMNS``: table is listed in
+      :attr:`FKTraversalPolicy.match_by_columns`. Reconciled by
+      the supplied column list (e.g. ``["URL"]`` for content-
+      addressed asset tables); same remap-and-rewrite shape as
+      vocab, just driven by a caller-supplied key instead of the
+      hard-coded ``Name``.
     - ``CONTENT``: every other in-scope table. Inserted by RID;
       collisions resolved per ``policy.content_on_conflict``.
+
+    ``match_by_columns`` takes precedence over the vocabulary
+    structural check: explicit caller intent overrides implicit
+    structural classification. (A table satisfying
+    ``is_vocabulary()`` is rarely in ``match_by_columns`` anyway —
+    if the caller bothered to name custom match columns, they
+    almost certainly mean to use them.)
 
     System schemas and out-of-bag schemas are filtered out earlier
     (by :meth:`_table_in_scope`) and never reach the classifier.
     """
 
     VOCABULARY = "vocabulary"
+    MATCH_BY_COLUMNS = "match_by_columns"
     CONTENT = "content"
 
 logger = logging.getLogger(__name__)
@@ -122,6 +136,15 @@ class TableLoadStats:
     (matched by ``Name``); the bag's source RID was remapped to the
     destination's RID for any child rows that reference it.
     Always zero for non-vocabulary tables."""
+
+    rows_matched_by_columns: int = 0
+    """Rows reconciled via
+    :attr:`FKTraversalPolicy.match_by_columns` — i.e., a row in the
+    bag whose match-column values already exist on the destination.
+    Same remap-and-rewrite semantics as ``rows_matched_by_name``,
+    driven by a caller-supplied unique key instead of the hard-coded
+    ``Name``. Always zero for tables not listed in
+    ``match_by_columns``."""
 
     rows_skipped_on_conflict: int = 0
     """Content rows whose RID already existed on the destination,
@@ -488,13 +511,20 @@ class BagCatalogLoader:
     def _classify_table(self, table: DerivaTable) -> _TableClass:
         """Decide whether a table is reconciled by name or by RID.
 
-        See :class:`_TableClass` for the policy. Vocabulary detection
-        delegates to
-        :meth:`deriva.core.ermrest_model.Table.is_vocabulary`, which
-        checks for the canonical vocab column shape (``ID``/``URI``/
-        ``Name``/``Description``/``Synonyms``). Everything else is
-        ``CONTENT``.
+        See :class:`_TableClass` for the policy. Order:
+
+        1. **``match_by_columns``** — explicit caller intent.
+           A ``(schema, table)`` key in the policy dict overrides
+           the structural vocabulary check.
+        2. **Vocabulary structural check** —
+           :meth:`deriva.core.ermrest_model.Table.is_vocabulary`
+           checks for the canonical vocab column shape
+           (``ID``/``URI``/``Name``/``Description``/``Synonyms``).
+        3. **Content** — every other in-scope table.
         """
+        key = (table.schema.name, table.name)
+        if key in self.policy.match_by_columns:
+            return _TableClass.MATCH_BY_COLUMNS
         if table.is_vocabulary():
             return _TableClass.VOCABULARY
         return _TableClass.CONTENT
@@ -549,8 +579,11 @@ class BagCatalogLoader:
         if not rows:
             return stats
 
-        if self._classify_table(table) == _TableClass.VOCABULARY:
+        table_class = self._classify_table(table)
+        if table_class == _TableClass.VOCABULARY:
             await self._load_vocabulary_table(table, rows, stats)
+        elif table_class == _TableClass.MATCH_BY_COLUMNS:
+            await self._load_match_by_columns_table(table, rows, stats)
         else:
             await self._load_content_table(table, rows, stats)
 
@@ -649,6 +682,111 @@ class BagCatalogLoader:
 
         rows = await asyncio.to_thread(_do_get)
         return {row["Name"]: row["RID"] for row in rows if row.get("Name")}
+
+    # ------------------------------------------------------------------
+    # Match-by-columns path (caller-supplied unique key + RID remap)
+    # ------------------------------------------------------------------
+
+    async def _load_match_by_columns_table(
+        self,
+        table: DerivaTable,
+        rows: list[dict[str, Any]],
+        stats: TableLoadStats,
+    ) -> None:
+        """Reconcile a table by the caller-supplied match columns.
+
+        Same shape as :meth:`_load_vocabulary_table` but parameterized
+        by the column list from
+        :attr:`FKTraversalPolicy.match_by_columns`. For each bag row:
+
+        - Compute the row's composite key from the named columns.
+        - If the destination has a row with the same composite key,
+          record ``src_rid → dst_rid`` in the loader's remap so
+          child rows that FK-reference this row get rewritten at
+          insert time. The bag row is **not** inserted.
+        - Otherwise, insert the bag row and record an identity
+          remap entry.
+
+        Rows whose match-key has any ``None`` component fall
+        through to the insert path — composite NULL semantics are
+        ambiguous and we don't want to silently match e.g. two
+        ``(NULL, NULL)`` rows as the same logical entity.
+        """
+        schema_name = table.schema.name
+        key = (schema_name, table.name)
+        match_cols = self.policy.match_by_columns[key]
+
+        existing_by_key = await self._fetch_existing_by_columns(
+            schema_name, table.name, match_cols
+        )
+
+        new_rows: list[dict[str, Any]] = []
+        remap = self._rid_remap.setdefault(key, {})
+        for row in rows:
+            src_rid = row.get("RID")
+            match_key = tuple(row.get(col) for col in match_cols)
+            if src_rid is None or any(v is None for v in match_key):
+                # Either no RID (defensive — should not happen for
+                # an in-scope bag row) or one of the match columns
+                # is NULL. Either way, don't try to match; insert
+                # as new and let any uniqueness constraint at the
+                # destination surface its own error.
+                new_rows.append(row)
+                continue
+            dst_rid = existing_by_key.get(match_key)
+            if dst_rid is not None:
+                remap[src_rid] = dst_rid
+                stats.rows_matched_by_columns += 1
+            else:
+                # Identity remap — same rationale as vocab: the
+                # insert preserves the RID, so child rows still
+                # find it via the remap.
+                remap[src_rid] = src_rid
+                new_rows.append(row)
+
+        if new_rows:
+            inserted = await self._insert_rows(table, new_rows)
+            stats.rows_inserted = inserted
+
+    async def _fetch_existing_by_columns(
+        self,
+        schema_name: str,
+        table_name: str,
+        match_cols: list[str],
+    ) -> dict[tuple[Any, ...], str]:
+        """Return ``{(col1_value, col2_value, ...): RID}`` for all rows.
+
+        One GET to ``/attributegroup/{schema}:{table}/<cols>;RID``
+        covers the whole table. For asset tables, the match
+        columns are typically a single content-addressed key
+        (e.g. ``["URL"]``), so the result is small — same shape
+        and round-trip cost as the vocab fetch.
+
+        Rows whose match-key has any ``None`` component are
+        dropped from the result map; the caller's matching loop
+        already declines to match such rows, so including them
+        here would only invite collisions on ``(None, None, ...)``
+        bag rows.
+        """
+        cols_path = ",".join(match_cols)
+        path = (
+            f"/attributegroup/"
+            f"{schema_name}:{table_name}/{cols_path};RID"
+        )
+
+        def _do_get() -> list[dict[str, Any]]:
+            response = self.catalog.get(path)
+            response.raise_for_status()
+            return response.json()
+
+        rows = await asyncio.to_thread(_do_get)
+        result: dict[tuple[Any, ...], str] = {}
+        for row in rows:
+            key = tuple(row.get(col) for col in match_cols)
+            if any(v is None for v in key):
+                continue
+            result[key] = row["RID"]
+        return result
 
     # ------------------------------------------------------------------
     # Content path (RID-stable + conflict policy)

--- a/deriva/bag/traversal.py
+++ b/deriva/bag/traversal.py
@@ -232,7 +232,29 @@ class FKTraversalPolicy(BaseModel):
             on **content** tables (non-vocabulary, non-system).
             See :class:`ContentConflictStrategy`. Default ``FAIL``.
             Vocabulary tables use match-by-name regardless of this
-            setting.
+            setting; tables listed in :attr:`match_by_columns` use
+            match-by-supplied-columns regardless of this setting.
+        match_by_columns: Per-table caller-supplied "reconcile by
+            these columns" rule. Maps ``(schema_name, table_name)``
+            to a list of column names that uniquely identify a row
+            on the destination. For each bag row in such a table,
+            the loader queries the destination by those columns;
+            if a match is found, the bag row is **not** inserted
+            and the source RID is remapped to the destination's
+            RID (so child rows that FK-reference it get rewritten
+            to the destination's RID at insert time). If no match,
+            the bag row is inserted normally and an identity remap
+            entry is recorded.
+
+            This generalises the vocabulary match-by-``Name``
+            behaviour to non-vocabulary tables that nevertheless
+            have a content-addressed unique key (e.g. asset tables
+            whose ``URL`` is hash-derived and stable across
+            executions). Empty dict (default) leaves all
+            non-vocabulary tables on the standard content path.
+
+            Empty column lists are rejected at validation time —
+            a table either has a match rule or it doesn't.
         preserve_provenance: Whether to preserve the bag's source
             audit columns (``RCT`` creation time, ``RCB`` creating
             user) at insert time. ``True`` (default) sends the bag
@@ -283,6 +305,9 @@ class FKTraversalPolicy(BaseModel):
     asset_mode: AssetMode = AssetMode.UPLOAD_IF_MISSING
     dangling_fk_strategy: DanglingFKStrategy = DanglingFKStrategy.FAIL
     content_on_conflict: ContentConflictStrategy = ContentConflictStrategy.FAIL
+    match_by_columns: dict[tuple[str, str], list[str]] = Field(
+        default_factory=dict
+    )
     preserve_provenance: bool = True
 
     @field_validator("max_depth")
@@ -294,6 +319,23 @@ class FKTraversalPolicy(BaseModel):
             raise ValueError(
                 "max_depth must be a non-negative integer or None"
             )
+        return v
+
+    @field_validator("match_by_columns")
+    @classmethod
+    def _match_by_columns_non_empty(
+        cls,
+        v: dict[tuple[str, str], list[str]],
+    ) -> dict[tuple[str, str], list[str]]:
+        # An empty column list for a table means "match by nothing",
+        # which is meaningless — every existing row would match.
+        # Make the caller delete the entry instead.
+        for key, cols in v.items():
+            if not cols:
+                raise ValueError(
+                    f"match_by_columns[{key!r}] is empty; drop the "
+                    f"entry rather than supply an empty column list."
+                )
         return v
 
     def validate_with_bag_state(self, *, holey: bool) -> None:

--- a/tests/deriva/bag/test_catalog_loader.py
+++ b/tests/deriva/bag/test_catalog_loader.py
@@ -1778,3 +1778,399 @@ def test_run_inside_event_loop_uses_nest_asyncio(tmp_path: Path) -> None:
         loader.dispose()
 
     assert result is sentinel
+
+
+# =============================================================================
+# match_by_columns — caller-supplied unique-key reconciliation
+# =============================================================================
+#
+# Generalises the vocab match-by-Name path to non-vocabulary
+# tables that nevertheless have a content-addressed unique key
+# (e.g. asset tables whose ``URL`` is hash-derived and stable
+# across executions). The classifier routes such tables through
+# a parallel ``_load_match_by_columns_table`` whose remap shape
+# matches the vocab path's exactly, so child FK rewriting via
+# ``_rewrite_fks`` works without further changes.
+
+
+def _build_image_widget_bag(tmp_path: Path) -> Path:
+    """Build a bag with one asset-like table + one content table.
+
+    Shapes:
+
+    * ``demo.Image`` — non-vocab table with a content-addressed
+      ``URL`` column. Used to exercise ``match_by_columns``.
+    * ``demo.Widget`` — content table with a single-column FK to
+      ``demo.Image`` for the RID-remap propagation check.
+
+    Differs from ``_build_vocab_bag`` in that neither table has
+    the canonical vocab columns; the classifier would route them
+    both as ``CONTENT`` without an explicit ``match_by_columns``
+    policy.
+    """
+    cache_key = "image_widget_bag"
+    bag = tmp_path / cache_key / "bag"
+    (bag / "data" / "demo").mkdir(parents=True)
+
+    doc = {
+        "snaptime": "2026-01-01T00:00:00",
+        "schemas": {
+            "demo": {
+                "schema_name": "demo",
+                "tables": {
+                    "Image": {
+                        "schema_name": "demo",
+                        "table_name": "Image",
+                        "kind": "table",
+                        "column_definitions": [
+                            {
+                                "name": "RID",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "URL",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "Filename",
+                                "type": {"typename": "text"},
+                                "nullok": True,
+                                "default": None,
+                                "comment": None,
+                            },
+                        ],
+                        "keys": [
+                            {
+                                "names": [["demo", "Image_RID_key"]],
+                                "unique_columns": ["RID"],
+                            },
+                            {
+                                "names": [["demo", "Image_URL_key"]],
+                                "unique_columns": ["URL"],
+                            },
+                        ],
+                        "foreign_keys": [],
+                    },
+                    "Widget": {
+                        "schema_name": "demo",
+                        "table_name": "Widget",
+                        "kind": "table",
+                        "column_definitions": [
+                            {
+                                "name": "RID",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "Image",
+                                "type": {"typename": "text"},
+                                "nullok": True,
+                                "default": None,
+                                "comment": None,
+                            },
+                        ],
+                        "keys": [
+                            {
+                                "names": [["demo", "Widget_RID_key"]],
+                                "unique_columns": ["RID"],
+                            }
+                        ],
+                        "foreign_keys": [
+                            {
+                                "names": [
+                                    ["demo", "Widget_Image_fkey"]
+                                ],
+                                "foreign_key_columns": [
+                                    {
+                                        "schema_name": "demo",
+                                        "table_name": "Widget",
+                                        "column_name": "Image",
+                                    }
+                                ],
+                                "referenced_columns": [
+                                    {
+                                        "schema_name": "demo",
+                                        "table_name": "Image",
+                                        "column_name": "RID",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                },
+            }
+        },
+    }
+    (bag / "data" / "schema.json").write_text(json.dumps(doc))
+    with (bag / "data" / "demo" / "Image.csv").open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["RID", "URL", "Filename"])
+        w.writerow(["I-SRC-A", "/hatrac/demo/abc.a.png", "a.png"])
+        w.writerow(["I-SRC-B", "/hatrac/demo/def.b.png", "b.png"])
+    with (bag / "data" / "demo" / "Widget.csv").open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["RID", "Image"])
+        w.writerow(["W1", "I-SRC-A"])
+        w.writerow(["W2", "I-SRC-B"])
+    return bag
+
+
+def test_classify_table_routes_through_match_by_columns(tmp_path: Path) -> None:
+    """A table listed in ``match_by_columns`` is reported as ``MATCH_BY_COLUMNS``.
+
+    Other tables fall through to ``VOCABULARY`` (structural) or
+    ``CONTENT``. The new class takes precedence over the
+    structural vocab check, so a vocab-shaped table listed in
+    the policy still routes through the new path.
+    """
+    from deriva.bag.catalog_loader import _TableClass
+
+    # Use the existing vocab bag so we also verify the
+    # match_by_columns override of the structural classification.
+    bag = _build_vocab_bag(tmp_path)
+    loader = BagCatalogLoader(
+        catalog=_mock_catalog(),
+        bag=bag,
+        policy=FKTraversalPolicy(
+            match_by_columns={("demo", "Color"): ["Name"]},
+        ),
+        database_dir=tmp_path / "db",
+    )
+    try:
+        color = loader.bag_db.model.schemas["demo"].tables["Color"]
+        widget = loader.bag_db.model.schemas["demo"].tables["Widget"]
+        # Color is vocab-shaped AND listed in match_by_columns;
+        # explicit policy wins.
+        assert loader._classify_table(color) == _TableClass.MATCH_BY_COLUMNS
+        # Widget isn't listed; default classification (CONTENT).
+        assert loader._classify_table(widget) == _TableClass.CONTENT
+    finally:
+        loader.dispose()
+
+
+def test_match_by_columns_matches_existing_and_records_remap(tmp_path: Path) -> None:
+    """Existing destination rows match by the supplied column; remap recorded.
+
+    Mirror of ``test_vocab_load_matches_by_name_and_records_remap``
+    but for the new ``match_by_columns`` path. The mock catalog
+    reports one of the bag's Image rows as already present at a
+    different RID; the loader should skip the insert for that row,
+    record ``src_rid → dst_rid``, and rewrite the Widget FK at
+    insert time.
+    """
+    bag = _build_image_widget_bag(tmp_path)
+
+    catalog = _mock_catalog()
+
+    def _get(path: str, **_: Any):
+        # Only the match-fetch is expected via GET in this test.
+        assert "Image" in path
+        assert "URL" in path
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = [
+            {"URL": "/hatrac/demo/abc.a.png", "RID": "I-DST-A"},
+            # The second image (.../def.b.png) is absent — must
+            # be inserted.
+        ]
+        return resp
+
+    insert_payloads: list[list[dict[str, Any]]] = []
+
+    def _post(path: str, **kwargs: Any):
+        insert_payloads.append(kwargs["json"])
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        return resp
+
+    catalog.get = _get
+    catalog.post = _post
+
+    loader = BagCatalogLoader(
+        catalog=catalog,
+        bag=bag,
+        policy=FKTraversalPolicy(
+            asset_mode=AssetMode.ROWS_ONLY,
+            match_by_columns={("demo", "Image"): ["URL"]},
+        ),
+        database_dir=tmp_path / "db",
+    )
+    try:
+        report = loader.run()
+    finally:
+        loader.dispose()
+
+    image_stats = report.table_stats["demo.Image"]
+    assert image_stats.rows_matched_by_columns == 1  # I-SRC-A matched
+    assert image_stats.rows_inserted == 1  # I-SRC-B inserted
+    # rows_matched_by_name is reserved for the structural vocab
+    # path and must stay zero on this code path.
+    assert image_stats.rows_matched_by_name == 0
+
+    # Remap: matched row → destination RID; unmatched → identity.
+    remap = loader._rid_remap[("demo", "Image")]
+    assert remap["I-SRC-A"] == "I-DST-A"
+    assert remap["I-SRC-B"] == "I-SRC-B"
+
+    # Widget rows were POSTed with their Image FK rewritten through
+    # the remap. W1 → Image=I-DST-A (matched), W2 → Image=I-SRC-B
+    # (identity).
+    widget_inserts = [
+        p
+        for p in insert_payloads
+        if any(
+            r.get("RID") in {"W1", "W2"}
+            for r in (p if isinstance(p, list) else [])
+        )
+    ]
+    assert widget_inserts, "expected Widget rows to be posted"
+    widget_rows = widget_inserts[0]
+    by_rid = {r["RID"]: r for r in widget_rows}
+    assert by_rid["W1"]["Image"] == "I-DST-A"
+    assert by_rid["W2"]["Image"] == "I-SRC-B"
+
+
+def test_match_by_columns_composite_key(tmp_path: Path) -> None:
+    """Composite match keys (multi-column) work as a single GET + tuple lookup.
+
+    Verifies the ``list[str]`` policy shape: more than one column
+    forms a composite key. The fetched-rows dict is keyed by
+    tuple ``(col1, col2, ...)``; the loader's per-row match uses
+    the same tuple shape.
+
+    Uses the vocab bag's Color table with a synthetic composite
+    key ``["Name", "Description"]`` — silly in practice (Name
+    alone is unique) but exercises the multi-column path with the
+    smallest possible fixture.
+    """
+    bag = _build_vocab_bag(tmp_path)
+    catalog = _mock_catalog()
+
+    def _get(path: str, **_: Any):
+        # Composite-key path includes both columns.
+        assert "Name" in path and "Description" in path
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = [
+            {
+                "Name": "Red",
+                "Description": "Red color",
+                "RID": "C-DST-RED",
+            },
+            # Blue absent → must be inserted.
+        ]
+        return resp
+
+    insert_payloads: list[list[dict[str, Any]]] = []
+
+    def _post(path: str, **kwargs: Any):
+        insert_payloads.append(kwargs["json"])
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        return resp
+
+    catalog.get = _get
+    catalog.post = _post
+
+    loader = BagCatalogLoader(
+        catalog=catalog,
+        bag=bag,
+        policy=FKTraversalPolicy(
+            asset_mode=AssetMode.ROWS_ONLY,
+            match_by_columns={
+                ("demo", "Color"): ["Name", "Description"],
+            },
+        ),
+        database_dir=tmp_path / "db",
+    )
+    try:
+        report = loader.run()
+    finally:
+        loader.dispose()
+
+    color_stats = report.table_stats["demo.Color"]
+    assert color_stats.rows_matched_by_columns == 1  # Red matched
+    assert color_stats.rows_inserted == 1  # Blue inserted
+
+
+def test_match_by_columns_null_in_key_falls_through(tmp_path: Path) -> None:
+    """Bag row with NULL in any match column is inserted, not matched.
+
+    Composite NULL semantics are ambiguous (``(NULL, NULL)`` ==
+    ``(NULL, NULL)``?); the loader's policy is to never match
+    such rows and let the destination's uniqueness constraint
+    surface any error itself.
+    """
+    bag = _build_image_widget_bag(tmp_path)
+
+    # Rewrite Image.csv so I-SRC-A has a NULL URL (empty string in
+    # CSV, which the loader normalises to None).
+    img_csv = bag / "data" / "demo" / "Image.csv"
+    with img_csv.open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["RID", "URL", "Filename"])
+        w.writerow(["I-SRC-A", "", "a.png"])  # NULL URL
+        w.writerow(["I-SRC-B", "/hatrac/demo/def.b.png", "b.png"])
+
+    catalog = _mock_catalog()
+
+    def _get(path: str, **_: Any):
+        # Destination returns no matching rows; both bag rows
+        # are inserts. The point of this test isn't the match —
+        # it's that the NULL-URL row reaches the insert path
+        # without being "matched" against a hypothetical NULL row.
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = []
+        return resp
+
+    posted: list[dict[str, Any]] = []
+
+    def _post(path: str, **kwargs: Any):
+        posted.extend(kwargs["json"])
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        return resp
+
+    catalog.get = _get
+    catalog.post = _post
+
+    loader = BagCatalogLoader(
+        catalog=catalog,
+        bag=bag,
+        policy=FKTraversalPolicy(
+            asset_mode=AssetMode.ROWS_ONLY,
+            match_by_columns={("demo", "Image"): ["URL"]},
+        ),
+        database_dir=tmp_path / "db",
+    )
+    try:
+        report = loader.run()
+    finally:
+        loader.dispose()
+
+    image_stats = report.table_stats["demo.Image"]
+    # No matches — NULL-URL row falls through, valid-URL row
+    # had nothing to match against.
+    assert image_stats.rows_matched_by_columns == 0
+    assert image_stats.rows_inserted == 2
+
+    # Both Image rows reached the insert payload.
+    image_rids = {r["RID"] for r in posted if "URL" in r}
+    assert image_rids == {"I-SRC-A", "I-SRC-B"}
+
+
+def test_match_by_columns_policy_rejects_empty_column_list() -> None:
+    """``match_by_columns[k] = []`` is a caller bug; validator rejects it."""
+    with pytest.raises(ValueError, match="empty"):
+        FKTraversalPolicy(
+            match_by_columns={("demo", "Image"): []},
+        )


### PR DESCRIPTION
## Summary

Generalises the existing vocabulary match-by-``Name`` path to non-vocabulary tables that have a content-addressed unique key (e.g. asset tables whose ``URL`` is hash-derived and stable across executions). Callers can now say "for this table, if a row with these column values already exists on the destination, skip the insert and remap the source RID to the existing RID."

Three pieces:

1. **``FKTraversalPolicy.match_by_columns: dict[(schema, table), list[str]]``** — per-table caller-supplied unique-key rule. A validator rejects empty column lists (caller bug; drop the entry instead of supplying ``[]``).

2. **``_TableClass.MATCH_BY_COLUMNS``** — new classifier variant. ``_classify_table`` checks the policy dict first; it takes precedence over the structural vocab check, since explicit caller intent overrides implicit classification.

3. **``BagCatalogLoader._load_match_by_columns_table``** + helper ``_fetch_existing_by_columns``. Same shape as the vocab pair (``_load_vocabulary_table`` + ``_fetch_existing_vocab_by_name``), parameterised by the caller's column list. Row's match-key is a tuple over those columns; rows whose key has any ``None`` component fall through to insert (composite-NULL semantics are ambiguous — let any destination unique constraint fire on its own terms).

   The remap shape (``_rid_remap[(schema, table)][src_rid] = dst_rid``) is identical to the vocab path, so existing ``_rewrite_fks`` handles child-row rewriting with no changes.

``TableLoadStats.rows_matched_by_columns`` reports the count parallel to ``rows_matched_by_name``.

Companion to [#241](https://github.com/informatics-isi-edu/deriva-py/pull/241), [#242](https://github.com/informatics-isi-edu/deriva-py/pull/242), [#243](https://github.com/informatics-isi-edu/deriva-py/pull/243), [#244](https://github.com/informatics-isi-edu/deriva-py/pull/244). Together they obsolete ~200 LoC of URL-dedup helpers in deriva-ml's ``bag_commit.py`` ([deriva-ml#104](https://github.com/informatics-isi-edu/deriva-ml/pull/104)).

## Test plan

- [x] ``test_classify_table_routes_through_match_by_columns`` — policy override of structural vocab classification.
- [x] ``test_match_by_columns_matches_existing_and_records_remap`` — end-to-end: existing row matched, new row inserted, child FK rewritten through remap. Mirrors the vocab e2e test.
- [x] ``test_match_by_columns_composite_key`` — multi-column match key works.
- [x] ``test_match_by_columns_null_in_key_falls_through`` — NULL in any match column → insert, not match.
- [x] ``test_match_by_columns_policy_rejects_empty_column_list`` — validator catches the caller bug.

All 5 new tests pass. Full ``test_catalog_loader.py`` + ``test_traversal.py``: 63/63 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)