### PR TITLE
fix(deps): declare bag-subsystem runtime deps; add test/dev extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,10 @@ setup(
         'globus_sdk>=3,<4',
         'fair-research-login>=0.3.1',
         'fair-identifiers-client>=0.5.1',
-        'jsonschema>=3.1'
+        'jsonschema>=3.1',
+        'sqlalchemy>=2.0',         # used by deriva.bag SQLite mirror
+        'pydantic>=2.0',           # used by deriva.bag traversal/anchors
+        'python-dateutil>=2.8'     # used by deriva.bag _column_types
     ],
     license='Apache 2.0',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,15 @@ setup(
         'pydantic>=2.0',           # used by deriva.bag traversal/anchors
         'python-dateutil>=2.8'     # used by deriva.bag _column_types
     ],
+    extras_require={
+        'test': [
+            'pytest>=9.0',
+        ],
+        'dev': [
+            'pytest>=9.0',
+            'ruff',
+        ],
+    },
     license='Apache 2.0',
     classifiers=[
         'Intended Audience :: Science/Research',


### PR DESCRIPTION
## Summary

Two-part scope, both reviewable as separate commits.

**Part 1 (runtime fix, commit `efe1aab`):** `deriva.bag` has imported
`sqlalchemy` (9 modules), `pydantic` (`traversal.py`, `anchors.py`),
and `python-dateutil` (`_column_types.py`) at runtime since its
introduction, but none were declared in `install_requires`. A user
who runs `pip install deriva` from PyPI and touches any bag API gets
`ImportError`. The bug has been silent in-house because parent
project lockfiles (deriva-ml, model-template) pull these in via their
own dep trees, so the maintainer's environment always has them.

**Part 2 (dev hygiene, commit `23c6c8b`):** `pytest` and `ruff` had
no declared extras path, so contributors had to know to install them
separately before running the suite or linter. Adds
`extras_require['test']` and `extras_require['dev']`.

## Audit chain

This surfaced during the e2e fix-pass for PR #266 (deriva-ml CSV →
SQLite array ingest fix). The agent working in a fresh worktree had
to manually `pip install sqlalchemy pydantic python-dateutil pytest`
before `pytest tests/deriva/bag/` would even import, despite the
worktree being a clean checkout of the repo with deriva-py
installed via `pip install -e .`. That manual recovery is the bug
report that motivates this PR.

Trust anchor for the runtime deps: `grep -rn -E "^(import|from)
(sqlalchemy|pydantic|dateutil)" deriva/bag/` returns 27 hits across
9 modules. No upper bounds applied (user directive: "greater than
current version as lower bound"); floors set to the major.minor
versions deriva-py is currently developed against (sqlalchemy 2.x,
pydantic 2.x — both have substantially different APIs from 1.x —
and dateutil 2.8, the first version with stable Python 3.x
packaging).

## Test plan

**Fresh-venv install simulation** (Python 3.13.13):

```
$ python3.13 -m venv /tmp/test_install_venv && source /tmp/test_install_venv/bin/activate
$ pip install -e /path/to/worktree
...
Successfully installed annotated-types-0.7.0 attrs-26.1.0 bagit-1.9.0
bagit-profile-1.3.1 bdbag-1.8.0 certifi-2026.5.20 cffi-2.0.0
charset_normalizer-3.4.7 cryptography-48.0.0 deriva-2.0.0.dev0
fair-identifiers-client-0.5.1 fair-research-login-0.3.1
globus_sdk-3.65.0 idna-3.17 jsonschema-4.26.0
jsonschema-specifications-2025.9.1 packaging-26.2 pika-1.4.1
portalocker-3.2.0 pycparser-3.0 pydantic-2.13.4 pydantic-core-2.46.4
pyjwt-2.13.0 python-dateutil-2.9.0.post0 pytz-2026.2 referencing-0.37.0
requests-2.34.2 rpds-py-2026.5.1 six-1.17.0 sqlalchemy-2.0.50
typing-extensions-4.15.0 typing-inspection-0.4.2 tzlocal-5.3.1
urllib3-2.7.0

$ python -c "
import deriva.bag.database
import deriva.bag.traversal
import deriva.bag.anchors
import deriva.bag._column_types
print('All bag imports succeed')
import sqlalchemy; print('sqlalchemy:', sqlalchemy.__version__)
import pydantic; print('pydantic:', pydantic.__version__)
import dateutil; print('python-dateutil:', dateutil.__version__)
"
All bag imports succeed
sqlalchemy: 2.0.50
pydantic: 2.13.4
python-dateutil: 2.9.0.post0
```

Without this PR, the `pip install -e .` would not auto-install
sqlalchemy / pydantic / python-dateutil, and the `deriva.bag.*`
imports would `ImportError`.

**[test] extra install**:

```
$ pip install -e "/path/to/worktree[test]"
Successfully installed deriva-2.0.0.dev0 iniconfig-2.3.0
pluggy-1.6.0 pygments-2.20.0 pytest-9.0.3
$ python -c "import pytest; print('pytest:', pytest.__version__)"
pytest: 9.0.3
```

**Test suite re-run** (`uv run python -m pytest tests/deriva/bag/ -v`):

```
================= 326 passed, 3 skipped, 176 warnings in 5.11s =================
```

Matches the PR #266 baseline. No regressions.

## Backwards compatibility

Users who install deriva from PyPI will now have a wider net of
transitive dependencies (sqlalchemy, pydantic, python-dateutil) than
before. Users who already had these installed via other paths
(parent project lockfiles, requirements files, sibling packages)
see no change — pip will respect existing installations within the
floor.

No upper bounds were applied, so future major releases of sqlalchemy
3.x or pydantic 3.x will require a follow-up bump but won't be
silently blocked here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)