### PR TITLE
BagCatalogLoader: route asset uploads through DerivaUpload._hatracUpload (WI1)

### DIFF
--- a/deriva/bag/catalog_loader.py
+++ b/deriva/bag/catalog_loader.py
@@ -15,13 +15,34 @@ Two surfaces:
   ``run()`` is a thin wrapper around ``arun()`` for callers in
   sync contexts.
 
-The loader does **not** implement its own asset uploader; it
-delegates each per-file upload to deriva-py's
-:class:`~deriva.transfer.upload.deriva_upload.DerivaUpload`
-recipe, which already handles Hatrac MD5-based dedupe, catalog
-row reconciliation (so additional metadata on the bag's row
-survives a re-upload), pre-allocated RID handling, and
-transfer-state resumption.
+The loader does **not** implement its own Hatrac upload — it
+hands each asset row to
+:meth:`~deriva.transfer.upload.deriva_upload.DerivaUpload._hatracUpload`,
+which picks chunked vs. single-PUT based on file size and (when
+the destination already has a matching MD5) skips byte transfer
+via :meth:`HatracStore.put_loc`'s built-in HEAD-then-PUT path.
+Server-side dedup is therefore transparent to the loader:
+:attr:`TableLoadStats.assets_attempted` counts upload invocations
+only; whether bytes actually transferred is decided downstream.
+
+Cross-process transfer-state resumption — the persistent
+``.deriva-upload-state-*.json`` machinery in
+:class:`~deriva.transfer.upload.deriva_upload.DerivaUpload` — is
+**not** wired up here. The bag-loader is a one-shot driver; the
+state-file overhead would buy resume-on-crash at the cost of a
+file lock that would serialize concurrent loads to the same bag.
+A future caller that needs resume can opt in by populating
+``self._uploader.transfer_state`` and calling
+:meth:`DerivaUpload.loadTransferState` before invoking
+:meth:`run`.
+
+Catalog row insertion is the loader's own responsibility, not
+the uploader's: row writes go directly through ``catalog.post``
+in :meth:`_insert_rows`, with row reconciliation, RID remap, and
+dangling-FK handling layered in by the table-class machinery
+(:meth:`_load_vocabulary_table`,
+:meth:`_load_match_by_columns_table`,
+:meth:`_load_content_table`).
 
 For non-asset tables, the loader walks the bag's SQLAlchemy ORM
 (via :class:`BagDatabase`) in :class:`ForeignKeyOrderer`-computed
@@ -123,13 +144,14 @@ class TableLoadStats:
     """Rows whose dangling FK columns were set to NULL (only
     nonzero when ``dangling_fk_strategy == NULLIFY``)."""
 
-    assets_uploaded: int = 0
-    """Asset files transferred to the destination Hatrac (zero
-    for ``ROWS_ONLY`` mode or when Hatrac dedupe found a match)."""
-
-    assets_deduped: int = 0
-    """Asset files that already existed in the destination Hatrac
-    with a matching MD5; bytes not transferred."""
+    assets_attempted: int = 0
+    """Number of asset rows for which :meth:`_hatracUpload` was
+    invoked. The deriva-py uploader's HEAD-then-PUT path (inside
+    :meth:`HatracStore.put_loc` when ``chunked=True``) decides
+    server-side whether to transfer bytes or skip-on-MD5-match;
+    the loader does not distinguish the two outcomes in this
+    counter. Zero in ``ROWS_ONLY`` mode (asset bytes aren't pushed
+    at all)."""
 
     rows_matched_by_name: int = 0
     """Vocabulary rows that already existed on the destination
@@ -604,12 +626,15 @@ class BagCatalogLoader:
             table.is_asset()
             and self.policy.asset_mode != AssetMode.ROWS_ONLY
         ):
-            # Upload asset bytes. For UPLOAD_IF_MISSING the upload
-            # recipe checks Hatrac via HEAD and skips bytes when
-            # MD5 matches; we count those skips for the report.
-            uploaded, deduped = await self._upload_assets(table, rows)
-            stats.assets_uploaded = uploaded
-            stats.assets_deduped = deduped
+            # Hand off each asset row to deriva-py's
+            # :meth:`DerivaUpload._hatracUpload`, which handles
+            # chunking-by-size, HEAD-then-PUT dedup against the
+            # destination's MD5, and (when wired up) per-chunk
+            # transfer-state. Dedup-vs-transfer is decided
+            # server-side inside :meth:`HatracStore.put_loc` and
+            # is not surfaced to the loader; ``assets_attempted``
+            # counts upload invocations only.
+            stats.assets_attempted = await self._upload_assets(table, rows)
 
         return stats
 
@@ -1276,35 +1301,50 @@ class BagCatalogLoader:
         self,
         table: DerivaTable,
         rows: list[dict[str, Any]],
-    ) -> tuple[int, int]:
-        """Push asset bytes to the destination Hatrac. Returns ``(uploaded, deduped)``.
+    ) -> int:
+        """Push asset bytes to the destination Hatrac via deriva-py's uploader.
 
-        For each asset row in ``rows``:
+        For each asset row in ``rows`` the loader hands the
+        bag-local file path and the source-catalog URL to
+        :meth:`DerivaUpload._hatracUpload`, which:
 
-        - Use ``Filename`` (now a local path inside the bag — see
-          :meth:`BagDatabase._localize_asset_row`) as the source
-          file.
-        - Use the path component of the row's ``URL`` (the
-          source-catalog Hatrac URL) as the destination Hatrac
-          path. Source and destination share the same logical
-          ``/hatrac/{table}/...`` layout, so the path is portable
-          across catalogs.
-        - With ``UPLOAD_IF_MISSING`` (default), HEAD the
-          destination first and skip the byte transfer when the
-          MD5 already matches.
-        - With ``UPLOAD_FORCE``, re-upload unconditionally.
+        - Picks chunked vs. single-PUT based on file size (default
+          chunk threshold is ``DEFAULT_CHUNK_SIZE``).
+        - HEADs the destination first; when ``Content-MD5`` matches
+          the supplied MD5 it returns the existing object location
+          without transferring bytes (server-side dedup). The
+          loader does not surface the dedup-vs-transfer distinction
+          to the caller — :attr:`TableLoadStats.assets_attempted`
+          counts upload invocations only.
+        - With ``UPLOAD_FORCE``, skips the HEAD and pushes
+          unconditionally.
 
         Rows missing a local file or URL are warned and skipped
-        (they count as neither uploaded nor deduped). HTTP errors
-        during upload propagate to the caller — the loader's job
-        is to surface them, not to swallow them.
-        """
-        hatrac = self._dest_hatrac_store()
+        (they don't count toward ``assets_attempted``). HTTP
+        errors during upload propagate to the caller — the
+        loader's job is to surface them, not to swallow them.
 
-        uploaded = 0
-        deduped = 0
+        Args:
+            table: The asset table being uploaded (used for the
+                bag-local path resolution and for diagnostic
+                logging).
+            rows: The bag rows to upload. Each row supplies
+                ``URL`` (destination Hatrac path source),
+                ``Filename`` (catalog-facing name; resolved to
+                the on-disk path by
+                :meth:`BagDatabase.resolve_asset_local_path`),
+                and ``MD5`` (used both for dedup HEAD-match and
+                for upload-job verification).
+
+        Returns:
+            Number of asset rows for which :meth:`_hatracUpload`
+            was invoked. Sets :attr:`TableLoadStats.assets_attempted`
+            at the caller.
+        """
+        uploader = self._get_uploader()
         force = self.policy.asset_mode == AssetMode.UPLOAD_FORCE
 
+        attempted = 0
         for row in rows:
             url = row.get("URL")
             if not url:
@@ -1345,42 +1385,69 @@ class BagCatalogLoader:
 
             md5 = row.get("MD5") or None
 
-            # HEAD-then-PUT so we can count dedupes accurately. For
-            # ``UPLOAD_FORCE`` skip the HEAD and just push.
-            if not force and await self._hatrac_already_has(
-                hatrac, hatrac_path, md5
-            ):
-                deduped += 1
-                continue
-
+            # Hand off to deriva-py's uploader. ``_hatracUpload``
+            # decides chunking based on file size and does
+            # HEAD-then-PUT dedup against the destination's MD5
+            # internally; when ``force`` is True it skips the HEAD
+            # and pushes unconditionally.
             await asyncio.to_thread(
-                hatrac.put_loc,
+                uploader._hatracUpload,
                 hatrac_path,
-                local_path,
+                str(local_path),
                 md5=md5,
+                chunked=True,
                 force=force,
             )
-            uploaded += 1
+            attempted += 1
 
-        return uploaded, deduped
+        return attempted
 
-    def _dest_hatrac_store(self) -> Any:
-        """Return a :class:`HatracStore` bound to the destination host.
+    def _get_uploader(self) -> Any:
+        """Return a minimal :class:`DerivaUpload` for asset uploads.
 
-        Cached on the loader since every asset upload reuses the
-        same store. The store reuses the catalog's credentials.
+        Constructed lazily on first asset-upload. We bypass the
+        public ``__init__`` (which loads a config file, installs
+        a SIGINT handler, and resolves credentials from the local
+        filesystem) and instead populate only the attributes
+        :meth:`_hatracUpload` and its callees read:
+
+        - ``store``: the :class:`HatracStore` bound to the
+          destination catalog's host.
+        - ``server_url``: used for log messages.
+        - ``transfer_state`` / ``transfer_state_fh`` /
+          ``transfer_state_locks``: present and empty so
+          ``getTransferState`` returns ``None`` and ``cleanupTransferState``
+          (called from ``__del__``) is a no-op. Wiring up the
+          state-file machinery for cross-process resume is a
+          deliberate non-goal here — the bag-loader is a one-shot
+          driver; the state-file overhead would buy resume on
+          process crash but at the cost of a file lock that
+          would serialize concurrent bag-loads to the same bag.
+        - ``cancelled``: ``False``; cancellation isn't wired up
+          through the bag-loader.
         """
-        if getattr(self, "_hatrac_store", None) is not None:
-            return self._hatrac_store
+        if getattr(self, "_uploader", None) is not None:
+            return self._uploader
+
         from deriva.core import HatracStore
+        from deriva.transfer.upload.deriva_upload import DerivaUpload
 
         deriva_server = self.catalog.deriva_server
-        self._hatrac_store = HatracStore(
+        store = HatracStore(
             deriva_server.scheme,
             deriva_server.server,
             credentials=self.catalog._credentials,
         )
-        return self._hatrac_store
+
+        uploader = DerivaUpload.__new__(DerivaUpload)
+        uploader.store = store
+        uploader.server_url = f"{deriva_server.scheme}://{deriva_server.server}"
+        uploader.transfer_state = {}
+        uploader.transfer_state_fh = None
+        uploader.transfer_state_locks = {}
+        uploader.cancelled = False
+        self._uploader = uploader
+        return uploader
 
     @staticmethod
     def _hatrac_path_for(url: str) -> str | None:
@@ -1415,35 +1482,6 @@ class BagCatalogLoader:
         if version_sep > last_slash:
             path = path[:version_sep]
         return path
-
-    async def _hatrac_already_has(
-        self,
-        hatrac: Any,
-        hatrac_path: str,
-        md5: str | None,
-    ) -> bool:
-        """HEAD the destination Hatrac object; True iff MD5 matches.
-
-        Missing MD5 means we can't be sure dedupe is safe, so we
-        return False (forcing an upload). A 404 on HEAD also means
-        we need to upload.
-        """
-        if not md5:
-            return False
-        import requests
-
-        def _head() -> bool:
-            try:
-                r = hatrac.head(hatrac_path)
-            except requests.HTTPError as e:
-                if getattr(e.response, "status_code", None) == 404:
-                    return False
-                raise
-            if r.status_code != 200:
-                return False
-            return r.headers.get("Content-MD5") == md5
-
-        return await asyncio.to_thread(_head)
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/tests/deriva/bag/test_catalog_loader.py
+++ b/tests/deriva/bag/test_catalog_loader.py
@@ -744,8 +744,7 @@ def test_table_load_stats_defaults() -> None:
     assert s.rows_inserted == 0
     assert s.rows_skipped_orphan == 0
     assert s.rows_nullified_orphan == 0
-    assert s.assets_uploaded == 0
-    assert s.assets_deduped == 0
+    assert s.assets_attempted == 0
 
 
 # ---------------------------------------------------------------------------
@@ -1308,17 +1307,44 @@ def _build_asset_only_bag(tmp_path: Path) -> Path:
     return bag
 
 
-def test_upload_assets_dedupe_skips_when_md5_matches(tmp_path: Path) -> None:
-    """``UPLOAD_IF_MISSING`` skips bytes when destination MD5 matches."""
+def _install_mock_uploader(loader: BagCatalogLoader, hatrac_store: Any) -> Any:
+    """Stand-in :class:`DerivaUpload` for the loader.
+
+    Bypasses the public ``__init__`` (config load, signal handler) by
+    pre-populating only the attributes :meth:`DerivaUpload._hatracUpload`
+    and its callees read. ``self.store`` is the caller's
+    ``HatracStore`` mock — that's the layer the test asserts against,
+    since :meth:`_hatracUpload` delegates byte transfer to it.
+    """
+    from deriva.transfer.upload.deriva_upload import DerivaUpload
+
+    uploader = DerivaUpload.__new__(DerivaUpload)
+    uploader.store = hatrac_store
+    uploader.server_url = "https://example.org"
+    uploader.transfer_state = {}
+    uploader.transfer_state_fh = None
+    uploader.transfer_state_locks = {}
+    uploader.cancelled = False
+    loader._uploader = uploader
+    return uploader
+
+
+def test_upload_assets_invokes_put_loc_per_row(tmp_path: Path) -> None:
+    """``UPLOAD_IF_MISSING`` invokes ``store.put_loc(chunked=True)`` per asset row.
+
+    The loader hands each row to :meth:`DerivaUpload._hatracUpload`, which
+    in turn calls :meth:`HatracStore.put_loc` with ``chunked=True``.
+    HEAD-then-PUT dedup is decided inside ``put_loc`` server-side; the
+    loader does not pre-check or count dedups. :attr:`assets_attempted`
+    counts upload invocations.
+    """
     import asyncio
 
     bag = _build_asset_only_bag(tmp_path)
     catalog = _mock_catalog()
     hatrac = MagicMock()
-    head_resp = MagicMock()
-    head_resp.status_code = 200
-    head_resp.headers = {"Content-MD5": "deadbeef"}
-    hatrac.head.return_value = head_resp
+    # put_loc returns a Content-Location string on success.
+    hatrac.put_loc.return_value = "/hatrac/Image/img.png:VERSION1"
 
     loader = BagCatalogLoader(
         catalog=catalog,
@@ -1326,67 +1352,34 @@ def test_upload_assets_dedupe_skips_when_md5_matches(tmp_path: Path) -> None:
         policy=FKTraversalPolicy(asset_mode=AssetMode.UPLOAD_IF_MISSING),
         database_dir=tmp_path / "db",
     )
-    loader._hatrac_store = hatrac  # bypass real construction
+    _install_mock_uploader(loader, hatrac)
     try:
         image = loader.bag_db.model.schemas["demo"].tables["Image"]
         rows = list(loader.bag_db.get_table_contents("Image"))
-        uploaded, deduped = asyncio.run(
-            loader._upload_assets(image, rows)
-        )
+        attempted = asyncio.run(loader._upload_assets(image, rows))
     finally:
         loader.dispose()
 
-    assert uploaded == 0
-    assert deduped == 1
-    hatrac.put_loc.assert_not_called()
-    hatrac.head.assert_called_once_with("/hatrac/Image/img.png")
-
-
-def test_upload_assets_uploads_when_md5_differs(tmp_path: Path) -> None:
-    """``UPLOAD_IF_MISSING`` pushes bytes when destination MD5 differs."""
-    import asyncio
-
-    bag = _build_asset_only_bag(tmp_path)
-    catalog = _mock_catalog()
-    hatrac = MagicMock()
-    head_resp = MagicMock()
-    head_resp.status_code = 200
-    head_resp.headers = {"Content-MD5": "different_md5"}
-    hatrac.head.return_value = head_resp
-
-    loader = BagCatalogLoader(
-        catalog=catalog,
-        bag=bag,
-        policy=FKTraversalPolicy(asset_mode=AssetMode.UPLOAD_IF_MISSING),
-        database_dir=tmp_path / "db",
-    )
-    loader._hatrac_store = hatrac
-    try:
-        image = loader.bag_db.model.schemas["demo"].tables["Image"]
-        rows = list(loader.bag_db.get_table_contents("Image"))
-        uploaded, deduped = asyncio.run(
-            loader._upload_assets(image, rows)
-        )
-    finally:
-        loader.dispose()
-
-    assert uploaded == 1
-    assert deduped == 0
+    assert attempted == 1
+    # put_loc was called with the canonicalized destination path, the
+    # row's MD5 (for server-side dedup verification), chunked mode on,
+    # and force off.
     hatrac.put_loc.assert_called_once()
-    # The destination Hatrac path is the source URL's path component.
     args, kwargs = hatrac.put_loc.call_args
     assert args[0] == "/hatrac/Image/img.png"
     assert kwargs.get("md5") == "deadbeef"
+    assert kwargs.get("chunked") is True
     assert kwargs.get("force") is False
 
 
-def test_upload_assets_force_bypasses_head(tmp_path: Path) -> None:
-    """``UPLOAD_FORCE`` skips the HEAD and pushes unconditionally."""
+def test_upload_assets_force_passes_through(tmp_path: Path) -> None:
+    """``UPLOAD_FORCE`` propagates as ``force=True`` to ``put_loc``."""
     import asyncio
 
     bag = _build_asset_only_bag(tmp_path)
     catalog = _mock_catalog()
     hatrac = MagicMock()
+    hatrac.put_loc.return_value = "/hatrac/Image/img.png:VERSION1"
 
     loader = BagCatalogLoader(
         catalog=catalog,
@@ -1394,25 +1387,26 @@ def test_upload_assets_force_bypasses_head(tmp_path: Path) -> None:
         policy=FKTraversalPolicy(asset_mode=AssetMode.UPLOAD_FORCE),
         database_dir=tmp_path / "db",
     )
-    loader._hatrac_store = hatrac
+    _install_mock_uploader(loader, hatrac)
     try:
         image = loader.bag_db.model.schemas["demo"].tables["Image"]
         rows = list(loader.bag_db.get_table_contents("Image"))
-        uploaded, deduped = asyncio.run(
-            loader._upload_assets(image, rows)
-        )
+        attempted = asyncio.run(loader._upload_assets(image, rows))
     finally:
         loader.dispose()
 
-    assert uploaded == 1
-    assert deduped == 0
-    hatrac.head.assert_not_called()
+    assert attempted == 1
     _args, kwargs = hatrac.put_loc.call_args
     assert kwargs.get("force") is True
 
 
 def test_upload_assets_skips_missing_local_file(tmp_path: Path) -> None:
-    """Rows whose Filename doesn't exist on disk are warned and skipped."""
+    """Rows whose Filename doesn't exist on disk are warned and skipped.
+
+    Skipped rows do not contribute to :attr:`assets_attempted` — the
+    counter reflects calls to :meth:`_hatracUpload`, which the loader
+    doesn't issue for rows without local bytes.
+    """
     import asyncio
 
     bag = _build_asset_only_bag(tmp_path)
@@ -1427,18 +1421,15 @@ def test_upload_assets_skips_missing_local_file(tmp_path: Path) -> None:
         policy=FKTraversalPolicy(asset_mode=AssetMode.UPLOAD_IF_MISSING),
         database_dir=tmp_path / "db",
     )
-    loader._hatrac_store = hatrac
+    _install_mock_uploader(loader, hatrac)
     try:
         image = loader.bag_db.model.schemas["demo"].tables["Image"]
         rows = list(loader.bag_db.get_table_contents("Image"))
-        uploaded, deduped = asyncio.run(
-            loader._upload_assets(image, rows)
-        )
+        attempted = asyncio.run(loader._upload_assets(image, rows))
     finally:
         loader.dispose()
 
-    assert uploaded == 0
-    assert deduped == 0
+    assert attempted == 0
     hatrac.put_loc.assert_not_called()
 
 


### PR DESCRIPTION
## Summary

\`BagCatalogLoader._upload_assets\` was calling \`HatracStore.put_loc\` directly with the default \`chunked=False\` argument, and pre-checking dedup via a hand-rolled \`_hatrac_already_has\` helper. Both bypass the upload machinery deriva-py already provides:

- \`chunked=False\` means a single-PUT for every asset, no matter the size — large files time out without ever attempting chunking.
- The hand-rolled HEAD-then-MD5 pre-check duplicates what \`HatracStore.put_loc(chunked=True, force=False)\` does internally.

This is deriva-py reimplementing deriva-py functionality inside its own bag-loader.

This PR routes the per-row upload call through \`DerivaUpload._hatracUpload\`, the published entry point for "upload bytes to a Hatrac URL." That method picks chunked vs. single-PUT by file size, and \`put_loc(chunked=True)\` handles the HEAD-MD5 skip server-side. The bag-loader's job shrinks to "for each row, hand bag-local-path + destination-URL + MD5 to the uploader and count invocations."

## Field rename and removal

The previous design surfaced dedup-vs-transfer to the caller as separate \`assets_uploaded\` / \`assets_deduped\` counters in \`TableLoadStats\`. After the cutover, \`put_loc\` decides server-side and doesn't return the distinction, so:

- **Renamed** \`TableLoadStats.assets_uploaded\` → \`assets_attempted\` to honestly describe the new semantic (counts \`_hatracUpload\` invocations).
- **Removed** \`TableLoadStats.assets_deduped\` entirely. No legacy compat shim — the field rename is clean.

Operator telemetry consequence: a re-load of a bag whose content already exists at the destination will report \`assets_attempted: N\` (full count) instead of the old \`uploaded: 0, deduped: N\`. The Hatrac side still does the right thing (no bytes transferred for matched-MD5); the loader just doesn't report it. Documented in the class docstring and the \`assets_attempted\` field doc.

## What's deleted

- \`_hatrac_already_has\` — HEAD-then-MD5 dedup pre-check; \`put_loc(chunked=True)\` does the same internally.
- \`_dest_hatrac_store\` — the \`HatracStore\` constructor wrapper; replaced by the \`DerivaUpload\` instance's own \`self.store\`.

## What's added

- \`_get_uploader\` — lazy-constructs a minimal \`DerivaUpload\` instance, bypassing the public \`__init__\` (which would load a config file, install a SIGINT handler, and resolve credentials from the local filesystem). Sets just enough attributes for \`_hatracUpload\` and its callees: \`store\`, \`server_url\`, empty \`transfer_state\`, \`cancelled = False\`.

Cross-process transfer-state resumption (the \`.deriva-upload-state-*.json\` machinery) is **not** wired up here — deliberate non-goal. The bag-loader is a one-shot driver; the state-file lock would serialize concurrent loads to the same bag. Documented in the docstring as opt-in for future callers.

## What's kept

- \`_hatrac_path_for\` — bag-specific URL canonicalization (strip \`:VERSIONID\`, accept full or bare URL). The uploader doesn't have an equivalent because it builds URIs from filename patterns; this is loader-specific.

## Class docstring

Rewritten. The old version claimed \`DerivaUpload\` handles "catalog row reconciliation... pre-allocated RID handling, and transfer-state resumption" — none of which the code actually delegated. The new docstring describes what the code does: hand asset uploads to \`_hatracUpload\`, keep row insertion in the loader's own \`_insert_rows\` (\`catalog.post\`-direct, which is the right level), don't wire up resume.

## Test plan

- [x] \`tests/deriva/bag/\` — 289 passed, 2 skipped.
- [x] \`tests/deriva/transfer/upload/\` — 20 passed.

Tests in \`test_catalog_loader.py\` rewritten: previously asserted on \`hatrac.head\` + \`hatrac.put_loc\` calls observable from the loader's pre-check. Post-cutover the loader doesn't do the pre-check — the test installs a mocked \`DerivaUpload\` via the new \`_install_mock_uploader\` helper, lets real \`_hatracUpload\` code run, and asserts on the resulting \`store.put_loc\` invocation (called with \`chunked=True\`, the md5 from the row, and the loader's \`force\` flag).

The dedup-test (\`test_upload_assets_dedupe_skips_when_md5_matches\`) is gone — its premise was the loader's pre-check, which no longer exists. The new \`test_upload_assets_invokes_put_loc_per_row\` covers the happy path; the missing-local-file and force tests cover the other branches.

## Cross-repo coordination

deriva-ml's \`tests/execution/test_bag_commit_poc.py\` references \`assets_deduped\` in a log message. That test will fail when consuming this PR's \`deriva-ml\` branch state. Fix is part of the deriva-ml-side Work Item 2 PR — the \`assets_deduped\` reference becomes a no-op log change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)