### PR TITLE
refactor(bag): extract SchemaPathWalker shared FK-graph primitive

### DIFF
--- a/deriva/bag/__init__.py
+++ b/deriva/bag/__init__.py
@@ -58,6 +58,10 @@ from deriva.bag.loader import (
     Sink,
     SQLiteSink,
 )
+from deriva.bag.path_walker import (
+    EdgeFilter,
+    SchemaPathWalker,
+)
 from deriva.bag.profile import (
     BAG_SCHEMA_VERSION,
     BAGIT_PROFILE_IDENTIFIER,
@@ -108,6 +112,9 @@ __all__ = [
     "ForeignKeyOrderer",
     "Sink",
     "SQLiteSink",
+    # Path walker (shared FK-graph primitive)
+    "EdgeFilter",
+    "SchemaPathWalker",
     # Schema
     "SchemaBuilder",
     "SchemaORM",

--- a/deriva/bag/catalog_builder.py
+++ b/deriva/bag/catalog_builder.py
@@ -57,6 +57,7 @@ from deriva.bag.anchors import (
     RIDAnchor,
     TableAnchor,
 )
+from deriva.bag.path_walker import SchemaPathWalker
 from deriva.bag.profile import (
     BAGIT_PROFILE_IDENTIFIER,
     write_provenance,
@@ -438,250 +439,54 @@ class CatalogBagBuilder:
     # ------------------------------------------------------------------
 
     def _compute_reached_tables(self) -> None:
-        """BFS the FK graph from the anchor set, honoring the policy.
+        """Run the shared FK walk from the anchor set.
 
-        The walk is bidirectional (FKs followed in both directions)
-        except for vocabulary tables, which are entered but not
-        exited — preventing the Subject → Species →
-        every-other-Subject explosion.
+        Delegates the bidirectional BFS to
+        :class:`~deriva.bag.path_walker.SchemaPathWalker`. The walker
+        carries the scope rules (schema allow/deny, table deny,
+        terminal-tables, ``max_depth``) and the per-target path-set
+        recording; this method translates anchors to roots, calls the
+        walker, and populates the builder's caches.
 
-        Records two side outputs in addition to ``_reached_tables``:
-
-        * :attr:`_anchor_tables` — the anchor-set tables themselves.
-        * :attr:`_table_paths` — every distinct simple FK path
-          (one or more) from an anchor that reached each table.
-          Used by :meth:`_table_query_path` to scope each non-
-          anchor table's query to rows reachable via that FK
-          route. BFS guarantees each recorded path is among the
-          shortest for its endpoint.
-
-        **Worked example** (single-anchor multi-path case):
-
-        Schema fragment::
-
-            Subject ──Image (FK Image.Subject → Subject.RID)
-                │
-                │ Dataset_Subject (assoc)
-                ▼
-            Dataset ─── Dataset_Image (assoc) ─── Image
-
-        Anchored at ``Subject``, the BFS visits ``Image`` two
-        ways:
-
-        1. ``[Subject, Image]`` — direct inbound FK (Image.Subject).
-        2. ``[Subject, Dataset_Subject, Dataset, Dataset_Image, Image]``
-           — via the Dataset_Image association.
-
-        Both paths are recorded in ``_table_paths[("demo", "Image")]``
-        so ``_build_export_spec`` emits one ``query_processor`` per
-        path, each scoped through ERMrest's natural-FK join. The
-        loader unions the two CSV files when the bag is consumed
-        (``ON CONFLICT DO NOTHING`` on RID), so the same Image row
-        reachable both ways is materialized exactly once at the
-        destination.
-
-        The ``max_paths`` knob caps the per-table path count so a
-        densely-connected catalog can't produce an unbounded spec.
+        Vocab tables are treated as leaves (entered but not exited)
+        and the ``max_paths`` cap (16 by default) keeps the spec
+        finite on densely-connected catalogs.
         """
-        from collections import deque
-
         model = self._get_model()
 
-        # Walk strategy:
-        #
-        # - The queue carries one (table, path) entry per FK route
-        #   we've discovered to that table. We dequeue *all* routes
-        #   to a given table even when the table itself is already
-        #   in ``reached_tables`` — that's the whole point of
-        #   multi-path emission. The simple-path guard in
-        #   :meth:`_enqueue_if_in_scope_with_path` (drops a path
-        #   that would re-enter a table it already visits) prevents
-        #   infinite walks on cycles.
-        # - ``paths`` records the BFS-shortest path discovered per
-        #   reached table (backwards-compat with single-path callers).
-        # - ``path_set`` records every distinct simple path
-        #   discovered per reached table so
-        #   :meth:`_build_export_spec` can emit one query_processor
-        #   per FK route. Bounded by ``max_paths`` to keep the spec
-        #   finite on densely-connected catalogs.
-        queue: deque[
-            tuple[str, str, int, tuple[tuple[str, str], ...]]
-        ] = deque()
-        reached: set[tuple[str, str]] = set()
+        # Translate anchors → (schema, table) roots and remember
+        # which keys are anchors so :meth:`_table_query_path` can
+        # detect them.
         anchor_tables: set[tuple[str, str]] = set()
-        paths: dict[tuple[str, str], list[tuple[str, str]]] = {}
-        path_set: dict[
-            tuple[str, str], list[tuple[tuple[str, str], ...]]
-        ] = {}
-
+        roots: list[tuple[str, str]] = []
         for anchor in self.anchors:
-            schema_name, table_name = self._resolve_table(
-                model, anchor.table
-            )
-            key = (schema_name, table_name)
+            key = self._resolve_table(model, anchor.table)
             anchor_tables.add(key)
-            if key not in paths:
-                paths[key] = [key]
-            path_set.setdefault(key, [])
-            anchor_path: tuple[tuple[str, str], ...] = (key,)
-            if anchor_path not in path_set[key]:
-                path_set[key].append(anchor_path)
-            queue.append((schema_name, table_name, 0, anchor_path))
+            roots.append(key)
 
-        max_depth = self.policy.max_depth
-        max_paths = self._max_paths_per_table()
-        while queue:
-            schema_name, table_name, depth, current_path = queue.popleft()
-            key = (schema_name, table_name)
-            reached.add(key)
+        walker = SchemaPathWalker(model=model, policy=self.policy)
+        path_set = walker.walk_bfs(
+            roots, max_paths_per_target=16
+        )
 
-            # Depth bound (None = unbounded).
-            if max_depth is not None and depth >= max_depth:
-                continue
+        # Backwards-compat shape: ``_table_paths`` is a flat
+        # ``{key: list[(schema, table)]}`` — the BFS-shortest path
+        # for each reached target. Pick the first recorded route
+        # (BFS order = shortest-first).
+        paths: dict[tuple[str, str], list[tuple[str, str]]] = {
+            key: list(routes[0]) for key, routes in path_set.items()
+        }
 
-            table = model.schemas[schema_name].tables[table_name]
-            is_vocab = table.is_vocabulary()
-            is_terminal = (
-                schema_name, table_name
-            ) in self.policy.terminal_tables
-            # Vocab tables are fully terminal — vocab terms are
-            # leaf nodes that don't reference further entities;
-            # the canonical vocab columns (ID/URI/Name/...) carry
-            # no outbound FKs in practice. Inbound FKs from a vocab
-            # term would chase every row in the catalog that uses
-            # it, so we don't follow those either.
-            if is_vocab:
-                continue
-            # Non-vocab terminal tables (declared via
-            # :attr:`FKTraversalPolicy.terminal_tables`) follow
-            # OUTBOUND FKs but not INBOUND ones.
-            #
-            # - **Outbound** (``table.foreign_keys``) = FKs the
-            #   terminal table itself declares to other tables.
-            #   These must be followed so the rows it references
-            #   land in the slice. Example: ``Execution.Workflow``
-            #   must resolve, so the walker continues to Workflow
-            #   from each in-slice Execution row.
-            # - **Inbound** (``table.referenced_by``) = FKs other
-            #   tables declare AT the terminal table. Following
-            #   these is what aggregates cross-anchor state: from
-            #   Execution, inbound goes to every ``*_Execution``
-            #   association, and from there to every other anchor
-            #   scope sharing the Execution. That's the over-fetch
-            #   the terminal-tables rule exists to prevent.
-            for fk in table.foreign_keys:
-                self._enqueue_if_in_scope_with_path(
-                    fk.pk_table,
-                    depth + 1,
-                    current_path,
-                    queue,
-                    paths,
-                    path_set,
-                    max_paths,
-                )
-            if is_terminal:
-                # Block inbound for terminal tables.
-                continue
-            for fk in table.referenced_by:
-                self._enqueue_if_in_scope_with_path(
-                    fk.table,
-                    depth + 1,
-                    current_path,
-                    queue,
-                    paths,
-                    path_set,
-                    max_paths,
-                )
-
-        self._reached_tables = reached
+        self._reached_tables = set(path_set.keys())
         self._anchor_tables = anchor_tables
         self._table_paths = paths
         self._table_path_set = path_set
-
-    def _max_paths_per_table(self) -> int:
-        """Cap on distinct FK paths emitted per target table.
-
-        Multi-path emission walks every simple route; densely
-        connected schemas (m FKs between n tables) can in theory
-        produce many. The cap is a finiteness guard, not a tuning
-        knob — in practice every catalog we've seen tops out at
-        2–3 paths to any given table. The default is generous so
-        the cap is never the explanation for missing rows.
-        """
-        return 16
-
-    def _enqueue_if_in_scope_with_path(
-        self,
-        table: DerivaTable,
-        depth: int,
-        prefix_path: tuple[tuple[str, str], ...],
-        queue: "deque[tuple[str, str, int, tuple[tuple[str, str], ...]]]",
-        paths: dict[tuple[str, str], list[tuple[str, str]]],
-        path_set: dict[
-            tuple[str, str], list[tuple[tuple[str, str], ...]]
-        ],
-        max_paths: int,
-    ) -> None:
-        """Queue a candidate with its FK-path prefix, if policy allows.
-
-        Records the BFS-shortest path on first sight (in ``paths``)
-        plus every distinct simple path discovered (in ``path_set``,
-        bounded by ``max_paths``). The caller's BFS still gates
-        the *expansion* of each table by ``visited``; this helper
-        only records the route the walk arrived by.
-
-        Cycles are guarded by the simple-path test (``key in
-        prefix_path``): a path that would re-enter a table it
-        already visits is dropped.
-        """
-        schema_name = table.schema.name
-        table_name = table.name
-        key = (schema_name, table_name)
-        if self._is_excluded_schema(schema_name):
-            return
-        if self._is_excluded_table(schema_name, table_name):
-            return
-        if (
-            self.policy.schemas is not None
-            and schema_name not in self.policy.schemas
-        ):
-            return
-        if key in prefix_path:
-            # Simple-path guard: don't walk back into a table we've
-            # already used on this path. ERMrest joins on natural
-            # FK relationships and the same join twice would be a
-            # loop in the query.
-            return
-        candidate_path: tuple[tuple[str, str], ...] = prefix_path + (key,)
-        if key not in paths:
-            paths[key] = list(candidate_path)
-        bucket = path_set.setdefault(key, [])
-        if candidate_path in bucket:
-            # We've already enqueued this exact path; the dequeue
-            # will walk its descendants once. Re-enqueueing would
-            # do redundant work.
-            return
-        if len(bucket) >= max_paths:
-            # Path budget exhausted; record the new path is dropped
-            # rather than silently emitting an over-large spec.
-            logger.debug(
-                "max_paths=%d reached for %s.%s; dropping path %s",
-                max_paths, schema_name, table_name, candidate_path,
-            )
-            return
-        bucket.append(candidate_path)
-        queue.append((schema_name, table_name, depth, candidate_path))
 
     def _is_excluded_schema(self, schema_name: str) -> bool:
         return (
             schema_name in DEFAULT_EXCLUDE_SCHEMAS
             or schema_name in self.policy.exclude_schemas
         )
-
-    def _is_excluded_table(
-        self, schema_name: str, table_name: str
-    ) -> bool:
-        return (schema_name, table_name) in self.policy.exclude_tables
 
     # ------------------------------------------------------------------
     # Export-spec generation

--- a/deriva/bag/path_walker.py
+++ b/deriva/bag/path_walker.py
@@ -1,0 +1,460 @@
+"""Generic FK-graph path walker.
+
+:class:`SchemaPathWalker` is the **shared primitive** for "walk the
+foreign-key graph from a root table, recording paths, honoring scope
+and depth limits, and treating vocabularies as leaves." It is the
+extracted core of :class:`~deriva.bag.catalog_builder.CatalogBagBuilder`'s
+``_compute_reached_tables`` and serves both:
+
+* **Bag export** (:class:`CatalogBagBuilder`): BFS from one or more
+  anchors, recording multi-path routes to each reached table, capped
+  by ``max_paths`` so densely-connected catalogs stay finite. The
+  result drives one ``query_processor`` per ``(target, route)``.
+* **Denormalization** (deriva-ml's ``DenormalizePlanner``):
+  exhaustive DFS from a single root (Dataset), emitting **every
+  prefix** of every walked path. The result drives JOIN-tree
+  construction and Rule 6 ambiguity detection.
+
+Both consumers ultimately want "all valid FK chains from the root
+through the schema graph." They differ in how much of the chain
+they consume — BFS-shortest vs. every-prefix — and in their
+finiteness guards. :class:`SchemaPathWalker` exposes both modes
+behind a single class so the *graph-traversal* logic lives in one
+place.
+
+What this module deliberately does **not** carry:
+
+* No anchor-RID filtering (the bag walker layers that on top by
+  attaching filters to query paths after the walk).
+* No domain-specific transparency rules (e.g. DerivaML's
+  "feature-association tables are transparent bridges"). Those
+  belong in the consumer because they reference domain concepts
+  (``Execution``) that have no place in a generic walker.
+* No vocab-export choice, asset mode, or any
+  :class:`~deriva.bag.traversal.FKTraversalPolicy` fields that
+  describe *what to do with the result* — those are
+  consumer-layer concerns. The walker honors only the fields that
+  shape the *walk itself*.
+
+Design note: this is a deliberately small, focused class. The
+duplication between the bag walker and denormalize's
+``_schema_to_paths`` was real but at the primitive level, not the
+API level. Extracting the primitive cleans up both call sites
+without forcing them onto a single output shape they can't agree
+on.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Callable, Iterator
+from typing import Any
+
+from deriva.core.ermrest_model import Table as DerivaTable
+
+from deriva.bag.traversal import DEFAULT_EXCLUDE_SCHEMAS, FKTraversalPolicy
+
+
+#: Type of an optional edge-filter hook.
+#:
+#: Called once per candidate edge during the walk. Returns ``True``
+#: to allow the edge, ``False`` to drop it. The walker passes the
+#: *source* table (where the walk currently is) and the *target*
+#: table (where the edge would lead). Domain-specific filters —
+#: e.g. "don't follow association tables back to the root table" —
+#: live in the consumer and plug in here.
+EdgeFilter = Callable[[DerivaTable, DerivaTable], bool]
+
+
+class SchemaPathWalker:
+    """Walk the FK graph from a root table.
+
+    The walker follows both **outbound** FKs (``table.foreign_keys``)
+    and **inbound** FKs (``table.referenced_by``) — the bidirectional
+    walk is the only one any real consumer wants. Vocabulary tables
+    are entered but not exited (they're leaves), preventing the
+    classic ``Subject → Species → every-other-Subject`` explosion.
+    Multi-FK edges between the same pair of tables are deduplicated
+    by target (one walk edge per ``(src, tgt)``); callers that need
+    the full FK set call :meth:`~deriva.core.ermrest_model.Table.foreign_keys`
+    themselves at the consumer layer.
+
+    Two enumeration modes:
+
+    * :meth:`walk_bfs` — BFS recording the shortest path discovered
+      per ``(target, route)``. Multiple distinct routes to the same
+      target are emitted. Used by the bag walker.
+    * :meth:`walk_all_prefixes` — DFS emitting **every prefix** of
+      every walked path. Used by denormalize's ``_schema_to_paths``,
+      which needs to filter and reshape paths post-hoc.
+
+    Args:
+        model: An ERMrest catalog model (the object returned by
+            :meth:`ErmrestCatalog.getCatalogModel`).
+        policy: :class:`FKTraversalPolicy`. Only the walk-shaping
+            fields are honored: ``schemas``, ``exclude_schemas``,
+            ``exclude_tables``, ``terminal_tables``, ``max_depth``.
+            Behavior-on-output fields (``vocab_export``,
+            ``asset_mode``, …) are ignored — those belong to the
+            consumer.
+        edge_filter: Optional hook for consumer-specific edge
+            pruning. Called per candidate edge; return ``False`` to
+            drop the edge.
+
+    Example:
+        BFS reachability from a single root::
+
+            walker = SchemaPathWalker(
+                model=catalog.getCatalogModel(),
+                policy=FKTraversalPolicy(schemas={"isa"}),
+            )
+            paths_by_target = dict(
+                walker.walk_bfs([("isa", "Dataset")])
+            )
+            for (schema, table), routes in paths_by_target.items():
+                for route in routes:
+                    print(table, "via", " -> ".join(t for _, t in route))
+
+        DFS every-prefix from a single root (denormalize style)::
+
+            walker = SchemaPathWalker(model=model, policy=policy)
+            for path in walker.walk_all_prefixes(root=dataset_table):
+                # path is a tuple[Table, ...] starting at dataset_table
+                ...
+    """
+
+    def __init__(
+        self,
+        *,
+        model: Any,
+        policy: FKTraversalPolicy | None = None,
+        edge_filter: EdgeFilter | None = None,
+    ) -> None:
+        self.model = model
+        self.policy = policy or FKTraversalPolicy()
+        self.edge_filter = edge_filter
+
+    # ------------------------------------------------------------------
+    # Mode 1: BFS, one BFS-shortest path per route per target.
+    # ------------------------------------------------------------------
+
+    def walk_bfs(
+        self,
+        roots: list[tuple[str, str]],
+        *,
+        max_paths_per_target: int = 16,
+    ) -> dict[
+        tuple[str, str], list[tuple[tuple[str, str], ...]]
+    ]:
+        """BFS the FK graph from a set of root tables.
+
+        For every reachable table, record one or more distinct
+        simple-path routes from a root. Each route is a tuple of
+        ``(schema, table)`` segments starting at the root and ending
+        at the target. ``max_paths_per_target`` bounds the per-target
+        route count so densely-connected catalogs can't produce an
+        unbounded set.
+
+        Args:
+            roots: One or more ``(schema, table)`` starting points.
+                Duplicates are deduplicated.
+            max_paths_per_target: Cap on per-target route count.
+                Default 16 — generous enough that real catalogs hit
+                their natural ceiling (2–3) before the cap fires.
+
+        Returns:
+            ``{(schema, table): [route, ...]}`` keyed by reached
+            table, where each route is a tuple of ``(schema, table)``
+            segments. Routes are recorded in BFS-discovery order.
+
+        Example:
+            >>> walker.walk_bfs([("isa", "Dataset")])  # doctest: +SKIP
+            {('isa', 'Dataset'): [(('isa', 'Dataset'),)],
+             ('isa', 'Image'): [(('isa', 'Dataset'), ('isa', 'Dataset_Image'), ('isa', 'Image'))],
+             ...}
+        """
+        # The queue carries one (table, depth, prefix-path) entry per
+        # FK route we've discovered to that table. We dequeue *all*
+        # routes to a given table — that's the whole point of
+        # multi-path recording. The simple-path guard in
+        # ``_record_edge`` (drops a candidate that would re-enter a
+        # table already on its path) prevents infinite walks on
+        # cycles.
+        queue: deque[
+            tuple[str, str, int, tuple[tuple[str, str], ...]]
+        ] = deque()
+        reached: set[tuple[str, str]] = set()
+        path_set: dict[
+            tuple[str, str], list[tuple[tuple[str, str], ...]]
+        ] = {}
+
+        # Seed the queue with each root.
+        seen_roots: set[tuple[str, str]] = set()
+        for root_key in roots:
+            if root_key in seen_roots:
+                continue
+            seen_roots.add(root_key)
+            schema_name, table_name = root_key
+            path_set.setdefault(root_key, [])
+            root_path: tuple[tuple[str, str], ...] = (root_key,)
+            if root_path not in path_set[root_key]:
+                path_set[root_key].append(root_path)
+            queue.append((schema_name, table_name, 0, root_path))
+
+        max_depth = self.policy.max_depth
+        while queue:
+            schema_name, table_name, depth, current_path = queue.popleft()
+            key = (schema_name, table_name)
+            reached.add(key)
+
+            # Depth bound (None = unbounded).
+            if max_depth is not None and depth >= max_depth:
+                continue
+
+            try:
+                table = self.model.schemas[schema_name].tables[table_name]
+            except KeyError:
+                # Schema/table dropped between queueing and dequeue
+                # (defensive). Skip silently.
+                continue
+
+            # Vocab tables: enter but never exit. Same rule both
+            # modes — the walker's universal "vocab is a leaf" guard.
+            if table.is_vocabulary():
+                continue
+
+            is_terminal = key in self.policy.terminal_tables
+
+            # Outbound FKs: tables this one references.
+            for fk in table.foreign_keys:
+                self._enqueue_candidate(
+                    fk.pk_table,
+                    depth + 1,
+                    current_path,
+                    queue,
+                    path_set,
+                    max_paths_per_target,
+                )
+
+            # Inbound FKs: tables that reference this one. Skipped for
+            # terminal tables — see FKTraversalPolicy.terminal_tables.
+            if is_terminal:
+                continue
+            for fk in table.referenced_by:
+                self._enqueue_candidate(
+                    fk.table,
+                    depth + 1,
+                    current_path,
+                    queue,
+                    path_set,
+                    max_paths_per_target,
+                )
+
+        # Filter the path set to reached tables only (defensive — the
+        # main loop already only populates entries for reached
+        # targets).
+        return {key: path_set[key] for key in sorted(reached)}
+
+    # ------------------------------------------------------------------
+    # Mode 2: DFS, every-prefix enumeration.
+    # ------------------------------------------------------------------
+
+    def walk_all_prefixes(
+        self,
+        root: DerivaTable,
+        *,
+        max_depth: int | None = None,
+        stop_at: str | None = None,
+    ) -> list[tuple[DerivaTable, ...]]:
+        """DFS the FK graph from one root, emit every prefix.
+
+        Recursive DFS, returning every walked prefix as a separate
+        path. If ``[Dataset, A, B, C]`` is walked, then ``[Dataset]``,
+        ``[Dataset, A]``, ``[Dataset, A, B]`` are also in the result.
+        This shape is what denormalize's planner needs to filter
+        post-hoc by endpoint and intermediate-membership.
+
+        Cycle detection: a table that already appears on the current
+        path is skipped (simple-path enforcement). Vocab tables are
+        emitted as terminal (the prefix containing them is in the
+        result; nothing further is walked).
+
+        Args:
+            root: Starting :class:`Table` for the DFS.
+            max_depth: Optional cap on path length (number of tables
+                in the path). Overrides the policy's ``max_depth``
+                for this call only. ``None`` (default) falls back to
+                the policy's ``max_depth``, which itself defaults to
+                unbounded.
+            stop_at: If supplied, return only paths whose last table
+                has this name. Inner DFS frames still emit normally;
+                this is a final filter applied to the result. Useful
+                for "all paths from X to Y" queries.
+
+        Returns:
+            List of paths, each a tuple of :class:`Table` objects
+            starting at ``root``. Includes every prefix.
+
+        Example:
+            >>> walker.walk_all_prefixes(root=dataset_table)  # doctest: +SKIP
+            [(dataset,), (dataset, dataset_subject), ..., (dataset, dataset_image, image, subject), ...]
+        """
+        effective_max = (
+            max_depth if max_depth is not None else self.policy.max_depth
+        )
+        paths: list[tuple[DerivaTable, ...]] = []
+        self._dfs_prefixes(
+            root=root,
+            current=[],
+            max_depth=effective_max,
+            stop_at=stop_at,
+            out=paths,
+        )
+        return paths
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _enqueue_candidate(
+        self,
+        table: DerivaTable,
+        depth: int,
+        prefix_path: tuple[tuple[str, str], ...],
+        queue: "deque[tuple[str, str, int, tuple[tuple[str, str], ...]]]",
+        path_set: dict[
+            tuple[str, str], list[tuple[tuple[str, str], ...]]
+        ],
+        max_paths_per_target: int,
+    ) -> None:
+        """Queue a candidate edge for the BFS, applying scope rules."""
+        schema_name = table.schema.name
+        table_name = table.name
+        key = (schema_name, table_name)
+
+        # Scope guards: schema allow/deny, table deny, edge filter.
+        if self._is_excluded_schema(schema_name):
+            return
+        if (schema_name, table_name) in self.policy.exclude_tables:
+            return
+        if (
+            self.policy.schemas is not None
+            and schema_name not in self.policy.schemas
+        ):
+            return
+        if key in prefix_path:
+            # Simple-path guard: don't walk back into a table this
+            # path already uses. ERMrest joins on natural FK
+            # relationships; revisiting a table would loop the
+            # corresponding query.
+            return
+        if self.edge_filter is not None:
+            # Source = last segment of the current prefix path.
+            src_schema, src_table = prefix_path[-1]
+            try:
+                src = self.model.schemas[src_schema].tables[src_table]
+            except KeyError:
+                return
+            if not self.edge_filter(src, table):
+                return
+
+        candidate_path: tuple[tuple[str, str], ...] = prefix_path + (key,)
+        bucket = path_set.setdefault(key, [])
+        if candidate_path in bucket:
+            return
+        if len(bucket) >= max_paths_per_target:
+            # Path budget exhausted; drop further routes to this
+            # target rather than emit an unbounded set.
+            return
+        bucket.append(candidate_path)
+        queue.append((schema_name, table_name, depth, candidate_path))
+
+    def _dfs_prefixes(
+        self,
+        *,
+        root: DerivaTable,
+        current: list[DerivaTable],
+        max_depth: int | None,
+        stop_at: str | None,
+        out: list[tuple[DerivaTable, ...]],
+    ) -> None:
+        """DFS recursion that records every prefix.
+
+        The current path is built incrementally; the new prefix is
+        appended to ``out`` on each call. Cycles are guarded by the
+        membership check (``root not in current``) — and vocab tables
+        terminate the recursion without further expansion.
+        """
+        # Cycle guard before append.
+        if root in current:
+            return
+
+        # Schema scope.
+        schema_name = root.schema.name
+        table_name = root.name
+        if self._is_excluded_schema(schema_name):
+            return
+        if (schema_name, table_name) in self.policy.exclude_tables:
+            return
+        if (
+            self.policy.schemas is not None
+            and schema_name not in self.policy.schemas
+        ):
+            return
+
+        new_path = current + [root]
+        out.append(tuple(new_path))
+
+        # Depth cap. Match historical _schema_to_paths semantics:
+        # "len(path) >= max_depth" stops recursion (the current
+        # prefix is emitted but children are not).
+        if max_depth is not None and len(new_path) >= max_depth:
+            return
+
+        # Vocab tables are leaves.
+        if root.is_vocabulary():
+            return
+
+        # Edge candidates: outbound + inbound, deduplicated by target
+        # (multi-FK between same pair counts as one walk edge).
+        parent = current[-1] if current else None
+        candidates: list[DerivaTable] = []
+        seen: set[int] = set()
+        for fk in root.foreign_keys:
+            t = fk.pk_table
+            if id(t) in seen:
+                continue
+            seen.add(id(t))
+            candidates.append(t)
+        for fk in root.referenced_by:
+            t = fk.table
+            if id(t) in seen:
+                continue
+            seen.add(id(t))
+            candidates.append(t)
+
+        for child in candidates:
+            if parent is not None and child is parent:
+                # Don't bounce back to immediate parent through
+                # referenced_by (it's just the same FK re-walked).
+                continue
+            if self.edge_filter is not None and not self.edge_filter(
+                root, child
+            ):
+                continue
+            self._dfs_prefixes(
+                root=child,
+                current=new_path,
+                max_depth=max_depth,
+                stop_at=stop_at,
+                out=out,
+            )
+
+    def _is_excluded_schema(self, schema_name: str) -> bool:
+        return (
+            schema_name in DEFAULT_EXCLUDE_SCHEMAS
+            or schema_name in self.policy.exclude_schemas
+        )
+
+
+__all__ = ["EdgeFilter", "SchemaPathWalker"]

--- a/tests/deriva/bag/test_path_walker.py
+++ b/tests/deriva/bag/test_path_walker.py
@@ -1,0 +1,400 @@
+"""Tests for :class:`~deriva.bag.path_walker.SchemaPathWalker`.
+
+These tests exercise the walker as a standalone primitive — separate
+from :class:`CatalogBagBuilder`, which uses it as its FK-walk engine.
+Coverage focuses on the two emission modes (BFS multi-route,
+DFS-every-prefix), the policy fields the walker honors
+(``schemas``/``exclude_schemas``/``exclude_tables``/``terminal_tables``/
+``max_depth``), the universal vocab-as-leaf rule, multi-FK
+deduplication, and the consumer-supplied ``edge_filter`` hook.
+
+The catalog model is mocked the same way ``test_catalog_builder.py``
+mocks it — these tests share the helper functions to keep behavior
+parity with the bag-builder tests.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from deriva.bag.path_walker import SchemaPathWalker
+from deriva.bag.traversal import FKTraversalPolicy
+
+
+# ---------------------------------------------------------------------------
+# Mock helpers — copies of the catalog-builder test helpers so this
+# test file stays self-contained.
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_table(
+    schema_name: str,
+    table_name: str,
+    *,
+    is_vocabulary: bool = False,
+    outbound_fks: list[Any] | None = None,
+    inbound_fks: list[Any] | None = None,
+) -> MagicMock:
+    t = MagicMock(name=f"Table[{schema_name}.{table_name}]")
+    t.name = table_name
+    t.schema = MagicMock(name=f"Schema[{schema_name}]")
+    t.schema.name = schema_name
+    t.is_vocabulary.return_value = is_vocabulary
+    t.foreign_keys = list(outbound_fks or [])
+    t.referenced_by = list(inbound_fks or [])
+    return t
+
+
+def _make_mock_model(
+    schemas: dict[str, dict[str, MagicMock]],
+) -> MagicMock:
+    model = MagicMock(name="Model")
+    model.schemas = {}
+    for schema_name, tables in schemas.items():
+        schema = MagicMock(name=f"Schema[{schema_name}]")
+        schema.name = schema_name
+        schema.tables = tables
+        for t in tables.values():
+            t.schema = schema
+        model.schemas[schema_name] = schema
+    return model
+
+
+def _fk(*, src: MagicMock, pk: MagicMock) -> MagicMock:
+    fk = MagicMock(name="ForeignKey")
+    fk.table = src
+    fk.pk_table = pk
+    return fk
+
+
+def _wire_fk(src: MagicMock, pk: MagicMock) -> None:
+    """Install one FK edge: ``src.{column}`` → ``pk.RID``."""
+    fk = _fk(src=src, pk=pk)
+    src.foreign_keys.append(fk)
+    pk.referenced_by.append(fk)
+
+
+# ---------------------------------------------------------------------------
+# walk_bfs
+# ---------------------------------------------------------------------------
+
+
+def test_walk_bfs_reaches_outbound_fk() -> None:
+    subject = _make_mock_table("demo", "Subject")
+    image = _make_mock_table("demo", "Image")
+    _wire_fk(src=image, pk=subject)
+    model = _make_mock_model(
+        {"demo": {"Image": image, "Subject": subject}}
+    )
+    walker = SchemaPathWalker(model=model)
+    paths = walker.walk_bfs([("demo", "Image")])
+    assert set(paths) == {("demo", "Image"), ("demo", "Subject")}
+    # BFS path from Image to Subject: [Image, Subject].
+    assert paths[("demo", "Subject")][0] == (
+        ("demo", "Image"),
+        ("demo", "Subject"),
+    )
+
+
+def test_walk_bfs_reaches_inbound_fk() -> None:
+    subject = _make_mock_table("demo", "Subject")
+    image = _make_mock_table("demo", "Image")
+    _wire_fk(src=image, pk=subject)
+    model = _make_mock_model(
+        {"demo": {"Image": image, "Subject": subject}}
+    )
+    walker = SchemaPathWalker(model=model)
+    paths = walker.walk_bfs([("demo", "Subject")])
+    assert set(paths) == {("demo", "Image"), ("demo", "Subject")}
+
+
+def test_walk_bfs_vocab_does_not_propagate_inbound() -> None:
+    species = _make_mock_table("demo", "Species", is_vocabulary=True)
+    subject = _make_mock_table("demo", "Subject")
+    other = _make_mock_table("demo", "Other")
+    _wire_fk(src=subject, pk=species)
+    _wire_fk(src=other, pk=species)
+    model = _make_mock_model(
+        {
+            "demo": {
+                "Species": species,
+                "Subject": subject,
+                "Other": other,
+            }
+        }
+    )
+    walker = SchemaPathWalker(model=model)
+    reached = walker.walk_bfs([("demo", "Subject")])
+    assert set(reached) == {("demo", "Subject"), ("demo", "Species")}
+    assert ("demo", "Other") not in reached
+
+
+def test_walk_bfs_respects_max_depth() -> None:
+    a = _make_mock_table("demo", "A")
+    b = _make_mock_table("demo", "B")
+    c = _make_mock_table("demo", "C")
+    _wire_fk(src=a, pk=b)
+    _wire_fk(src=b, pk=c)
+    model = _make_mock_model({"demo": {"A": a, "B": b, "C": c}})
+    walker = SchemaPathWalker(
+        model=model,
+        policy=FKTraversalPolicy(max_depth=1),
+    )
+    reached = walker.walk_bfs([("demo", "A")])
+    # Depth 1: A and its direct neighbor B; not C.
+    assert set(reached) == {("demo", "A"), ("demo", "B")}
+
+
+def test_walk_bfs_respects_exclude_tables() -> None:
+    a = _make_mock_table("demo", "A")
+    b = _make_mock_table("demo", "B")
+    c = _make_mock_table("demo", "C")
+    _wire_fk(src=a, pk=b)
+    _wire_fk(src=b, pk=c)
+    model = _make_mock_model({"demo": {"A": a, "B": b, "C": c}})
+    walker = SchemaPathWalker(
+        model=model,
+        policy=FKTraversalPolicy(exclude_tables={("demo", "B")}),
+    )
+    reached = walker.walk_bfs([("demo", "A")])
+    assert set(reached) == {("demo", "A")}
+
+
+def test_walk_bfs_respects_schema_allowlist() -> None:
+    a = _make_mock_table("demo", "A")
+    b = _make_mock_table("other", "B")
+    _wire_fk(src=a, pk=b)
+    model = _make_mock_model(
+        {"demo": {"A": a}, "other": {"B": b}}
+    )
+    walker = SchemaPathWalker(
+        model=model,
+        policy=FKTraversalPolicy(schemas={"demo"}),
+    )
+    reached = walker.walk_bfs([("demo", "A")])
+    assert set(reached) == {("demo", "A")}
+
+
+def test_walk_bfs_terminal_table_blocks_inbound_keeps_outbound() -> None:
+    # Execution is terminal: it follows its own outbound (Workflow) but
+    # not its inbound (Image_Execution → Execution → Other anchors).
+    execution = _make_mock_table("demo", "Execution")
+    workflow = _make_mock_table("demo", "Workflow")
+    image_exec = _make_mock_table("demo", "Image_Execution")
+    _wire_fk(src=execution, pk=workflow)  # outbound from Execution
+    _wire_fk(src=image_exec, pk=execution)  # inbound into Execution
+    model = _make_mock_model(
+        {
+            "demo": {
+                "Execution": execution,
+                "Workflow": workflow,
+                "Image_Execution": image_exec,
+            }
+        }
+    )
+    walker = SchemaPathWalker(
+        model=model,
+        policy=FKTraversalPolicy(
+            terminal_tables={("demo", "Execution")},
+        ),
+    )
+    reached = walker.walk_bfs([("demo", "Execution")])
+    # Workflow reached (outbound followed). Image_Execution NOT reached
+    # (inbound blocked).
+    assert set(reached) == {("demo", "Execution"), ("demo", "Workflow")}
+    assert ("demo", "Image_Execution") not in reached
+
+
+def test_walk_bfs_multi_path_records_all_routes() -> None:
+    # Image is reachable from Subject two ways:
+    #   1) Image.Subject (direct inbound)
+    #   2) Subject ← Dataset_Subject ← Dataset → Dataset_Image → Image
+    subject = _make_mock_table("demo", "Subject")
+    image = _make_mock_table("demo", "Image")
+    dataset = _make_mock_table("demo", "Dataset")
+    ds_subject = _make_mock_table("demo", "Dataset_Subject")
+    ds_image = _make_mock_table("demo", "Dataset_Image")
+    _wire_fk(src=image, pk=subject)
+    _wire_fk(src=ds_subject, pk=dataset)
+    _wire_fk(src=ds_subject, pk=subject)
+    _wire_fk(src=ds_image, pk=dataset)
+    _wire_fk(src=ds_image, pk=image)
+    model = _make_mock_model(
+        {
+            "demo": {
+                "Subject": subject,
+                "Image": image,
+                "Dataset": dataset,
+                "Dataset_Subject": ds_subject,
+                "Dataset_Image": ds_image,
+            }
+        }
+    )
+    walker = SchemaPathWalker(model=model)
+    paths = walker.walk_bfs([("demo", "Subject")])
+    image_routes = paths[("demo", "Image")]
+    # At least two distinct routes recorded.
+    assert len(image_routes) >= 2
+
+
+def test_walk_bfs_max_paths_caps_routes() -> None:
+    # Tightly connected graph that would explode without a cap.
+    a = _make_mock_table("demo", "A")
+    b = _make_mock_table("demo", "B")
+    # Wire multiple distinct routes by inserting hubs.
+    hubs = [_make_mock_table("demo", f"H{i}") for i in range(20)]
+    for h in hubs:
+        _wire_fk(src=a, pk=h)
+        _wire_fk(src=h, pk=b)
+    model = _make_mock_model(
+        {"demo": {"A": a, "B": b, **{h.name: h for h in hubs}}}
+    )
+    walker = SchemaPathWalker(model=model)
+    paths = walker.walk_bfs(
+        [("demo", "A")], max_paths_per_target=5
+    )
+    # Cap honored on the densely-reached B.
+    assert len(paths[("demo", "B")]) <= 5
+
+
+def test_walk_bfs_edge_filter_drops_edges() -> None:
+    a = _make_mock_table("demo", "A")
+    b = _make_mock_table("demo", "B")
+    c = _make_mock_table("demo", "C")
+    _wire_fk(src=a, pk=b)
+    _wire_fk(src=b, pk=c)
+    model = _make_mock_model(
+        {"demo": {"A": a, "B": b, "C": c}}
+    )
+    # Drop every edge that would land on B.
+    def filter_out_b(src: Any, tgt: Any) -> bool:
+        return tgt.name != "B"
+
+    walker = SchemaPathWalker(model=model, edge_filter=filter_out_b)
+    reached = walker.walk_bfs([("demo", "A")])
+    assert set(reached) == {("demo", "A")}
+
+
+# ---------------------------------------------------------------------------
+# walk_all_prefixes
+# ---------------------------------------------------------------------------
+
+
+def test_walk_all_prefixes_emits_every_prefix() -> None:
+    a = _make_mock_table("demo", "A")
+    b = _make_mock_table("demo", "B")
+    c = _make_mock_table("demo", "C")
+    _wire_fk(src=a, pk=b)
+    _wire_fk(src=b, pk=c)
+    model = _make_mock_model(
+        {"demo": {"A": a, "B": b, "C": c}}
+    )
+    walker = SchemaPathWalker(model=model)
+    paths = walker.walk_all_prefixes(root=a)
+    sigs = {tuple(t.name for t in p) for p in paths}
+    # Every prefix: [A], [A, B], [A, B, C].
+    assert ("A",) in sigs
+    assert ("A", "B") in sigs
+    assert ("A", "B", "C") in sigs
+
+
+def test_walk_all_prefixes_vocab_terminates() -> None:
+    a = _make_mock_table("demo", "A")
+    vocab = _make_mock_table("demo", "Vocab", is_vocabulary=True)
+    other = _make_mock_table("demo", "Other")
+    _wire_fk(src=a, pk=vocab)
+    _wire_fk(src=other, pk=vocab)  # Other references Vocab too
+    model = _make_mock_model(
+        {"demo": {"A": a, "Vocab": vocab, "Other": other}}
+    )
+    walker = SchemaPathWalker(model=model)
+    paths = walker.walk_all_prefixes(root=a)
+    sigs = {tuple(t.name for t in p) for p in paths}
+    # A and A→Vocab present; nothing past Vocab.
+    assert ("A",) in sigs
+    assert ("A", "Vocab") in sigs
+    # Should NOT walk Vocab.referenced_by → Other.
+    for sig in sigs:
+        assert "Other" not in sig
+
+
+def test_walk_all_prefixes_respects_max_depth() -> None:
+    a = _make_mock_table("demo", "A")
+    b = _make_mock_table("demo", "B")
+    c = _make_mock_table("demo", "C")
+    _wire_fk(src=a, pk=b)
+    _wire_fk(src=b, pk=c)
+    model = _make_mock_model(
+        {"demo": {"A": a, "B": b, "C": c}}
+    )
+    walker = SchemaPathWalker(model=model)
+    paths = walker.walk_all_prefixes(root=a, max_depth=2)
+    sigs = {tuple(t.name for t in p) for p in paths}
+    assert ("A",) in sigs
+    assert ("A", "B") in sigs
+    # max_depth=2 stops at length-2 paths; C should not be reached.
+    assert ("A", "B", "C") not in sigs
+
+
+def test_walk_all_prefixes_detects_cycles() -> None:
+    # A → B → A cycle.
+    a = _make_mock_table("demo", "A")
+    b = _make_mock_table("demo", "B")
+    _wire_fk(src=a, pk=b)
+    _wire_fk(src=b, pk=a)
+    model = _make_mock_model({"demo": {"A": a, "B": b}})
+    walker = SchemaPathWalker(model=model)
+    paths = walker.walk_all_prefixes(root=a)
+    # Should terminate (no infinite recursion) and each path should
+    # appear at most once.
+    sigs = [tuple(t.name for t in p) for p in paths]
+    for sig in sigs:
+        # No table appears twice on the same path.
+        assert len(set(sig)) == len(sig), f"Cycle in {sig}"
+
+
+def test_walk_all_prefixes_dedupes_multi_fk_edges() -> None:
+    # Two FKs between A and B should collapse to one walk edge.
+    a = _make_mock_table("demo", "A")
+    b = _make_mock_table("demo", "B")
+    _wire_fk(src=a, pk=b)
+    _wire_fk(src=a, pk=b)  # second FK to the same target
+    model = _make_mock_model({"demo": {"A": a, "B": b}})
+    walker = SchemaPathWalker(model=model)
+    paths = walker.walk_all_prefixes(root=a)
+    sigs = [tuple(t.name for t in p) for p in paths]
+    # ("A", "B") should appear once, not twice.
+    ab_count = sum(1 for s in sigs if s == ("A", "B"))
+    assert ab_count == 1
+
+
+def test_walk_all_prefixes_edge_filter_can_block_loopback() -> None:
+    # Simulate the nested-dataset-loopback: A → Bridge → A.
+    a = _make_mock_table("demo", "A")
+    bridge = _make_mock_table("demo", "Bridge")
+    other = _make_mock_table("demo", "Other")
+    _wire_fk(src=bridge, pk=a)
+    _wire_fk(src=bridge, pk=other)
+    model = _make_mock_model(
+        {"demo": {"A": a, "Bridge": bridge, "Other": other}}
+    )
+
+    # Loopback filter: don't allow bridge → a when traversal is
+    # already past a.
+    def filter_loopback(src: Any, tgt: Any) -> bool:
+        if src.name == "Bridge" and tgt.name == "A":
+            return False
+        return True
+
+    walker = SchemaPathWalker(model=model, edge_filter=filter_loopback)
+    paths = walker.walk_all_prefixes(root=a)
+    sigs = {tuple(t.name for t in p) for p in paths}
+    # A → Bridge → Other should still be discoverable.
+    assert ("A", "Bridge", "Other") in sigs
+    # A → Bridge → A should NOT appear (cycle would be blocked anyway,
+    # but this verifies the filter is consulted).
+    for sig in sigs:
+        assert sig != ("A", "Bridge", "A")


### PR DESCRIPTION
## Summary

- Extracts the BFS/DFS FK-graph walk out of `CatalogBagBuilder` into a focused, reusable primitive (`deriva.bag.path_walker.SchemaPathWalker`).
- `CatalogBagBuilder._compute_reached_tables` is now a 30-line driver around the walker; the 250-line BFS body it replaced is gone.
- All 303 existing bag tests pass unchanged; 16 new tests cover the walker directly (total 319 in the bag suite).

## Why

deriva-ml's denormalize pipeline has its own near-duplicate FK walker
(`DenormalizePlanner._schema_to_paths`). The two implementations have
the same shape — bidirectional FK walk, vocab-as-leaf, multi-FK
dedup, simple-path cycle guard, schema/exclude scope — but with
divergent code paths that have drifted independently. The denormalize
audit (`docs/audits/2026-05-26-denormalize-audit.md` on the
deriva-ml repo) calls this out as real duplication worth factoring.

Extracting the shared primitive into deriva-py lets both consumers
share one implementation. The companion deriva-ml PR
(`refactor/denormalize-uses-deriva-py-walker`) refactors
`_schema_to_paths` to a 30-line wrapper around `SchemaPathWalker`,
layering DerivaML-specific rules (nested-dataset loopback,
`Dataset_Dataset` / `Execution` skip set) via the walker's
`edge_filter` hook.

## Public API

\`\`\`python
class SchemaPathWalker:
    def __init__(
        self,
        *,
        model,                  # ErmrestCatalog model
        policy: FKTraversalPolicy | None = None,
        edge_filter: EdgeFilter | None = None,
    ) -> None: ...

    def walk_bfs(
        self,
        roots: list[tuple[str, str]],
        *,
        max_paths_per_target: int = 16,
    ) -> dict[tuple[str, str], list[tuple[tuple[str, str], ...]]]: ...

    def walk_all_prefixes(
        self,
        root: DerivaTable,
        *,
        max_depth: int | None = None,
        stop_at: str | None = None,
    ) -> list[tuple[DerivaTable, ...]]: ...
\`\`\`

`EdgeFilter = Callable[[Table, Table], bool]` — consumer-supplied
hook for domain-specific edge pruning (DerivaML's loopback rule,
etc.). Returns `False` to drop the edge.

`FKTraversalPolicy` fields the walker honors: `schemas`,
`exclude_schemas`, `exclude_tables`, `terminal_tables`, `max_depth`.
The other policy fields (`vocab_export`, `asset_mode`,
`dangling_fk_strategy`, …) describe what to do *with* the walk's
output and stay on the bag-layer consumers.

## Backwards-incompatible changes

None for the bag layer's public API. The walker's internals are
behind `CatalogBagBuilder` — no behavior change observable from
outside.

Internally, the following private methods on `CatalogBagBuilder`
were removed (they don't exist anymore):

- `_enqueue_if_in_scope_with_path`
- `_max_paths_per_table`
- `_is_excluded_table`

These were only called from inside the now-deleted BFS body; no
external test or call site referenced them.

## Test plan

- [x] All 303 pre-existing bag tests pass (`uv run python -m pytest tests/deriva/bag/`).
- [x] 16 new tests cover `SchemaPathWalker` directly (BFS multi-route, DFS every-prefix, max_depth, exclude_tables, schema allowlist, terminal_tables, vocab-as-leaf, edge_filter, multi-FK dedup, cycle detection).
- [x] Full bag suite: **319 passed, 3 skipped**.
- [ ] Integration with deriva-ml's `DenormalizePlanner._schema_to_paths` exercised by the companion PR's live-catalog tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)