### PR TITLE
Upload: prepopulated_metadata + _uploadTable nondefaults (E1+E2)

### DIFF
--- a/deriva/transfer/upload/deriva_upload.py
+++ b/deriva/transfer/upload/deriva_upload.py
@@ -777,7 +777,29 @@ class DerivaUpload(object):
             default_columns = asset_mapping.get("default_columns")
             if not default_columns:
                 default_columns = self.catalog.getDefaultColumns({}, self.metadata['target_table'])
+            # Optional ``nondefaults`` parameter on the asset_mapping mirrors
+            # the same-named parameter on :meth:`_catalogRecordCreate` (single
+            # row insert). Callers use it to install bulk rows with
+            # caller-supplied values for normally-auto-assigned columns —
+            # most commonly ``nondefaults=["RID"]`` so pre-leased RIDs from
+            # ERMrest_RID_Lease survive the insert. Without this, the server
+            # assigns new RIDs and any FK reference in another table pointing
+            # at the leased RID would break.
+            #
+            # Deduplicate: any column in both ``default_columns`` and
+            # ``nondefaults`` should be treated as nondefault. The asset
+            # mapping's intent is "auto-default these, but explicitly NOT
+            # those" — overlap on a column means "explicit wins."
+            nondefaults = asset_mapping.get("nondefaults") or []
+            if nondefaults:
+                default_columns = [c for c in default_columns if c not in nondefaults]
             default_param = ('?defaults=%s' % ','.join(default_columns)) if len(default_columns) > 0 else ''
+            if nondefaults:
+                nondefaults_str = ','.join(nondefaults)
+                if default_param:
+                    default_param += '&nondefaults=%s' % nondefaults_str
+                else:
+                    default_param = '?nondefaults=%s' % nondefaults_str
             file_ext = self.metadata['file_ext']
             file_ext = file_ext.lower()
             if file_ext == 'csv':

--- a/deriva/transfer/upload/deriva_upload.py
+++ b/deriva/transfer/upload/deriva_upload.py
@@ -951,6 +951,26 @@ class DerivaUpload(object):
     def _initFileMetadata(self, file_path, asset_mapping, match_groupdict):
         self.metadata.clear()
         self._updateFileMetadata(match_groupdict)
+        # Optional caller-supplied metadata overlay. Useful when row metadata
+        # is known externally (e.g., from a bag's CSV row) rather than
+        # derivable from a filename regex. Values here override any
+        # equivalently-named groupdict captures — the caller's prepopulated
+        # values are treated as authoritative because they typically come
+        # from a structured source rather than from path parsing.
+        #
+        # Interaction with framework-derived fields: this overlay runs
+        # before the unconditional writes below for ``file_name``,
+        # ``file_size``, ``file_ext``, ``base_path``, ``base_name``,
+        # ``_upload_*``, and ``_identity_*``. Those framework writes are
+        # last-wins, so the overlay cannot override them — supplying any
+        # of those keys here is harmless but has no effect. The overlay
+        # CAN supply reserved keys that are written *later* in the upload
+        # pipeline (e.g., ``URI``, ``md5``, ``md5_base64``); those values
+        # may be overwritten by later steps (``_getFileHatracMetadata``,
+        # the hash-computation step in ``_uploadAsset``) but reach the
+        # column_map interpolation and any template references that fire
+        # before those later steps run.
+        self._updateFileMetadata(asset_mapping.get("prepopulated_metadata", {}))
         # Fast-fail check for pre-allocated-RID asset mappings: the caller
         # opted in via ``use_pre_allocated_rid: true`` and must supply the
         # RID via a ``(?P<RID>...)`` named group in the file_pattern regex.

--- a/tests/deriva/transfer/upload/test_prepopulated_metadata.py
+++ b/tests/deriva/transfer/upload/test_prepopulated_metadata.py
@@ -1,0 +1,164 @@
+"""Unit tests for the ``prepopulated_metadata`` asset-mapping key.
+
+The ``prepopulated_metadata`` key on an asset-mapping is an opt-in
+overlay merged into ``self.metadata`` during
+:meth:`DerivaUpload._initFileMetadata`, after the regex groupdict and
+before the framework-derived fields. It lets callers feed row metadata
+into the upload pipeline from a source other than the filesystem (e.g.,
+a bag's CSV row), so the recipe-driven uploader can be used by callers
+that know their metadata externally rather than deriving it from
+filenames.
+
+See the docstring on :meth:`DerivaUpload._initFileMetadata` for the
+precise interaction order with framework-derived fields.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def uploader():
+    """Construct a GenericUploader with mocked catalog + identity.
+
+    Bypasses ``__init__`` (which would try to load credentials and a
+    server config) and populates only the attributes the methods under
+    test read.
+    """
+    from deriva.transfer.upload.deriva_upload import GenericUploader
+    inst = GenericUploader.__new__(GenericUploader)
+    inst.metadata = {}
+    inst.catalog = MagicMock()
+    inst.identity = {"id": "anon", "display_name": "a", "full_name": "A", "email": "a@b"}
+    inst.processor_output = {}
+    inst.cancelled = False
+    # Satisfy __del__ → cleanupTransferState on GC; otherwise pytest 9
+    # escalates the AttributeError to a test error.
+    inst.transfer_state_fh = None
+    inst.transfer_state = {}
+    inst.transfer_state_locks = {}
+    # Stub the helpers _initFileMetadata calls so the test doesn't need
+    # a real catalog model or an on-disk file.
+    inst.getCatalogTable = MagicMock(return_value="S:T")
+    inst.getFileDisplayName = MagicMock(return_value="payload.dat")
+    inst.getFileSize = MagicMock(return_value=4096)
+    return inst
+
+
+def test_prepopulated_metadata_absent_is_no_op(uploader):
+    """Asset mappings without the new key behave exactly as before.
+
+    Existing callers (every current asset_mapping) shouldn't see any
+    difference. Verifies the opt-in property is genuine.
+    """
+    asset_mapping = {"target_table": ["S", "T"]}
+    match_groupdict = {"schema": "S", "asset_table": "T"}
+
+    uploader._initFileMetadata("/tmp/payload.dat", asset_mapping, match_groupdict)
+
+    # Framework-derived fields and groupdict captures are present.
+    assert uploader.metadata["schema"] == "S"
+    assert uploader.metadata["asset_table"] == "T"
+    assert uploader.metadata["file_name"] == "payload.dat"
+    assert uploader.metadata["file_size"] == 4096
+    # No spurious overlay-derived keys leaked in.
+    assert "URI" not in uploader.metadata
+    assert "MD5" not in uploader.metadata
+
+
+def test_prepopulated_metadata_supplies_external_values(uploader):
+    """Caller-supplied values land in self.metadata and survive."""
+    asset_mapping = {
+        "target_table": ["S", "T"],
+        "prepopulated_metadata": {
+            "URI": "/hatrac/Image/abc.png",
+            "MD5": "deadbeef",
+            "Length": 12345,
+            "Description": "training image",
+        },
+    }
+    match_groupdict = {"schema": "S", "asset_table": "T", "RID": "1-ABC"}
+
+    uploader._initFileMetadata("/tmp/payload.dat", asset_mapping, match_groupdict)
+
+    assert uploader.metadata["URI"] == "/hatrac/Image/abc.png"
+    assert uploader.metadata["MD5"] == "deadbeef"
+    assert uploader.metadata["Length"] == 12345
+    assert uploader.metadata["Description"] == "training image"
+    # Groupdict captures still present.
+    assert uploader.metadata["RID"] == "1-ABC"
+    # Framework-derived fields still computed.
+    assert uploader.metadata["file_size"] == 4096
+
+
+def test_prepopulated_metadata_overrides_groupdict(uploader):
+    """When a key exists in both groupdict and overlay, overlay wins.
+
+    Caller-supplied values are treated as authoritative — typically they
+    come from a structured source (CSV row, JSON manifest) while the
+    groupdict captures come from path-pattern parsing, which is less
+    precise.
+    """
+    asset_mapping = {
+        "target_table": ["S", "T"],
+        "prepopulated_metadata": {
+            "RID": "1-OVERLAY",
+            "extra_col": "from-overlay",
+        },
+    }
+    match_groupdict = {"RID": "1-FROMPATH", "extra_col": "from-path"}
+
+    uploader._initFileMetadata("/tmp/payload.dat", asset_mapping, match_groupdict)
+
+    # Overlay wins over groupdict for both keys.
+    assert uploader.metadata["RID"] == "1-OVERLAY"
+    assert uploader.metadata["extra_col"] == "from-overlay"
+
+
+def test_framework_fields_override_prepopulated_metadata(uploader):
+    """Framework-derived fields are last-wins over any overlay value.
+
+    A caller can put ``file_name`` etc. in ``prepopulated_metadata``
+    without breaking framework invariants — the value is silently
+    overwritten by the framework's own computation. Surfaces as
+    "harmless but ineffective" rather than a config error.
+    """
+    asset_mapping = {
+        "target_table": ["S", "T"],
+        "prepopulated_metadata": {
+            "file_name": "WRONG.bin",
+            "file_size": 999,
+        },
+    }
+    match_groupdict = {}
+
+    uploader._initFileMetadata("/tmp/payload.dat", asset_mapping, match_groupdict)
+
+    # Framework values present and correct — overlay had no effect.
+    assert uploader.metadata["file_name"] == "payload.dat"
+    assert uploader.metadata["file_size"] == 4096
+
+
+def test_prepopulated_metadata_combines_with_use_pre_allocated_rid(uploader):
+    """Overlay can supply RID for use_pre_allocated_rid asset mappings.
+
+    Today ``use_pre_allocated_rid`` requires a ``(?P<RID>...)`` capture
+    in the file_pattern regex. The overlay is a second path to satisfy
+    the same check: as long as ``self.metadata["RID"]`` is set by the
+    time the validation runs, the source (groupdict OR overlay) doesn't
+    matter.
+    """
+    asset_mapping = {
+        "target_table": ["S", "T"],
+        "use_pre_allocated_rid": True,
+        "prepopulated_metadata": {"RID": "1-XYZ"},
+    }
+    # Groupdict does NOT capture RID — overlay must supply it.
+    match_groupdict = {"schema": "S", "asset_table": "T"}
+
+    # Should not raise — overlay populated RID before the check.
+    uploader._initFileMetadata("/tmp/payload.dat", asset_mapping, match_groupdict)
+
+    assert uploader.metadata["RID"] == "1-XYZ"

--- a/tests/deriva/transfer/upload/test_uploadtable_nondefaults.py
+++ b/tests/deriva/transfer/upload/test_uploadtable_nondefaults.py
@@ -1,0 +1,149 @@
+"""Unit tests for the ``nondefaults`` asset-mapping key on _uploadTable.
+
+The ``nondefaults`` key on a ``asset_type: "table"`` asset-mapping
+plumbs an ERMrest ``&nondefaults=...`` URL parameter into the bulk
+``POST /entity/T`` insert that :meth:`DerivaUpload._uploadTable`
+performs. It mirrors the same-named parameter on
+:meth:`_catalogRecordCreate` (the single-row insert path).
+
+The typical use case is ``nondefaults: ["RID"]``: a caller has already
+leased RIDs via ``ERMrest_RID_Lease`` and wants the bulk insert to
+honor those pre-allocated values rather than letting the server
+auto-assign new RIDs. Without ``nondefaults``, the server assigns a
+fresh RID to every row regardless of what's in the CSV, which breaks
+any FK reference in another table that points at the leased value.
+"""
+from __future__ import annotations
+
+import io
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def uploader():
+    """GenericUploader with mocked catalog, identity, and on-disk file."""
+    from deriva.transfer.upload.deriva_upload import GenericUploader
+    inst = GenericUploader.__new__(GenericUploader)
+    inst.metadata = {}
+    inst.catalog = MagicMock()
+    # Default-columns lookup gets stubbed per-test as needed.
+    inst.catalog.getDefaultColumns = MagicMock(return_value=[])
+    inst.catalog.post = MagicMock(return_value=MagicMock(status_code=200))
+    inst.identity = {"id": "anon", "display_name": "a", "full_name": "A", "email": "a@b"}
+    inst.processor_output = {}
+    inst.cancelled = False
+    inst.transfer_state_fh = None
+    inst.transfer_state = {}
+    inst.transfer_state_locks = {}
+    inst.getCatalogTable = MagicMock(return_value="S:T")
+    inst.getFileDisplayName = MagicMock(return_value="rows.csv")
+    inst.getFileSize = MagicMock(return_value=1024)
+    inst._execute_processors = MagicMock()
+    return inst
+
+
+def _run_upload_table(uploader, asset_mapping, *, file_ext="csv"):
+    """Drive _uploadTable with a dummy file path and CSV body.
+
+    Returns the URL string the uploader called ``catalog.post`` with so
+    tests can assert on the defaults/nondefaults parameters.
+
+    Real callers feed ``file_ext`` into ``match_groupdict`` via the
+    ``ext_pattern`` regex capture (per the default config, e.g.
+    ``"^.*[.](?P<file_ext>json|csv)$"``). We simulate that here so
+    ``_uploadTable``'s ``file_ext == 'csv'`` branch resolves correctly.
+    """
+    match_groupdict = {"file_ext": file_ext}
+    fake_open = patch("builtins.open", return_value=io.BytesIO(b"RID,Name\n1-ABC,foo\n"))
+    with fake_open:
+        uploader._uploadTable("/tmp/rows.csv", asset_mapping, match_groupdict)
+    # _uploadTable calls catalog.post(url, fp, headers=...).
+    call = uploader.catalog.post.call_args
+    return call.args[0]
+
+
+def test_nondefaults_absent_legacy_behavior(uploader):
+    """No ``nondefaults`` key → URL has only ``?defaults=...``.
+
+    Existing asset_mappings (every current caller) shouldn't see any
+    change. Verifies the new key is genuinely opt-in.
+    """
+    asset_mapping = {
+        "asset_type": "table",
+        "default_columns": ["RCB", "RMB", "RCT", "RMT"],
+    }
+    url = _run_upload_table(uploader, asset_mapping)
+    assert url == "/entity/S:T?defaults=RCB,RMB,RCT,RMT"
+
+
+def test_nondefaults_present_appended_to_defaults(uploader):
+    """Both ``default_columns`` and ``nondefaults`` → defaults+nondefaults in URL."""
+    asset_mapping = {
+        "asset_type": "table",
+        "default_columns": ["RCB", "RMB", "RCT", "RMT"],
+        "nondefaults": ["RID"],
+    }
+    url = _run_upload_table(uploader, asset_mapping)
+    assert url == "/entity/S:T?defaults=RCB,RMB,RCT,RMT&nondefaults=RID"
+
+
+def test_nondefaults_present_no_defaults(uploader):
+    """``nondefaults`` alone (no default_columns) → URL starts with ``?nondefaults=``."""
+    asset_mapping = {
+        "asset_type": "table",
+        "default_columns": [],
+        "nondefaults": ["RID"],
+    }
+    url = _run_upload_table(uploader, asset_mapping)
+    assert url == "/entity/S:T?nondefaults=RID"
+
+
+def test_nondefaults_dedups_against_default_columns(uploader):
+    """Column in both ``default_columns`` and ``nondefaults`` → removed from defaults.
+
+    The asset_mapping's intent for an overlap is "explicit wins": if a
+    column is named in both lists, the caller is opting out of the
+    server-side default for that column. The framework reconciles by
+    dropping the overlap from defaults.
+    """
+    asset_mapping = {
+        "asset_type": "table",
+        "default_columns": ["RID", "RCB", "RMB", "RCT", "RMT"],
+        "nondefaults": ["RID"],
+    }
+    url = _run_upload_table(uploader, asset_mapping)
+    # RID dropped from defaults; nondefaults preserves it.
+    assert url == "/entity/S:T?defaults=RCB,RMB,RCT,RMT&nondefaults=RID"
+
+
+def test_nondefaults_multi_column(uploader):
+    """Multiple columns in ``nondefaults`` → comma-joined in URL."""
+    asset_mapping = {
+        "asset_type": "table",
+        "default_columns": ["RCB", "RMB"],
+        "nondefaults": ["RID", "RCT", "RMT"],
+    }
+    url = _run_upload_table(uploader, asset_mapping)
+    assert url == "/entity/S:T?defaults=RCB,RMB&nondefaults=RID,RCT,RMT"
+
+
+def test_nondefaults_with_implicit_default_columns(uploader):
+    """When ``default_columns`` is omitted, framework fetches from catalog.
+
+    The fetched list will typically include ``RID`` (every column the
+    table declares). If the caller adds ``nondefaults=["RID"]``, the
+    dedup logic strips ``RID`` from the implicit defaults before
+    building the URL — same as the explicit-default_columns case.
+    """
+    # Stub getDefaultColumns to return all the table's columns.
+    uploader.catalog.getDefaultColumns = MagicMock(return_value=["RID", "RCB", "RMB"])
+    asset_mapping = {
+        "asset_type": "table",
+        # No default_columns supplied; framework will fetch via getDefaultColumns.
+        "nondefaults": ["RID"],
+    }
+    url = _run_upload_table(uploader, asset_mapping)
+    # RID dropped from the auto-fetched defaults.
+    assert url == "/entity/S:T?defaults=RCB,RMB&nondefaults=RID"


### PR DESCRIPTION
## Summary

Two small, opt-in, backwards-compatible additions to `GenericUploader` that let callers with externally-known row metadata use the recipe-driven upload pipeline. Motivated by an in-progress `BagCatalogLoader` rewrite (separate, follow-up PR) that needs to drive `GenericUploader` from a bag's CSV rows rather than from filesystem-pattern derivation — but the two extensions stand on their own and are useful to any caller in the same shape.

Both extensions are purely additive new optional keys on the asset_mapping schema. No existing caller is affected; an asset_mapping without the new keys behaves identically to today.

## E1: `prepopulated_metadata` (commit `88c866d`)

**Problem.** `_uploadAsset` derives per-file metadata exclusively from filesystem patterns (`dir_pattern`/`file_pattern`/`ext_pattern` named-group captures). Callers that already know the row's metadata externally — from a structured source like a CSV row or a JSON manifest — must either re-encode that metadata into the filename or live with the framework re-deriving it (and risk divergence).

**Fix.** Add an optional `prepopulated_metadata` dict on the asset_mapping. When present, `_initFileMetadata` merges it into `self.metadata` after the regex groupdict and before framework-derived fields (`file_name`, `file_size`, identity, timestamps). Caller-supplied values are authoritative against groupdict captures (structured source beats path parsing). Framework-derived fields are last-wins, so the overlay cannot break framework invariants for keys it manages.

The overlay can supply reserved-but-pipeline-late keys (`URI`, `md5`, `md5_base64`) — those reach `column_map` interpolation before being overwritten by later steps (`_getFileHatracMetadata`, the hash-computation step). To pass a caller-supplied URI through unchanged, set `hatrac_templates.hatrac_uri = "{URI}"`.

**Tests** (`test_prepopulated_metadata.py`, 5 tests):
- Absent key is a no-op (existing callers unaffected).
- Normal supply: overlay values land in `self.metadata`.
- Overlay beats colliding groupdict captures.
- Framework-derived fields override overlay values (silently — harmless misuse).
- `prepopulated_metadata` can supply RID for `use_pre_allocated_rid` asset mappings.

## E2: `nondefaults` on `_uploadTable` (commit `3bd942e`)

**Problem.** `_uploadTable` performs the bulk-row insert (`POST /entity/{T}?defaults=...` with a CSV body). It has no way to opt out of server-side default assignment for specific columns. Callers with pre-leased RIDs (from `ERMrest_RID_Lease`) cannot use the bulk path — the server assigns fresh RIDs and any FK reference at the leased values breaks.

**Fix.** Add `nondefaults` to the asset_mapping. When present, `&nondefaults=...` is appended to the POST URL. Mirrors the same-named parameter on `_catalogRecordCreate` (the single-row insert path), where this knob already exists.

Deduplication: when a column appears in both `default_columns` and `nondefaults`, the column is dropped from defaults before the URL is built. The intent for an overlap is "explicit wins" — supplying a column in `nondefaults` is opting out of server-side default for that column.

**Tests** (`test_uploadtable_nondefaults.py`, 6 tests):
- Absent key (legacy behavior preserved).
- Both `default_columns` and `nondefaults` set.
- `nondefaults` alone (no defaults).
- Overlap dedup against explicit `default_columns`.
- Overlap dedup against auto-fetched (`getDefaultColumns`) defaults.
- Multi-column `nondefaults`.

## Test plan

- [x] `tests/deriva/transfer/upload/test_prepopulated_metadata.py` — 5/5 pass.
- [x] `tests/deriva/transfer/upload/test_uploadtable_nondefaults.py` — 6/6 pass.
- [x] `tests/deriva/transfer/upload/test_pre_allocated_rid.py` (pre-existing) — 9/9 pass.
- [x] Full `tests/deriva/transfer/upload/` — 20/20 pass.

## Why this PR is separate

These are useful beyond their motivating caller (the `BagCatalogLoader` rewrite). Bundling them into the larger `BagCatalogLoader` PR would force reviewers to weigh the extension semantics against the bag-loader's design simultaneously. As a standalone PR, the surface area is ~50 LoC of source + ~300 LoC of tests — independently reviewable and mergeable on its own timeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)