### PR TITLE
bag: Phase 5b — safe performance caches (P.5 + P.6)

### DIFF
--- a/deriva/bag/builder.py
+++ b/deriva/bag/builder.py
@@ -251,6 +251,24 @@ class BagBuilder:
 
         self._finalized = False
 
+        # Memoized schema-JSON projection of ``self.metadata``.
+        # ``_write_schema_json`` and ``_metadata_as_model`` both walk
+        # the metadata; the underlying ``MetaData`` is fixed at
+        # construction time (the package has no schema-mutator on
+        # ``BagBuilder`` after ``__init__``), so a single walk is
+        # safe to share. Filled lazily by ``_schema_json``.
+        self._schema_json_cache: dict[str, Any] | None = None
+
+    def _schema_json(self) -> dict[str, Any]:
+        """Return (and memoize) the ERMrest-JSON projection of self.metadata.
+
+        See :data:`_schema_json_cache` for why a single walk is
+        safe across the bag's lifetime.
+        """
+        if self._schema_json_cache is None:
+            self._schema_json_cache = metadata_to_ermrest_json(self.metadata)
+        return self._schema_json_cache
+
     # ------------------------------------------------------------------
     # Schema access (mostly for callers that want to introspect what
     # tables BagBuilder knows about before adding rows).
@@ -669,7 +687,7 @@ class BagBuilder:
 
     def _write_schema_json(self) -> None:
         """Write ``data/schema.json`` from the metadata."""
-        doc = metadata_to_ermrest_json(self.metadata)
+        doc = self._schema_json()
         # Constructive bags have no source-catalog snapshot, but the
         # ``snaptime`` field is part of the ERMrest wire format.
         # metadata_to_ermrest_json defaults it to None; that's fine.
@@ -722,7 +740,7 @@ class BagBuilder:
         ``Model.fromfile``; that was "mildly wasteful" and is now
         gone).
         """
-        doc = metadata_to_ermrest_json(self.metadata)
+        doc = self._schema_json()
         return Model("file-system", doc)
 
     def _write_provenance_file(self) -> None:

--- a/deriva/core/ermrest_catalog.py
+++ b/deriva/core/ermrest_catalog.py
@@ -385,9 +385,29 @@ class ErmrestCatalog(DerivaBinding):
         r.raise_for_status()
         return r.json()
 
-    def getPathBuilder(self):
-        """Returns the 'path builder' interface for this catalog."""
-        return datapath.from_catalog(self)
+    def getPathBuilder(self, refresh=False):
+        """Returns the 'path builder' interface for this catalog.
+
+        The returned wrapper is **cached on the catalog instance**.
+        Constructing the wrapper walks the full catalog ``/schema``
+        endpoint; for callers that build multiple path expressions
+        against the same catalog (e.g. several
+        :class:`~deriva.bag.catalog_loader.BagCatalogLoader`
+        instances), sharing one wrapper avoids re-walking.
+
+        Args:
+            refresh: When ``True``, discard the cached wrapper and
+                build a fresh one — useful if the catalog schema
+                changed under us. Default ``False``.
+
+        The cache holds one wrapper per catalog instance. Schema
+        rows added by another process between calls are not seen
+        unless the caller passes ``refresh=True``; this is the
+        same staleness window every other catalog-model read has.
+        """
+        if refresh or getattr(self, "_path_builder_cache", None) is None:
+            self._path_builder_cache = datapath.from_catalog(self)
+        return self._path_builder_cache
 
     def getTableSchema(self, fq_table_name):
         # first try to get from cache(s)

--- a/tests/deriva/core/test_ermrest_catalog.py
+++ b/tests/deriva/core/test_ermrest_catalog.py
@@ -1,0 +1,57 @@
+"""Unit tests for :class:`deriva.core.ErmrestCatalog` glue.
+
+Live-catalog functionality is covered by ``test_datapath.py`` and
+the asyncio suites (which require ``DERIVA_PY_TEST_HOSTNAME``).
+This module is for the in-process helpers that don't need a
+server — currently the path-builder cache.
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+def _make_catalog():
+    """Construct an :class:`ErmrestCatalog` without hitting a server.
+
+    ``__init__`` only constructs the base URL — no HTTP — so we can
+    instantiate it directly. Tests that exercise ``getPathBuilder``
+    patch :func:`deriva.core.datapath.from_catalog` to avoid the
+    schema fetch.
+    """
+    from deriva.core import ErmrestCatalog
+
+    return ErmrestCatalog("https", "example.org", "1")
+
+
+def test_get_path_builder_caches_the_wrapper() -> None:
+    """Repeat calls return the same :class:`_CatalogWrapper`."""
+    catalog = _make_catalog()
+    with patch("deriva.core.ermrest_catalog.datapath.from_catalog") as mk:
+        mk.return_value = MagicMock(name="PathBuilder")
+        pb1 = catalog.getPathBuilder()
+        pb2 = catalog.getPathBuilder()
+    assert pb1 is pb2
+    # The expensive ``from_catalog`` walk fired exactly once.
+    assert mk.call_count == 1
+
+
+def test_get_path_builder_refresh_rebuilds_the_wrapper() -> None:
+    """``refresh=True`` discards the cache and walks again."""
+    catalog = _make_catalog()
+    with patch("deriva.core.ermrest_catalog.datapath.from_catalog") as mk:
+        mk.side_effect = lambda c: MagicMock(name="PathBuilder")
+        pb1 = catalog.getPathBuilder()
+        pb2 = catalog.getPathBuilder(refresh=True)
+    assert pb1 is not pb2
+    assert mk.call_count == 2
+
+
+def test_get_path_builder_cache_is_per_catalog() -> None:
+    """Two distinct catalogs get independent caches."""
+    a = _make_catalog()
+    b = _make_catalog()
+    with patch("deriva.core.ermrest_catalog.datapath.from_catalog") as mk:
+        mk.side_effect = lambda c: MagicMock(name=f"PB[{id(c)}]")
+        pb_a = a.getPathBuilder()
+        pb_b = b.getPathBuilder()
+    assert pb_a is not pb_b
+    assert mk.call_count == 2


### PR DESCRIPTION
## Summary

Two memoizations from the Phase 4 audit's performance lens. Both
are correctness-preserving, bounded-scope, and safe at any
workload size — not the speculative scale-out items (which I'm
deliberately deferring until a real benchmark exists).

## What's in

**P.5: Cache `_CatalogWrapper` on `ErmrestCatalog`**

`getPathBuilder()` walks the full `/schema` endpoint and builds
the entire schema → table → column mock-up tree. For callers
that build multiple path expressions against the same catalog
(e.g. several `BagCatalogLoader` instances), sharing one wrapper
avoids re-walking. Now memoized on the catalog instance, with a
`refresh=False` kwarg as an opt-out.

```python
# Same wrapper across calls — no second /schema fetch.
pb1 = catalog.getPathBuilder()
pb2 = catalog.getPathBuilder()
assert pb1 is pb2

# Opt-out when the schema actually changed under us.
pb3 = catalog.getPathBuilder(refresh=True)
assert pb3 is not pb1
```

Three new unit tests in `tests/deriva/core/test_ermrest_catalog.py`
pin (a) repeat calls share the wrapper, (b) `refresh=True`
rebuilds, (c) cache is per-catalog (two distinct catalogs get
independent caches).

**P.6: Cache `metadata_to_ermrest_json` on `BagBuilder`**

`_write_schema_json` and `_metadata_as_model` both walked the
same `MetaData`. Now share one result via a per-`BagBuilder`
cache. Safe because `BagBuilder` has no schema-mutator after
`__init__` — the metadata is fixed at construction time.

## What's NOT in

**P.7: `ForeignKeyOrderer._build_dependency_graph` cache —
skipped.**

The audit's framing implied a hot loop, but actual production
callers invoke `get_insertion_order` / `find_cycles` exactly
once per loader run. Caching saves microseconds while adding
cache-key + invalidation surface. Not worth the complexity at
the call frequency we actually see.

**The scale-out items (P.1, P.2, P.3, 4.2) — deferred.**

The Phase 4 audit characterized these as inert at today's
<100K-row workloads. P.2 (asset-upload `asyncio.gather`) in
particular has a real concurrency-design hazard (per-host
connection limits, server-side ordering for chunked uploads).
Doing them speculatively against the current test fixtures
means writing code we can't measure. The right time is when
a real workload shows pain.

## Test plan

- [x] `pytest tests/deriva/bag/ tests/deriva/core/test_ermrest_catalog.py` — 297 passed, 1 skipped (+3 from new tests)
- [x] Live smoke against localhost catalog 189 — producer + consumer paths green
- [ ] deriva-ml lockstep verification (no public-API changes; should be a no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)