### PR TITLE
fix(bag): map ermrest array types to SQLite JSON, not silent TEXT

### DIFF
--- a/deriva/bag/_column_types.py
+++ b/deriva/bag/_column_types.py
@@ -159,6 +159,27 @@ class StringToDate(TypeDecorator):
         return parser.parse(value).date()
 
 
+class ArrayAsJson(TypeDecorator):
+    """Serialise Python list values as JSON-encoded TEXT for SQLite.
+
+    ERMrest emits array columns (``text[]``, ``int4[]``, ...) as JSON
+    arrays, which deriva-py deserialises into Python lists. SQLite has
+    no native array type and SQLAlchemy's SQLite dialect cannot bind a
+    list to a TEXT column. JSON-encode on write, decode on read, so
+    callers see ``list`` end-to-end.
+
+    The wrapped :class:`sqlalchemy.JSON` already round-trips Python
+    ``list`` / ``dict`` values transparently on SQLite; the decorator
+    exists so the bag's lossless schema round-trip
+    (:data:`deriva.bag.schema_io.SQL_TO_ERMREST`) has a named class to
+    distinguish *array* columns from scalar ``json`` / ``jsonb``
+    columns when no ``ermrest_typename`` is stashed in ``col.info``.
+    """
+
+    impl = JSON
+    cache_ok = True
+
+
 # =============================================================================
 # ERMrest typename → SQLAlchemy type
 # =============================================================================
@@ -207,7 +228,9 @@ def sql_type_for_ermrest(deriva_type: "DerivaType") -> type[TypeEngine]:
             :class:`Column` definition).
 
     Returns:
-        SQLAlchemy column type class. Unknown ERMrest typenames fall
+        SQLAlchemy column type class. Array types
+        (``deriva_type.is_array`` is True) route to
+        :class:`ArrayAsJson`; unknown scalar ERMrest typenames fall
         back to :class:`sqlalchemy.String`, which works for any value
         that survives the CSV round-trip as a string.
 
@@ -215,6 +238,7 @@ def sql_type_for_ermrest(deriva_type: "DerivaType") -> type[TypeEngine]:
         >>> # Pure-Python example — runs for real:
         >>> from sqlalchemy import String
         >>> from deriva.bag._column_types import (
+        ...     ArrayAsJson,
         ...     ERMREST_TO_SQL,
         ...     StringToInteger,
         ...     sql_type_for_ermrest,
@@ -225,9 +249,18 @@ def sql_type_for_ermrest(deriva_type: "DerivaType") -> type[TypeEngine]:
         >>> # Unknown typename falls back to String via the helper.
         >>> class _FakeType:
         ...     typename = "never_seen_this"
+        ...     is_array = False
         >>> sql_type_for_ermrest(_FakeType()) is String
         True
+        >>> # Array types route to ArrayAsJson regardless of element type.
+        >>> class _FakeArray:
+        ...     typename = "text[]"
+        ...     is_array = True
+        >>> sql_type_for_ermrest(_FakeArray()) is ArrayAsJson
+        True
     """
+    if getattr(deriva_type, "is_array", False):
+        return ArrayAsJson
     return ERMREST_TO_SQL.get(deriva_type.typename, String)
 
 

--- a/deriva/bag/schema_io.py
+++ b/deriva/bag/schema_io.py
@@ -72,6 +72,7 @@ from sqlalchemy.sql.type_api import TypeEngine
 # continues to work, and the symbol is part of this module's
 # documented public surface.
 from deriva.bag._column_types import (
+    ArrayAsJson,
     ERMREST_TO_SQL,
     ERMRestBoolean,
     StringToDate,
@@ -102,6 +103,16 @@ SQL_TO_ERMREST: list[tuple[type, str]] = [
     (StringToDateTime, "timestamptz"),
     (StringToFloat, "float8"),
     (StringToInteger, "int4"),
+    # ``ArrayAsJson`` wraps SQLAlchemy ``JSON`` but means an ERMrest
+    # array column, not a scalar JSON column. The element type
+    # (text vs int4 vs …) isn't recoverable from the SQLAlchemy type
+    # alone, so the inverse defaults to ``text[]`` — callers that
+    # need full fidelity for non-text element types either go
+    # through :func:`ermrest_json_to_metadata` (which stashes the
+    # original typename on ``col.info["ermrest_typename"]`` and
+    # :func:`metadata_to_ermrest_json` reads it back) or carry the
+    # original :class:`~deriva.core.ermrest_model.Type` alongside.
+    (ArrayAsJson, "text[]"),
     # Plain SQLAlchemy types.
     (Boolean, "boolean"),
     (Date, "date"),
@@ -266,10 +277,20 @@ def ermrest_json_to_metadata(
         for table_name, table_def in schema.get("tables", {}).items():
             columns: list[SQLColumn] = []
             for col_def in table_def.get("column_definitions", []):
-                ermrest_type = (
-                    col_def.get("type", {}).get("typename", "text")
-                )
-                sql_type_cls = ERMREST_TO_SQL.get(ermrest_type, String)
+                type_doc = col_def.get("type", {})
+                ermrest_type = type_doc.get("typename", "text")
+                # Array columns (``text[]``, ``int4[]``, …) route to
+                # :class:`ArrayAsJson` so SQLite can round-trip
+                # Python ``list`` values as JSON-encoded TEXT.
+                # Without this, the mirror declares the column as
+                # ``String`` and SQLAlchemy raises
+                # ``sqlite3.ProgrammingError: type 'list' is not
+                # supported`` the moment ERMrest hands back a list
+                # for the column.
+                if type_doc.get("is_array"):
+                    sql_type_cls = ArrayAsJson
+                else:
+                    sql_type_cls = ERMREST_TO_SQL.get(ermrest_type, String)
                 # ERMrest's ``nullok`` defaults to True if absent.
                 nullok = col_def.get("nullok", True)
                 # PK detection: only the RID column is treated as PK,

--- a/tests/deriva/bag/test_column_types.py
+++ b/tests/deriva/bag/test_column_types.py
@@ -22,9 +22,19 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import MagicMock
 
-from sqlalchemy import JSON, String
+from sqlalchemy import (
+    JSON,
+    Column,
+    MetaData,
+    String,
+    Table,
+    create_engine,
+    insert,
+    select,
+)
 
 from deriva.bag._column_types import (
+    ArrayAsJson,
     ERMREST_TO_SQL,
     ERMRestBoolean,
     StringToDate,
@@ -121,12 +131,14 @@ def test_sql_type_for_ermrest_falls_back_to_string_on_unknown() -> None:
     """Unknown ERMrest typenames degrade to ``String``, not raise."""
     fake = MagicMock()
     fake.typename = "this_typename_does_not_exist"
+    fake.is_array = False
     assert sql_type_for_ermrest(fake) is String
 
 
 def test_sql_type_for_ermrest_returns_the_mapped_class() -> None:
     """Known typenames return the same class the map carries."""
     fake = MagicMock()
+    fake.is_array = False
     fake.typename = "int4"
     assert sql_type_for_ermrest(fake) is StringToInteger
     fake.typename = "boolean"
@@ -189,6 +201,97 @@ def test_is_key_column_rejects_rid_with_no_key_declaration() -> None:
     other = _mock_column("Other")
     table = _mock_table_with_keys([other])
     assert is_key_column(rid, table) is False
+
+
+# =============================================================================
+# Array column round-trip (ArrayAsJson)
+# =============================================================================
+#
+# Regression: ERMrest array columns (``text[]``, ``int4[]``, …) used
+# to silently fall back to :class:`String` because
+# :func:`sql_type_for_ermrest` had no :attr:`is_array` branch. The
+# SQLite mirror declared the column as ``TEXT`` and SQLAlchemy's
+# SQLite dialect raised ``sqlite3.ProgrammingError: type 'list' is
+# not supported`` the moment ERMrest handed back a Python ``list``
+# for that column (see the bag denormalizer's vocab-table populate
+# path).
+
+
+def test_sql_type_for_ermrest_routes_arrays_through_array_as_json() -> None:
+    """``is_array`` types go to :class:`ArrayAsJson` regardless of typename."""
+    fake = MagicMock()
+    fake.is_array = True
+    fake.typename = "text[]"
+    assert sql_type_for_ermrest(fake) is ArrayAsJson
+    # Element type doesn't matter — int4[] / float8[] / unknown[] all
+    # route the same way. The ``is_array`` flag is the only gate.
+    fake.typename = "int4[]"
+    assert sql_type_for_ermrest(fake) is ArrayAsJson
+    fake.typename = "never_seen_this[]"
+    assert sql_type_for_ermrest(fake) is ArrayAsJson
+
+
+def test_sql_type_for_ermrest_scalar_json_still_resolves_via_map() -> None:
+    """The new array branch leaves scalar ``json`` / ``jsonb`` untouched."""
+    fake = MagicMock()
+    fake.is_array = False
+    fake.typename = "json"
+    assert sql_type_for_ermrest(fake) is JSON
+    fake.typename = "jsonb"
+    assert sql_type_for_ermrest(fake) is JSON
+
+
+def test_array_as_json_round_trips_python_lists_through_sqlite() -> None:
+    """``ArrayAsJson`` round-trips ``list`` values through a SQLite TEXT cell.
+
+    This is the regression test the audit asks for: the bag's mirror
+    used to declare array columns as ``String`` and crash on the
+    bind. ``ArrayAsJson`` wraps SQLAlchemy ``JSON`` so the value goes
+    in as ``list``, serialises to JSON-encoded TEXT inside SQLite,
+    and comes back out as ``list`` (or ``None``) without the caller
+    seeing the encoding.
+    """
+    metadata = MetaData()
+    table = Table(
+        "vocab",
+        metadata,
+        Column("rid", String, primary_key=True),
+        Column("synonyms", ArrayAsJson),
+    )
+    engine = create_engine("sqlite:///:memory:")
+    metadata.create_all(engine)
+
+    rows = [
+        {"rid": "A", "synonyms": ["plane", "aeroplane"]},
+        {"rid": "B", "synonyms": []},
+        {"rid": "C", "synonyms": None},
+        {"rid": "D", "synonyms": [1, 2, 3]},
+    ]
+    with engine.begin() as conn:
+        conn.execute(insert(table), rows)
+        result = {r.rid: r.synonyms for r in conn.execute(select(table))}
+
+    assert result == {
+        "A": ["plane", "aeroplane"],
+        "B": [],
+        "C": None,
+        "D": [1, 2, 3],
+    }
+
+
+def test_array_as_json_inverse_routes_back_to_array_typename() -> None:
+    """The inverse map :data:`SQL_TO_ERMREST` resolves ``ArrayAsJson``.
+
+    The element type isn't recoverable from the SQLAlchemy type alone
+    so the inverse defaults to ``text[]``; callers that need full
+    fidelity for non-text element types rely on the
+    ``col.info["ermrest_typename"]`` stash that
+    :func:`ermrest_json_to_metadata` writes (and
+    :func:`metadata_to_ermrest_json` reads).
+    """
+    from deriva.bag.schema_io import sql_type_to_ermrest_name
+
+    assert sql_type_to_ermrest_name(ArrayAsJson()) == "text[]"
 
 
 # =============================================================================

--- a/tests/deriva/bag/test_schema_builder.py
+++ b/tests/deriva/bag/test_schema_builder.py
@@ -841,3 +841,115 @@ def _two_table_association_doc() -> dict:
             }
         },
     }
+
+
+# =============================================================================
+# Array-column round-trip (regression: SQLite list-binding failure)
+# =============================================================================
+
+
+def _build_vocab_model_with_array(
+    snaptime: str = "2026-01-01T00:00:00",
+) -> Model:
+    """Build a Model with a vocab table that has a ``text[]`` Synonyms column.
+
+    Matches the deriva-ml standard vocabulary shape; mirrors what the
+    denormalizer hits live when it walks through any vocabulary
+    table.
+    """
+    doc = {
+        "snaptime": snaptime,
+        "schemas": {
+            "demo": {
+                "schema_name": "demo",
+                "tables": {
+                    "Vocab": {
+                        "schema_name": "demo",
+                        "table_name": "Vocab",
+                        "kind": "table",
+                        "column_definitions": [
+                            {
+                                "name": "RID",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "Name",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "Synonyms",
+                                "type": {
+                                    "typename": "text[]",
+                                    "is_array": True,
+                                    "base_type": {"typename": "text"},
+                                },
+                                "nullok": True,
+                                "default": None,
+                                "comment": None,
+                            },
+                        ],
+                        "keys": [
+                            {
+                                "names": [["demo", "Vocab_RID_key"]],
+                                "unique_columns": ["RID"],
+                            }
+                        ],
+                        "foreign_keys": [],
+                    },
+                },
+            },
+        },
+    }
+    import json
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".json", delete=False
+    ) as f:
+        json.dump(doc, f)
+        path = f.name
+    return Model.fromfile("file-system", path)
+
+
+def test_schemabuilder_array_column_accepts_python_lists() -> None:
+    """Inserting ``list`` values into a ``text[]`` column doesn'"'"'t raise.
+
+    Regression: before the :class:`ArrayAsJson` route, the mirror'"'"'s
+    ``Synonyms`` column was declared :class:`String` and SQLAlchemy
+    raised ``sqlite3.ProgrammingError: type '"'"'list'"'"' is not supported``
+    on the bind. This test reproduces the exact wire shape the
+    bag'"'"'s denormalizer feeds the SQLite mirror (rows with
+    ``list[str]``, ``[]``, and ``None`` values for the array column)
+    and confirms the round-trip returns Python lists.
+    """
+    from sqlalchemy import insert, select
+
+    model = _build_vocab_model_with_array()
+    builder = SchemaBuilder(model, ["demo"], database_path=":memory:")
+    orm = builder.build()
+    try:
+        table = orm.find_table("demo_Vocab")
+        rows = [
+            {"RID": "A", "Name": "airplane", "Synonyms": ["plane", "aeroplane"]},
+            {"RID": "B", "Name": "bird", "Synonyms": []},
+            {"RID": "C", "Name": "cat", "Synonyms": None},
+        ]
+        with orm.engine.begin() as conn:
+            conn.execute(insert(table), rows)
+            result = {
+                r.RID: r.Synonyms
+                for r in conn.execute(select(table))
+            }
+        assert result == {
+            "A": ["plane", "aeroplane"],
+            "B": [],
+            "C": None,
+        }
+    finally:
+        orm.dispose()

--- a/tests/deriva/bag/test_schema_io.py
+++ b/tests/deriva/bag/test_schema_io.py
@@ -368,6 +368,130 @@ def test_ermrest_json_to_metadata_roundtrip_preserves_int8() -> None:
     assert out_cols["Small"]["type"]["typename"] == "int2"
 
 
+def test_ermrest_json_to_metadata_routes_array_columns_through_array_as_json() -> None:
+    """Array typenames declare an ``ArrayAsJson`` column in the mirror.
+
+    Regression: ``text[]`` / ``int4[]`` / etc. used to fall through
+    ``ERMREST_TO_SQL.get(typename, String)`` to ``String`` because
+    the map has no entries for any array typename. The mirror then
+    refused list values at the SQLite bind boundary. The reader now
+    inspects ``type.is_array`` and routes such columns through
+    :class:`ArrayAsJson`.
+    """
+    from deriva.bag._column_types import ArrayAsJson
+
+    doc = {
+        "snaptime": "2026-01-01T00:00:00",
+        "schemas": {
+            "demo": {
+                "schema_name": "demo",
+                "tables": {
+                    "Vocab": {
+                        "schema_name": "demo",
+                        "table_name": "Vocab",
+                        "kind": "table",
+                        "column_definitions": [
+                            {
+                                "name": "RID",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "Synonyms",
+                                "type": {
+                                    "typename": "text[]",
+                                    "is_array": True,
+                                    "base_type": {"typename": "text"},
+                                },
+                                "nullok": True,
+                                "default": None,
+                                "comment": None,
+                            },
+                        ],
+                        "keys": [
+                            {
+                                "names": [["demo", "Vocab_RID_key"]],
+                                "unique_columns": ["RID"],
+                            }
+                        ],
+                        "foreign_keys": [],
+                    }
+                },
+            }
+        },
+    }
+    md = ermrest_json_to_metadata(doc)
+    cols = {c.name: c for c in md.tables["demo.Vocab"].columns}
+    assert isinstance(cols["Synonyms"].type, ArrayAsJson)
+    # And the original ERMrest typename is stashed for lossless
+    # write-out — element type ``text[]`` round-trips back even
+    # though the SQLAlchemy type alone would default to ``text[]``.
+    assert cols["Synonyms"].info["ermrest_typename"] == "text[]"
+
+
+def test_ermrest_json_to_metadata_roundtrip_preserves_array_typename() -> None:
+    """A json → metadata → json round-trip preserves ``int4[]`` element type.
+
+    The ``ArrayAsJson`` decorator loses the element type at the
+    SQLAlchemy layer; the round-trip works because the original
+    ERMrest typename is stashed in ``col.info["ermrest_typename"]``
+    by the reader and read back by the writer.
+    """
+    from deriva.bag.schema_io import metadata_to_ermrest_json
+
+    doc = {
+        "snaptime": "2026-01-01T00:00:00",
+        "schemas": {
+            "demo": {
+                "schema_name": "demo",
+                "tables": {
+                    "T": {
+                        "schema_name": "demo",
+                        "table_name": "T",
+                        "kind": "table",
+                        "column_definitions": [
+                            {
+                                "name": "RID",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "Scores",
+                                "type": {
+                                    "typename": "int4[]",
+                                    "is_array": True,
+                                    "base_type": {"typename": "int4"},
+                                },
+                                "nullok": True,
+                                "default": None,
+                                "comment": None,
+                            },
+                        ],
+                        "keys": [
+                            {
+                                "names": [["demo", "T_RID_key"]],
+                                "unique_columns": ["RID"],
+                            }
+                        ],
+                        "foreign_keys": [],
+                    }
+                },
+            }
+        },
+    }
+    md = ermrest_json_to_metadata(doc)
+    out = metadata_to_ermrest_json(md)
+    out_cols = {
+        c["name"]: c
+        for c in out["schemas"]["demo"]["tables"]["T"]["column_definitions"]
+    }
+    assert out_cols["Scores"]["type"]["typename"] == "int4[]"
+
+
 def test_ermrest_json_to_metadata_roundtrip_preserves_annotations() -> None:
     """A json → metadata → json round-trip preserves column annotations.
 


### PR DESCRIPTION
## Summary

- `deriva/bag/_column_types.py`: add `ArrayAsJson` (a `TypeDecorator` wrapping `sqlalchemy.JSON`) and grow `sql_type_for_ermrest()` with an `is_array` branch so array columns route to `ArrayAsJson` regardless of element type.
- `deriva/bag/schema_io.py`: detect `is_array` in the ERMrest-JSON reader and add `ArrayAsJson -> "text[]"` to `SQL_TO_ERMREST` for callers that build a `MetaData` directly (round-trips that go through the reader still recover the original element type via `col.info["ermrest_typename"]`).

Before this change every `text[]` / `int4[]` column silently fell back to `String`, the SQLite mirror declared the column as `TEXT`, and the very first INSERT carrying a `list` raised `sqlite3.ProgrammingError: type 'list' is not supported`. Every vocabulary table on a deriva-ml catalog (`Synonyms text[]`) was affected the moment the denormalizer walked through it.

Full audit: [`deriva-ml-model-template-e2e/findings/investigation/04-sqlite-array-binding-bug.md`](https://github.com/informatics-isi-edu/deriva-ml-model-template/blob/main/docs/...) (local path: `/Users/carl/GitHub/DerivaML/deriva-ml-model-template-e2e/findings/investigation/04-sqlite-array-binding-bug.md`).

## Test plan

- [x] `pytest tests/deriva/bag/` — baseline 319 passed / 3 skipped; after change 326 passed / 3 skipped (7 new tests, 0 regressions).
- [x] New unit tests in `tests/deriva/bag/test_column_types.py`:
  - `sql_type_for_ermrest()` routes any `is_array=True` type to `ArrayAsJson` regardless of typename.
  - Scalar `json` / `jsonb` columns still resolve through the unchanged map path.
  - `ArrayAsJson` round-trips Python `list` / `[]` / `None` values through a SQLite TEXT cell.
  - `sql_type_to_ermrest_name(ArrayAsJson())` resolves to `text[]`.
- [x] New `tests/deriva/bag/test_schema_io.py` tests cover the reader's `is_array` branch and the json -> metadata -> json round-trip preserving `int4[]` via the `col.info["ermrest_typename"]` stash.
- [x] New `tests/deriva/bag/test_schema_builder.py` test builds a vocab-shaped model via `Model.fromfile`, runs it through `SchemaBuilder`, inserts rows with `list[str]` / `[]` / `None` Synonyms, and confirms the SQLite round-trip returns Python lists — the exact bug site the audit identified.
- [x] Live reproduction against catalog 27 on dev-localhost (CIFAR-10 schema, `Image + Image_Class + Synonyms text[]`):
  - **Before fix**: `Denormalizer.as_dataframe(include_tables=["Image", "Image_Class"], row_per="Image")` raises `sqlite3.ProgrammingError: type 'list' is not supported` on the `Image_Class` INSERT.
  - **After fix**: returns a `(676, 12)` DataFrame; `Image_Class.Synonyms` cells are Python lists (`['plane', 'aeroplane']`, `[]`, `['lorry']`, …) end-to-end — no PG literal strings, no JSON-encoded text.

## Out of scope (called out in the audit, not bundled here)

- Consolidating the triple-defined `Type.sqlite3_ddl()` in `deriva/core/ermrest_model.py` (method exists three times, called zero times).
- Removing `_coerce_pg_array` in `deriva/bag/catalog_loader.py` (becomes dead code once both paths use `ArrayAsJson`).
- The deriva-ml lockfile bump that will pin to this fix once it lands.