### PR TITLE
fix(bag): BagCacheIndex.record accumulates anchors (fixes deriva-ml#142)

### DIFF
--- a/deriva/bag/cache_index.py
+++ b/deriva/bag/cache_index.py
@@ -182,11 +182,22 @@ class BagCacheIndex:
     ) -> None:
         """Record a bag in the index.
 
-        Idempotent: re-recording a bag with the same checksum
-        updates the metadata and *replaces* the anchor list
-        (because the bag's contents are content-addressed; if the
-        anchor RIDs differ for the same checksum, the most recent
-        producer's claim wins).
+        Idempotent on the metadata row and **accumulative** on the
+        anchor list. Re-recording the same checksum updates the
+        ``bags`` row's metadata (profile, built_at, size, summary)
+        and adds any new ``(table, rid)`` anchor pairs that aren't
+        already in the reverse index. Existing anchor rows are
+        preserved.
+
+        This matches reverse-index semantics: a single
+        content-addressed bag may legitimately be anchored from
+        multiple RIDs (e.g., two datasets that share content via
+        clone-via-bag, or a dev-version rerun whose checksum
+        coincides with a release version). Each producer's claim
+        accumulates rather than replacing the prior claim.
+
+        To remove a bag's index entry (and all its anchors via FK
+        cascade), use :meth:`forget`.
 
         Args:
             checksum: The bag's BDBag checksum. Used as the
@@ -194,8 +205,10 @@ class BagCacheIndex:
             profile_id: Optional BagIt-Profile-Identifier URL. Helps
                 future tooling tell deriva-bag profile bags apart
                 from other BDBag flavors.
-            anchors: An iterable of ``(table, rid)`` pairs to put
-                in the reverse index. May be empty.
+            anchors: An iterable of ``(table, rid)`` pairs to add
+                to the reverse index. May be empty. Duplicates of
+                existing rows (same checksum + table + rid) are
+                silently ignored.
             anchor_summary: Optional dict (e.g., a serialized
                 ``Anchor`` list) recorded as JSON for provenance.
             size_bytes: Optional bag size on disk. Useful for
@@ -237,20 +250,16 @@ class BagCacheIndex:
                     "size_bytes": size_bytes,
                 },
             )
-            # Replace anchors: delete the existing rows and re-insert.
-            # The FK ON DELETE CASCADE would handle this, but we
-            # want to keep the bags row stable across re-records, so
-            # we delete only the anchor rows.
-            conn.execute(
-                text(
-                    'DELETE FROM bag_anchor_rids WHERE checksum = :c'
-                ),
-                {"c": checksum},
-            )
+            # Accumulate anchors: insert new (checksum, table, rid)
+            # triples; rely on the PRIMARY KEY constraint and
+            # ``INSERT OR IGNORE`` to silently dedupe rows that are
+            # already in the reverse index. Existing anchors are
+            # preserved across re-records — see the docstring for
+            # the semantic and the GitHub issue trail.
             if anchor_rows:
                 conn.execute(
                     text(
-                        "INSERT INTO bag_anchor_rids "
+                        "INSERT OR IGNORE INTO bag_anchor_rids "
                         '(checksum, "table", rid) '
                         "VALUES (:checksum, :table, :rid)"
                     ),

--- a/tests/deriva/bag/test_cache_index.py
+++ b/tests/deriva/bag/test_cache_index.py
@@ -93,8 +93,13 @@ def test_cache_index_forget_unknown_returns_false(tmp_path: Path) -> None:
         idx.dispose()
 
 
-def test_cache_index_record_is_idempotent(tmp_path: Path) -> None:
-    """Re-recording the same checksum updates rather than duplicating."""
+def test_cache_index_record_metadata_is_idempotent(tmp_path: Path) -> None:
+    """Re-recording the same checksum updates metadata in place.
+
+    The ``bags`` row's metadata (profile_id, built_at, summary,
+    size_bytes) reflects the most recent ``record()`` call —
+    upsert semantics on the metadata row.
+    """
     idx = BagCacheIndex(tmp_path)
     try:
         idx.record(checksum="abc", profile_id="old", anchors=[("T", "1")])
@@ -102,8 +107,43 @@ def test_cache_index_record_is_idempotent(tmp_path: Path) -> None:
         record = idx.get("abc")
         assert record is not None
         assert record["profile_id"] == "new"
-        # Anchor list is replaced, not appended.
-        assert idx.find_bags_for_rid(table="T", rid="1") == []
+    finally:
+        idx.dispose()
+
+
+def test_cache_index_record_accumulates_anchors(tmp_path: Path) -> None:
+    """Re-recording the same checksum **accumulates** anchor rows.
+
+    A single content-addressed bag can legitimately be anchored
+    from multiple RIDs (e.g., two datasets that share content via
+    clone-via-bag, or a dev-version rerun whose checksum coincides
+    with a release version). Each ``record()`` call adds anchors
+    without removing prior ones.
+    """
+    idx = BagCacheIndex(tmp_path)
+    try:
+        idx.record(checksum="abc", anchors=[("T", "1")])
+        idx.record(checksum="abc", anchors=[("T", "2")])
+        # Both anchors resolve after the round-trip.
+        assert idx.find_bags_for_rid(table="T", rid="1") == ["abc"]
+        assert idx.find_bags_for_rid(table="T", rid="2") == ["abc"]
+    finally:
+        idx.dispose()
+
+
+def test_cache_index_record_dedupes_repeated_anchor(tmp_path: Path) -> None:
+    """Re-inserting an existing (checksum, table, rid) row is a no-op.
+
+    Surfaces the ``INSERT OR IGNORE`` guard on the anchor table.
+    Without it, a re-record with an overlapping anchor would raise
+    on the PRIMARY KEY constraint.
+    """
+    idx = BagCacheIndex(tmp_path)
+    try:
+        idx.record(checksum="abc", anchors=[("T", "1")])
+        idx.record(checksum="abc", anchors=[("T", "1"), ("T", "2")])
+        # No duplicate-key error; both anchors resolve, exactly once.
+        assert idx.find_bags_for_rid(table="T", rid="1") == ["abc"]
         assert idx.find_bags_for_rid(table="T", rid="2") == ["abc"]
     finally:
         idx.dispose()


### PR DESCRIPTION
## Summary

Fixes the **anchor-erasure** bug surfaced by [deriva-ml#142](https://github.com/informatics-isi-edu/deriva-ml/issues/142).

`BagCacheIndex.record()` used to **replace** the entire anchor list on every call via an unconditional `DELETE FROM bag_anchor_rids WHERE checksum = :c`. That made the reverse index quietly lose information whenever the same checksum was recorded with two different anchor RIDs:

1. `record(checksum=X, anchors=[("Dataset", "A")])` — A in reverse index.
2. `record(checksum=X, anchors=[("Dataset", "B")])` — B in reverse index; A is **gone**.
3. `find_bags_for_rid(rid="A")` returns `[]`. The cache looks empty to A even though the bag's bytes are still on disk.

This bites two real-world workflows in deriva-ml:

- **Clone-via-bag** — produces two dataset RIDs that share content by construction. Both downloads hit the same checksum.
- **Dev-version reruns** (ADR-0003) — the same content can be republished under a new version RID; the export's checksum is identical.

The docstring framed the old behaviour as deliberate ("the most recent producer's claim wins"), but reverse-index semantics imply accumulation. The audit's `tests/dataset/test_multi_anchor_bag_cache.py` carries an `xfail(strict=True)` documenting the desired behaviour this PR delivers.

## What changed

`deriva/bag/cache_index.py`:

- Dropped the `DELETE FROM bag_anchor_rids` block in `record()`.
- Switched the anchor `INSERT` to `INSERT OR IGNORE`. The schema's existing `PRIMARY KEY (checksum, "table", rid)` constraint silently dedupes overlapping rows; no schema migration.
- Rewrote the `record()` docstring: contract is now "metadata row upserts, anchor list accumulates; use `forget()` to wipe both."
- The metadata-row upsert (`profile_id`, `built_at`, `anchor_summary_json`, `size_bytes`) is unchanged — "most recent producer wins" still applies where it makes sense.

`tests/deriva/bag/test_cache_index.py`:

- Replaced `test_cache_index_record_is_idempotent` (which pinned the old replacement behaviour) with three more-precise tests:
  - `test_cache_index_record_metadata_is_idempotent` — metadata upsert still works.
  - `test_cache_index_record_accumulates_anchors` — the audit's user story now succeeds.
  - `test_cache_index_record_dedupes_repeated_anchor` — pins the `INSERT OR IGNORE` guard against duplicate-key errors when a re-record overlaps existing anchors.

## Caller compatibility

The single workspace caller is `deriva-ml`'s `bag_download.download_dataset_minid`, which already passes exactly one `(table, rid)` anchor pair per call. After this fix, two downloads of overlapping content accumulate two anchors against the same checksum — exactly what the cache layer wanted all along. The deriva-ml-side `xfail` in `test_multi_anchor_bag_cache.py` will flip to passing after a deriva-py version bump.

## Test plan

- [x] `uv run pytest tests/deriva/bag/test_cache_index.py -v` → 16 passed (was 14, +2 new tests, -1 renamed)
- [x] `uv run pytest tests/deriva/bag/ -q` → 291 passed, 2 skipped (no regressions in the wider deriva.bag suite)
- [x] `uv run ruff check deriva/bag/cache_index.py tests/deriva/bag/test_cache_index.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)