### PR TITLE
fix(packaging): require Python 3.12+ (drop 3.9-3.11)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'deriva.config': ['examples/*.json'],
         'deriva.core': ['schemas/*.schema.json']
     },
-    python_requires='>=3.8, <4',
+    python_requires='>=3.12, <4',
     entry_points={
         'console_scripts': [
             'deriva-upload-cli = deriva.transfer.upload.__main__:main',
@@ -83,9 +83,6 @@ setup(
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: Microsoft :: Windows',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
         'Programming Language :: Python :: 3.14'


### PR DESCRIPTION
## Summary

`setup.py` declared `python_requires='>=3.8, <4'`, but `deriva/bag/`
uses `enum.StrEnum` (added in Python 3.11). Rather than stop at the
StrEnum floor, this PR raises the declared floor to **3.12** to
match the team's actually-tested environment.

- `python_requires`: `>=3.8, <4` → `>=3.12, <4`
- Trove classifiers: drop 3.9, 3.10, 3.11; keep 3.12, 3.13, 3.14

## Why 3.12, not 3.11

StrEnum is the proximate technical trigger for the investigation,
but the codebase has **no 3.12-specific constructs**. The 3.12 floor
is a maintenance-policy choice, not a code requirement, matching:

- **The team's actual venv.** Local development and testing runs on
  Python 3.13 (the deriva-py worktree's venv is `python3.13`).
  Declaring `>=3.11` would claim support for a version no one tests.
- **Python 3.11 nears EOL** (Oct 2027). Bumping now avoids a second
  packaging bump in the near future.
- **Honesty over reach.** Trove classifiers and `python_requires`
  should reflect what's exercised in CI/dev, not the widest interval
  the code happens to compile under.

## Discovery

Surfaced during PR #267 verification on a Python 3.10 host —
`enum.StrEnum` raised `ImportError`, exposing that the declared
`>=3.8` floor was stale. PR #267 is on a separate concern (runtime
dependency declarations) and is not affected by this change.

## Verification

Grep confirms no 3.12-specific constructs in the codebase (so the
floor is policy, not code):

| Construct | Hits |
|---|---|
| PEP 695 type aliases (`type X = ...`) | 0 |
| PEP 695 generic syntax (`def foo[T]`, `class Foo[T]`) | 0 |
| `itertools.batched` | 0 |
| `pathlib.Path.walk` | 0 |
| `typing.override` decorator | 0 |
| `sys.monitoring` | 0 |

Test suite on Python 3.13: `tests/deriva/bag/` → 326 passed, 3
skipped (matches baseline; packaging metadata change has no runtime
impact).

## Alternatives considered

- **Keep the 3.11 floor (match StrEnum).** Rejected: no one on the
  team tests 3.11, so the support claim wouldn't be backed by CI.
- **Polyfill StrEnum for 3.10.** Rejected: 3.10 is already past its
  active-support window, and 3.11 itself is nearing EOL — paying
  the polyfill complexity for a version we're about to drop anyway
  is the wrong trade.

## Related

- Discovered while verifying #267. That PR is independent and is
  not blocked by this one.