### PR TITLE
feat(bag): RID-set fetch for fast one-CSV-per-table bag generation

### DIFF
--- a/deriva/bag/catalog_builder.py
+++ b/deriva/bag/catalog_builder.py
@@ -86,6 +86,15 @@ class CatalogBagBuilder:
         output_dir: Directory to receive the bag.
         producer: Identifier stamped into the bag's provenance.
             Defaults to ``"deriva.bag.catalog_builder.CatalogBagBuilder"``.
+        rid_sets: Optional ``{(schema, table): [RID, ...]}`` map. When
+            supplied, the export spec emits one rid-set csv processor per
+            reached non-vocab table (flat ``{schema}/{table}`` output,
+            RID set carried inline) instead of one csv processor per FK
+            path. The engine chunks the RID set and appends to a single
+            clean CSV, so the loader gets one file per table with no
+            union needed. When ``None`` (the default), per-FK-path
+            emission is used unchanged. Vocab-FULL and asset-fetch
+            processors are unaffected.
 
     Example:
         Build a bag rooted at a few Subject RIDs::
@@ -113,6 +122,7 @@ class CatalogBagBuilder:
         producer: str = (
             "deriva.bag.catalog_builder.CatalogBagBuilder"
         ),
+        rid_sets: dict[tuple[str, str], list[str]] | None = None,
     ):
         if not anchors:
             raise ValueError(
@@ -124,6 +134,7 @@ class CatalogBagBuilder:
         self.output_dir = Path(output_dir)
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self.producer = producer
+        self.rid_sets = rid_sets
 
         # Cached after first build() call.
         self._model: Any | None = None
@@ -565,6 +576,24 @@ class CatalogBagBuilder:
                             "output_path": (
                                 f"{schema_name}/{table_name}"
                             ),
+                            "paged_query": True,
+                        },
+                    }
+                )
+            elif self.rid_sets is not None:
+                # Format B: one rid-set csv processor per table — flat
+                # output_path, RID set carried inline. The engine chunks
+                # the RID set and appends to one clean CSV (get_as_file
+                # rid_set). Replaces the per-FK-path emission; the loader
+                # gets one file per table (no union needed).
+                rids = self.rid_sets.get(key, [])
+                query_processors.append(
+                    {
+                        "processor": "csv",
+                        "processor_params": {
+                            "rid_table": f"{schema_name}:{table_name}",
+                            "rid_set": rids,
+                            "output_path": f"{schema_name}/{table_name}",
                             "paged_query": True,
                         },
                     }

--- a/deriva/bag/catalog_builder.py
+++ b/deriva/bag/catalog_builder.py
@@ -580,12 +580,27 @@ class CatalogBagBuilder:
                         },
                     }
                 )
-            elif self.rid_sets is not None:
+            elif self.rid_sets is not None and not table_obj.is_vocabulary():
                 # Format B: one rid-set csv processor per table — flat
                 # output_path, RID set carried inline. The engine chunks
                 # the RID set and appends to one clean CSV (get_as_file
                 # rid_set). Replaces the per-FK-path emission; the loader
                 # gets one file per table (no union needed).
+                #
+                # Vocab tables are excluded from this branch: they're
+                # referenced by Name, not RID, so a reachability map
+                # carries no RID set for them. A REFERENCED_ONLY vocab
+                # must fall through to the per-FK-path ``else`` below, or
+                # it would get an empty rid-set CSV and its FK references
+                # wouldn't resolve at the destination.
+                if key not in self.rid_sets:
+                    logger.warning(
+                        "rid_sets has no entry for reached table %s:%s; "
+                        "emitting empty rid-set CSV (possible incomplete "
+                        "reachability map)",
+                        schema_name,
+                        table_name,
+                    )
                 rids = self.rid_sets.get(key, [])
                 query_processors.append(
                     {

--- a/deriva/core/ermrest_catalog.py
+++ b/deriva/core/ermrest_catalog.py
@@ -643,6 +643,199 @@ class ErmrestCatalog(DerivaBinding):
                         return last_record
             return last_record
 
+    def _fetch_paged_csv(self, destfile, base_path, headers, callback,
+                         page_size, page_sort_columns, first_page):
+        """Page through ``base_path`` and append rows to an open ``destfile``.
+
+        This is the paged-fetch loop extracted verbatim from
+        :meth:`get_as_file`. It walks ``base_path`` page by page using the
+        ``@sort``/``@after``/``limit`` cursor, applies the query-runtime-limit
+        page-size backoff, and handles both ``text/csv`` and
+        ``application/x-json-stream`` responses. The CSV header is written only
+        when ``first_page`` is ``True`` for the very first page processed; each
+        subsequent page (and every page after the first across chunked calls)
+        skips the header line(s).
+
+        Passing the caller-managed ``first_page`` in and returning the updated
+        value lets multiple calls append into one CSV with the header written
+        exactly once (used by :meth:`_get_rid_set_as_file` to chunk-append a
+        RID set).
+
+        Args:
+            destfile: An already-open binary file (mode ``w+b``) to append to.
+            base_path: Catalog-relative path to page (e.g.
+                ``/entity/S:T/RID=any(...)``). ``self._server_uri`` is
+                prepended internally, exactly as the inlined loop did.
+            headers: Request headers (already copied by the caller).
+            callback: Optional progress callback; same contract as
+                :meth:`get_as_file`.
+            page_size: Initial page size; reduced in-place on runtime-limit
+                backoff.
+            page_sort_columns: Columns used for the ``@sort``/``@after``
+                cursor.
+            first_page: Whether the next page processed is the first one (i.e.
+                whether to emit the CSV header).
+
+        Returns:
+            A ``(first_page, total)`` tuple where ``first_page`` is the updated
+            flag (``False`` once any page has been processed) and ``total`` is
+            the number of bytes written by this call.
+        """
+        total = 0
+        first_line = None
+        last_record = None
+        usr = urlsplit(self._server_uri + base_path)
+        path = str(usr.path.split('@sort')[0])
+        while True:
+            sort = "@sort(%s)%s" % (",".join(page_sort_columns or ["RID"]),
+                                    ("@after(%s)" % ",".join(last_record)) if last_record is not None else "")
+            limit = "limit=%s" % int(page_size) if page_size > 0 else "none"
+            query = re.sub(r"([^.]*)(limit=.*?)($|[&;])([^.]*)$", r"\1%s\3\4" % limit, usr.query, flags=re.I)
+            url = urlunsplit((usr.scheme, usr.netloc, path + sort, query if query else limit, usr.fragment))
+
+            # 1. Try to get a page worth of data, back-off page size if query run time errors are encountered
+            with self._session.get(url, headers=headers) as r:
+                if r.status_code == 400 and "Query run time limit exceeded" in r.text:
+                    if page_size == 1:
+                        self._response_raise_for_status(r)
+                    r.close()
+                    page_size //= 2
+                    page_size = 1 if page_size < 1 else page_size
+                    logging.warning("Query runtime exceeded while attempting to transfer rows from %s to file "
+                                    "[%s]. The page size is being reduced to %s and the query will be retried."
+                                    % (url, destfile.name, page_size))
+                    if callback:
+                        if not callback(progress="Retrying query: %s" % url):
+                            destfile.close()
+                            return first_page, total
+                    continue
+                else:
+                    self._response_raise_for_status(r)
+
+                # 2. Write the page to disk and check the last record processed in order to get the next page
+                last_line = {}
+                content_type = r.headers.get("Content-Type")
+                logging.debug("Transferring data from [%s] to %s" % (url, destfile.name))
+                # CSV processing iterates over lines in the response, skipping the header line(s) in all but
+                # the first page, and captures the last line of each page to determine the last record processed.
+                # After writing, the last complete CSV record is found by reading back from the destination file
+                # using Python's csv module, which correctly handles multi-line quoted fields (RFC 4180).
+                if content_type == "text/csv":
+                    skip = 1
+                    line_num = 0
+                    if first_page:
+                        lines = r.iter_lines(decode_unicode=True)
+                        reader = csv.reader(lines)
+                        first_line = next(reader)
+                        skip = reader.line_num
+                    for line in r.iter_lines():
+                        if not first_page:
+                            line_num += 1
+                            if line_num <= skip:
+                                continue
+                        tline = line + b"\n"
+                        destfile.write(tline)
+                        total += len(tline)
+                        last_line = tline
+                    if last_line and last_line != first_line:
+                        # Read back the last complete CSV record from the file.
+                        # We cannot rely on the last raw byte line because CSV
+                        # fields may contain embedded newlines inside quoted
+                        # values (e.g., OCR text with grid data).  Parsing the
+                        # last raw line as a record would produce an incorrect
+                        # RID for the @after() cursor, causing an infinite loop.
+                        destfile.flush()
+                        last_line = self._read_last_csv_record(destfile.name, first_line)
+                    first_page = False
+                # JSON-Stream processing writes the entire buffer to the destination file. The last line is
+                # captured by reverse seeking in the buffer from right before the last b'\n' newline to the next
+                # newline or buf[0], then calling readline from the current position
+                elif content_type == "application/x-json-stream":
+                    buf = r.content
+                    if not buf:
+                        break
+                    destfile.write(buf)
+                    total += len(buf)
+                    b = io.BytesIO(buf)
+                    b.seek(-2, os.SEEK_END)
+                    while b.read(1) != b'\n':
+                        b.seek(-2, os.SEEK_CUR)
+                        if b.tell() == os.SEEK_SET:
+                            break
+                    last_line = json.loads(b.readline().decode('utf-8'))
+
+                # 3. Save the last record key and flush the destination file buffers to disk.
+                if not last_line:
+                    break
+                destfile.flush()
+                last_record = [urlquote(str(last_line.get(key))) for key in page_sort_columns]
+                if callback:
+                    if not callback(progress="Downloading: %.2f MB transferred" %
+                                             (float(total) / float(Megabyte))):
+                        destfile.close()
+                        return first_page, total
+
+        return first_page, total
+
+    def _get_rid_set_as_file(self, rid_set, rid_table, destfilename, *, headers,
+                             callback, delete_if_empty, page_size, page_sort_columns):
+        """Fetch a RID set as one CSV by chunk-append (see RID_SET_CHUNK_SIZE).
+
+        Chunks ``rid_set`` into URL-safe batches, fetches each chunk's
+        ``RID=any(...)`` page(s), and appends all chunks into one CSV. The
+        ``first_page`` flag persists across chunks so the header is written
+        exactly once (for the first page of the first chunk).
+
+        Args:
+            rid_set: The RIDs to fetch rows for.
+            rid_table: Catalog-relative table path the RIDs belong to.
+            destfilename: Path of the CSV file to write.
+            headers: Request headers (passed through to each paged fetch).
+            callback: Optional progress callback; same contract as
+                :meth:`get_as_file`.
+            delete_if_empty: When ``True``, delete the file if the result is
+                empty (header-only or zero bytes).
+            page_size: Initial page size for each chunk's paged fetch.
+            page_sort_columns: Columns used for the ``@sort``/``@after`` cursor.
+
+        Returns:
+            The ``destfilename`` on success, or ``None`` when the result was
+            empty and ``delete_if_empty`` deletion applied. The result is
+            treated as empty when no bytes were written at all, or when
+            ``delete_if_empty`` is set and the CSV contains only the header
+            line (``rowcount <= 1``).
+        """
+        destfile = open(destfilename, 'w+b')
+        try:
+            first_page = True
+            total = 0
+            for chunk in self._rid_set_chunks(rid_set, RID_SET_CHUNK_SIZE):
+                base_path = self._rid_set_query_url(rid_table, chunk)
+                first_page, written = self._fetch_paged_csv(
+                    destfile, base_path, headers, callback,
+                    page_size, page_sort_columns, first_page,
+                )
+                total += written
+            destfile.flush()
+            delete_file = (total == 0)
+            if delete_if_empty and total > 0:
+                # RID-set fetch is CSV-only by construction: the
+                # ``RID=any(...)`` entity query always returns text/csv, so the
+                # emptiness check parses with csv.reader unconditionally. Unlike
+                # get_as_file's epilogue, there is no json-stream branch to
+                # handle here -- the CSV-only assumption is intentional, not an
+                # oversight.
+                destfile.seek(0)
+                reader = csv.reader(codecs.iterdecode(destfile, 'utf-8'))
+                rowcount = sum(1 for _ in reader)
+                delete_file = rowcount <= 1
+        finally:
+            destfile.close()
+        if delete_file and os.path.exists(destfilename):
+            os.remove(destfilename)
+            return None
+        return destfilename
+
     def get_as_file(self,
                     path,
                     destfilename,
@@ -651,7 +844,9 @@ class ErmrestCatalog(DerivaBinding):
                     delete_if_empty=False,
                     paged=False,
                     page_size=DEFAULT_PAGE_SIZE,
-                    page_sort_columns=frozenset(["RID"])):
+                    page_sort_columns=frozenset(["RID"]),
+                    rid_set=None,
+                    rid_table=None):
         """
            Retrieve catalog data streamed to destination file.
            Caller is responsible to clean up file even on error, when the file may or may not exist.
@@ -659,7 +854,23 @@ class ErmrestCatalog(DerivaBinding):
            json/json-stream content, the presence of a single empty JSON object will be tested for. In the case of
            CSV content, the file will be parsed with CSV reader to determine that only a single header line and no row
            data is present.
+
+           When "rid_set" is provided, "path" is ignored and the rows for those
+           RIDs are fetched from "rid_table" by chunking the RID set into
+           URL-safe ``RID=any(...)`` batches and appending every chunk's CSV
+           page(s) into one CSV (the header is written exactly once). "rid_table"
+           is required in this mode. Returns the destination filename, or None
+           if the result was empty and "delete_if_empty" applied.
         """
+        if rid_set is not None:
+            if not rid_table:
+                raise ValueError("rid_table is required when rid_set is provided")
+            return self._get_rid_set_as_file(
+                rid_set, rid_table, destfilename, headers=headers,
+                callback=callback, delete_if_empty=delete_if_empty,
+                page_size=page_size, page_sort_columns=page_sort_columns,
+            )
+
         self.check_path(path)
 
         # Only entity API supported with paged mode at this time, otherwise fallback. We fallback rather than raise an
@@ -699,99 +910,22 @@ class ErmrestCatalog(DerivaBinding):
                                 return
                 destfile.flush()
             else:
-                first_page = True
-                first_line = None
-                last_record = None
-                usr = urlsplit(self._server_uri + path)
-                path = str(usr.path.split('@sort')[0])
-                while True:
-                    sort = "@sort(%s)%s" % (",".join(page_sort_columns or ["RID"]),
-                                            ("@after(%s)" % ",".join(last_record)) if last_record is not None else "")
-                    limit = "limit=%s" % int(page_size) if page_size > 0 else "none"
-                    query = re.sub(r"([^.]*)(limit=.*?)($|[&;])([^.]*)$", r"\1%s\3\4" % limit, usr.query, flags=re.I)
-                    url = urlunsplit((usr.scheme, usr.netloc, path + sort, query if query else limit, usr.fragment))
-
-                    # 1. Try to get a page worth of data, back-off page size if query run time errors are encountered
-                    with self._session.get(url, headers=headers) as r:
-                        if r.status_code == 400 and "Query run time limit exceeded" in r.text:
-                            if page_size == 1:
-                                self._response_raise_for_status(r)
-                            r.close()
-                            page_size //= 2
-                            page_size = 1 if page_size < 1 else page_size
-                            logging.warning("Query runtime exceeded while attempting to transfer rows from %s to file "
-                                            "[%s]. The page size is being reduced to %s and the query will be retried."
-                                            % (url, destfilename, page_size))
-                            if callback:
-                                if not callback(progress="Retrying query: %s" % url):
-                                    destfile.close()
-                                    return
-                            continue
-                        else:
-                            self._response_raise_for_status(r)
-
-                        # 2. Write the page to disk and check the last record processed in order to get the next page
-                        last_line = {}
-                        content_type = r.headers.get("Content-Type")
-                        logging.debug("Transferring data from [%s] to %s" % (url, destfilename))
-                        # CSV processing iterates over lines in the response, skipping the header line(s) in all but
-                        # the first page, and captures the last line of each page to determine the last record processed.
-                        # After writing, the last complete CSV record is found by reading back from the destination file
-                        # using Python's csv module, which correctly handles multi-line quoted fields (RFC 4180).
-                        if content_type == "text/csv":
-                            skip = 1
-                            line_num = 0
-                            if first_page:
-                                lines = r.iter_lines(decode_unicode=True)
-                                reader = csv.reader(lines)
-                                first_line = next(reader)
-                                skip = reader.line_num
-                            for line in r.iter_lines():
-                                if not first_page:
-                                    line_num += 1
-                                    if line_num <= skip:
-                                        continue
-                                tline = line + b"\n"
-                                destfile.write(tline)
-                                total += len(tline)
-                                last_line = tline
-                            if last_line and last_line != first_line:
-                                # Read back the last complete CSV record from the file.
-                                # We cannot rely on the last raw byte line because CSV
-                                # fields may contain embedded newlines inside quoted
-                                # values (e.g., OCR text with grid data).  Parsing the
-                                # last raw line as a record would produce an incorrect
-                                # RID for the @after() cursor, causing an infinite loop.
-                                destfile.flush()
-                                last_line = self._read_last_csv_record(destfilename, first_line)
-                            first_page = False
-                        # JSON-Stream processing writes the entire buffer to the destination file. The last line is
-                        # captured by reverse seeking in the buffer from right before the last b'\n' newline to the next
-                        # newline or buf[0], then calling readline from the current position
-                        elif content_type == "application/x-json-stream":
-                            buf = r.content
-                            if not buf:
-                                break
-                            destfile.write(buf)
-                            total += len(buf)
-                            b = io.BytesIO(buf)
-                            b.seek(-2, os.SEEK_END)
-                            while b.read(1) != b'\n':
-                                b.seek(-2, os.SEEK_CUR)
-                                if b.tell() == os.SEEK_SET:
-                                    break
-                            last_line = json.loads(b.readline().decode('utf-8'))
-
-                        # 3. Save the last record key and flush the destination file buffers to disk.
-                        if not last_line:
-                            break
-                        destfile.flush()
-                        last_record = [urlquote(str(last_line.get(key))) for key in page_sort_columns]
-                        if callback:
-                            if not callback(progress="Downloading: %.2f MB transferred" %
-                                                     (float(total) / float(Megabyte))):
-                                destfile.close()
-                                return
+                # The paged branch only ever requests one of the two accepted
+                # content types (the fallback filter above guarantees it), so
+                # the response Content-Type matches ``accept``. Recording it
+                # here preserves the delete-if-empty epilogue's behavior, which
+                # inspects ``content_type``.
+                content_type = accept
+                _first_page, total = self._fetch_paged_csv(
+                    destfile, path, headers, callback,
+                    page_size, page_sort_columns, True,
+                )
+                # A falsy callback inside the page loop closes destfile and
+                # aborts early, exactly as the inlined ``destfile.close();
+                # return`` did before extraction. Detect that and bail out of
+                # get_as_file without touching the closed file in the epilogue.
+                if destfile.closed:
+                    return
 
             elapsed = datetime.datetime.now() - start
             summary = get_transfer_summary(total, elapsed)

--- a/deriva/core/ermrest_catalog.py
+++ b/deriva/core/ermrest_catalog.py
@@ -580,6 +580,25 @@ class ErmrestCatalog(DerivaBinding):
             yield rids[i:i + chunk_size]
 
     @staticmethod
+    def _rid_set_query_url(rid_table, rid_chunk):
+        """Build a ``/entity/{rid_table}/RID=any(...)`` path for one RID chunk.
+
+        Each RID *value* is URL-quoted individually; the comma separators are
+        ``any()`` syntax and stay literal. Quoting the joined string instead
+        (encoding commas to ``%2C``) breaks the predicate and silently returns
+        zero rows — the bug this function exists to prevent.
+
+        Args:
+            rid_table: ``"schema:table"`` of the table being queried.
+            rid_chunk: List of RID strings (one URL-safe batch).
+
+        Returns:
+            Catalog-relative path string starting at ``/entity/``.
+        """
+        joined = ",".join(urlquote(str(rid)) for rid in rid_chunk)
+        return "/entity/%s/RID=any(%s)" % (rid_table, joined)
+
+    @staticmethod
     def _read_last_csv_record(filepath, fieldnames):
         """Read the last complete CSV record from a file.
 

--- a/deriva/core/ermrest_catalog.py
+++ b/deriva/core/ermrest_catalog.py
@@ -149,6 +149,11 @@ _clone_state_url = "tag:isrd.isi.edu,2018:clone-status"
 
 DEFAULT_PAGE_SIZE = 100000
 
+RID_SET_CHUNK_SIZE = 500
+"""URL-safe batch size for RID-set fetches. A ``RID=any(...)`` filter over
+thousands of RIDs exceeds the server's URI length limit (a 225k-RID URL is
+~1.9 MB → HTTP 414); chunking keeps each request URL well within limits."""
+
 class ResolveRidResult (NamedTuple):
     datapath: datapath.DataPath
     table: ermrest_model.Table
@@ -557,6 +562,22 @@ class ErmrestCatalog(DerivaBinding):
            Deprecated, call `get_as_file` instead.
         """
         self.get_as_file(path, destfilename, headers, callback, delete_if_empty, paged, page_size, page_sort_columns)
+
+    @staticmethod
+    def _rid_set_chunks(rid_set, chunk_size):
+        """Yield successive ``chunk_size``-length lists from ``rid_set``.
+
+        Args:
+            rid_set: Iterable of RID strings.
+            chunk_size: Max RIDs per chunk.
+
+        Yields:
+            Lists of at most ``chunk_size`` RIDs, preserving order, no RID
+            lost or duplicated.
+        """
+        rids = list(rid_set)
+        for i in range(0, len(rids), chunk_size):
+            yield rids[i:i + chunk_size]
 
     @staticmethod
     def _read_last_csv_record(filepath, fieldnames):

--- a/deriva/transfer/download/processors/query/base_query_processor.py
+++ b/deriva/transfer/download/processors/query/base_query_processor.py
@@ -39,6 +39,8 @@ class BaseQueryProcessor(BaseProcessor):
         self.paged_query = self.parameters.get("paged_query", False)
         self.paged_query_size = self.parameters.get("paged_query_size", 100000)
         self.paged_query_sort_columns = self.parameters.get("paged_query_sort_columns", ["RID"])
+        self.rid_set = self.parameters.get("rid_set", None)
+        self.rid_table = self.parameters.get("rid_table", None)
 
     def process(self):
         resp = self.catalogQuery(headers={'accept': self.content_type})
@@ -77,7 +79,9 @@ class BaseQueryProcessor(BaseProcessor):
                                                 delete_if_empty=True,
                                                 paged=self.paged_query,
                                                 page_size=self.paged_query_size,
-                                                page_sort_columns=self.paged_query_sort_columns)
+                                                page_sort_columns=self.paged_query_sort_columns,
+                                                rid_set=self.rid_set,
+                                                rid_table=self.rid_table)
             else:
                 return self.catalog.get(self.query, headers=headers).json()
         except requests.HTTPError as e:

--- a/deriva/transfer/download/processors/query/base_query_processor.py
+++ b/deriva/transfer/download/processors/query/base_query_processor.py
@@ -60,7 +60,10 @@ class BaseQueryProcessor(BaseProcessor):
         return self.outputs
 
     def catalogQuery(self, headers=None, as_file=True):
-        if not self.query:
+        # A rid_set-bearing processor (Format B) carries no query_path —
+        # get_as_file ignores ``self.query`` and fetches by RID set. Only
+        # short-circuit when there is NEITHER a query path NOR a rid_set.
+        if not self.query and not self.rid_set:
             return {}
 
         if not headers:

--- a/docs/superpowers/plans/2026-06-14-rid-set-bag-generation.md
+++ b/docs/superpowers/plans/2026-06-14-rid-set-bag-generation.md
@@ -1,0 +1,692 @@
+# RID-Set Bag Generation (deriva-py, Plan B1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the bag export engine fetch a large explicit RID set as ONE logical query that produces ONE clean CSV per table — eliminating the deep-FK-join cost and the per-path CSV fragmentation.
+
+**Architecture:** Add an optional `rid_set` + `rid_table` to `ErmrestCatalog.get_as_file`: when present, it chunks the RIDs into URL-safe batches (~500), fetches `/entity/{rid_table}/RID=any(...)` per chunk (each RID individually URL-quoted), and appends every chunk to one CSV by reusing the existing per-page header-skip append loop. `CSVQueryProcessor` passes `rid_set`/`rid_table` through from `processor_params`. `CatalogBagBuilder` emits one rid-set csv processor per reached table from a supplied `{table: rids}` map, replacing the per-FK-path emission. The SQLite loader needs no change (one CSV per table is a strict subset of what it already handles).
+
+**Tech Stack:** Python, deriva-py (`deriva/core/ermrest_catalog.py`, `deriva/transfer/download/processors/query/base_query_processor.py`, `deriva/bag/catalog_builder.py`), pytest. Tests mock the HTTP session / catalog model (no live catalog), mirroring `tests/deriva/core/test_csv_paging.py` and `tests/deriva/bag/test_catalog_builder.py`.
+
+---
+
+## Scope: this is Plan B1 of two (deriva-py side)
+
+Stage B spans two repos. **This plan is the deriva-py half** and ships as its own deriva-py PR on the `deriva-ml` branch (the branch deriva-ml pins). It produces working, testable software on its own: the `rid_set` engine capability + rid-set spec emission, with upstream contract tests. **Plan B2 (deriva-ml)** — written after this lands — bumps the deriva-py pin and wires `DatasetBagBuilder` → `compute_reachability` → Format-B export spec.
+
+Design: `deriva-ml/docs/superpowers/specs/2026-06-14-stage-b-fast-portable-bag-design.md` (decisions D1–D4) + `2026-06-14-portable-bag-csv-contract.md` (the CSV contract). Proven prototype + gotchas: deriva-ml memory `csv-ridset-chunk-append-proto.md`.
+
+**The per-RID-quoting gotcha (load-bearing, pinned by Task 2):** in `RID=any(a,b,c)` the commas are ERMrest *syntax separators*, not part of the values. Quote each RID individually (`",".join(urlquote(r) for r in batch)`), NOT `urlquote(",".join(batch))` — the latter encodes commas to `%2C`, breaks the predicate, and **silently returns zero rows**.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `deriva/core/ermrest_catalog.py` | `get_as_file` gains `rid_set`/`rid_table`; new private `_rid_set_chunks` helper; the chunk loop wraps the existing paged fetch with a persistent `first_page` flag. | **Modify** (`get_as_file` ~606; add helper) |
+| `tests/deriva/core/test_rid_set_fetch.py` | Unit tests for the chunking helper (pure) + the chunk-append behavior (mocked session): header-once, RID-distinct, complete, per-RID-quoting. | **Create** |
+| `deriva/transfer/download/processors/query/base_query_processor.py` | `BaseQueryProcessor.__init__` reads `rid_set`/`rid_table` from `processor_params`; `catalogQuery` passes them to `get_as_file`. | **Modify** (~39, ~74) |
+| `deriva/bag/catalog_builder.py` | `_build_export_spec` emits one rid-set csv processor per reached table from a supplied `{(schema,table): rids}` map, replacing the `for fk_path in self._fk_paths_for(key)` per-path emission. New `rid_sets` attribute + constructor/`get_export_spec` param. | **Modify** (~495, ~584) |
+| `tests/deriva/bag/test_catalog_builder.py` | Extend: when `rid_sets` is supplied, the spec has one csv processor per table carrying `rid_table`+`rid_set`, not one-per-FK-path. | **Modify** |
+
+The SQLite loader (`deriva/bag/database.py` / `loader.py`) is intentionally **not** modified: it already groups CSVs by `{schema}.{table}` basename and unions by RID via `ON CONFLICT`. One clean CSV per table is a strict subset of that — it loads correctly with zero change. (Plan B2's integration test confirms the round-trip.)
+
+---
+
+## Interface (locked here so all tasks agree)
+
+```python
+# deriva/core/ermrest_catalog.py
+
+def get_as_file(self, path, destfilename, headers=DEFAULT_HEADERS, callback=None,
+                delete_if_empty=False, paged=False, page_size=DEFAULT_PAGE_SIZE,
+                page_sort_columns=frozenset(["RID"]),
+                rid_set=None, rid_table=None):
+    """... existing behavior unchanged when rid_set is None ...
+
+    When ``rid_set`` (a list/iterable of RID strings) is provided, ``path`` is
+    ignored and the data is fetched by chunking ``rid_set`` into URL-safe
+    batches and querying ``/entity/{rid_table}/RID=any(...)`` per batch,
+    appending all batches to one CSV. ``rid_table`` (``"schema:table"``) is
+    required when ``rid_set`` is given. Forces paged CSV semantics internally.
+    """
+
+RID_SET_CHUNK_SIZE = 500   # module constant; URL-safe batch size
+```
+
+`CatalogBagBuilder` gains:
+```python
+# deriva/bag/catalog_builder.py
+def __init__(self, ..., rid_sets: dict[tuple[str, str], list[str]] | None = None):
+    ...
+    self.rid_sets = rid_sets   # {(schema, table): [RID, ...]} or None
+```
+When `rid_sets` is not None, `_build_export_spec` emits one rid-set csv processor per reached table (using `rid_sets[key]`) instead of per-FK-path processors. When None, current per-path behavior is unchanged (so existing callers and tests keep working until B2 supplies rid_sets).
+
+---
+
+### Task 1: RID-set chunking helper (pure)
+
+**Files:**
+- Modify: `deriva/core/ermrest_catalog.py` (add module constant + `_rid_set_chunks` staticmethod)
+- Test: `tests/deriva/core/test_rid_set_fetch.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/deriva/core/test_rid_set_fetch.py
+"""Tests for RID-set chunk-append fetch in get_as_file (no live catalog)."""
+
+from deriva.core.ermrest_catalog import ErmrestCatalog, RID_SET_CHUNK_SIZE
+
+
+def test_rid_set_chunks_splits_at_chunk_size():
+    rids = [f"1-{i:04d}" for i in range(1250)]
+    chunks = list(ErmrestCatalog._rid_set_chunks(rids, 500))
+    assert len(chunks) == 3
+    assert [len(c) for c in chunks] == [500, 500, 250]
+    # No RID lost or duplicated across chunks.
+    flat = [r for c in chunks for r in c]
+    assert flat == rids
+
+
+def test_rid_set_chunks_empty():
+    assert list(ErmrestCatalog._rid_set_chunks([], 500)) == []
+
+
+def test_rid_set_chunk_size_default_is_500():
+    assert RID_SET_CHUNK_SIZE == 500
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/carl/GitHub/deriva-py && uv run pytest tests/deriva/core/test_rid_set_fetch.py -v`
+Expected: FAIL — `ImportError: cannot import name 'RID_SET_CHUNK_SIZE'` (and `_rid_set_chunks` missing)
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the module constant near the other module-level constants at the top of `deriva/core/ermrest_catalog.py` (after the imports):
+
+```python
+RID_SET_CHUNK_SIZE = 500
+"""URL-safe batch size for RID-set fetches. A ``RID=any(...)`` filter over
+thousands of RIDs exceeds the server's URI length limit (a 225k-RID URL is
+~1.9 MB → HTTP 414); chunking keeps each request URL well within limits."""
+```
+
+Add the static helper as a method on `ErmrestCatalog` (place near `_read_last_csv_record`):
+
+```python
+    @staticmethod
+    def _rid_set_chunks(rid_set, chunk_size):
+        """Yield successive ``chunk_size``-length lists from ``rid_set``.
+
+        Args:
+            rid_set: Iterable of RID strings.
+            chunk_size: Max RIDs per chunk.
+
+        Yields:
+            Lists of at most ``chunk_size`` RIDs, preserving order, no RID
+            lost or duplicated.
+        """
+        rids = list(rid_set)
+        for i in range(0, len(rids), chunk_size):
+            yield rids[i:i + chunk_size]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/carl/GitHub/deriva-py && uv run pytest tests/deriva/core/test_rid_set_fetch.py -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/carl/GitHub/deriva-py && git add deriva/core/ermrest_catalog.py tests/deriva/core/test_rid_set_fetch.py && git commit -m "feat(ermrest): RID-set chunking helper for bag fetch"
+```
+
+---
+
+### Task 2: RID-set URL builder (per-RID quoting — the gotcha)
+
+**Files:**
+- Modify: `deriva/core/ermrest_catalog.py` (add `_rid_set_query_url` staticmethod)
+- Test: `tests/deriva/core/test_rid_set_fetch.py`
+
+This isolates the load-bearing per-RID-quoting rule into a pure, directly-tested function so the gotcha can never silently regress.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/deriva/core/test_rid_set_fetch.py
+from deriva.core.ermrest_catalog import ErmrestCatalog
+
+
+def test_rid_set_query_url_quotes_each_rid_not_the_commas():
+    """Commas are any() SYNTAX separators, not values. Each RID is quoted
+    individually; the commas stay literal. Quoting the whole joined string
+    (%2C) would break the predicate and silently return zero rows."""
+    url = ErmrestCatalog._rid_set_query_url("eye-ai:Image", ["1-ABC", "1-DEF"])
+    assert url == "/entity/eye-ai:Image/RID=any(1-ABC,1-DEF)"
+    # The separating commas must be literal, never percent-encoded.
+    assert "%2C" not in url
+
+
+def test_rid_set_query_url_quotes_special_chars_in_rid():
+    """A RID value containing a reserved char IS quoted (the value, not the
+    comma)."""
+    url = ErmrestCatalog._rid_set_query_url("S:T", ["a b", "c"])
+    # space in the value is encoded; the comma separator is not.
+    assert url == "/entity/S:T/RID=any(a%20b,c)"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/carl/GitHub/deriva-py && uv run pytest tests/deriva/core/test_rid_set_fetch.py::test_rid_set_query_url_quotes_each_rid_not_the_commas -v`
+Expected: FAIL — `AttributeError: ... has no attribute '_rid_set_query_url'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+`urlquote` is already imported at the top of the module (`from . import urlquote, ...`). Add:
+
+```python
+    @staticmethod
+    def _rid_set_query_url(rid_table, rid_chunk):
+        """Build a ``/entity/{rid_table}/RID=any(...)`` path for one RID chunk.
+
+        Each RID *value* is URL-quoted individually; the comma separators are
+        ``any()`` syntax and stay literal. Quoting the joined string instead
+        (encoding commas to ``%2C``) breaks the predicate and silently returns
+        zero rows — the bug this function exists to prevent.
+
+        Args:
+            rid_table: ``"schema:table"`` of the table being queried.
+            rid_chunk: List of RID strings (one URL-safe batch).
+
+        Returns:
+            Catalog-relative path string starting at ``/entity/``.
+        """
+        joined = ",".join(urlquote(str(rid)) for rid in rid_chunk)
+        return "/entity/%s/RID=any(%s)" % (rid_table, joined)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/carl/GitHub/deriva-py && uv run pytest tests/deriva/core/test_rid_set_fetch.py -v`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/carl/GitHub/deriva-py && git add deriva/core/ermrest_catalog.py tests/deriva/core/test_rid_set_fetch.py && git commit -m "feat(ermrest): per-RID-quoted RID-set query URL builder"
+```
+
+---
+
+### Task 3: get_as_file rid_set chunk-append (the core)
+
+**Files:**
+- Modify: `deriva/core/ermrest_catalog.py` (`get_as_file` signature + chunk loop)
+- Test: `tests/deriva/core/test_rid_set_fetch.py`
+
+The core change. When `rid_set` is provided, wrap the existing paged-CSV fetch in an outer loop over chunks. The `first_page` flag persists ACROSS chunks (only the very first page of the very first chunk writes a header), so all chunks append into one clean CSV. Within a chunk, the existing `@after(RID)` paging still applies (a 500-RID `any()` result can itself exceed `page_size`).
+
+The implementation strategy that minimizes risk: extract the existing paged-fetch inner body into a helper `_fetch_paged_into(destfile, base_path, headers, page_size, page_sort_columns, first_page)` that returns the updated `(first_page, total_so_far)`, then call it once per chunk (or once for the non-rid_set path). Because the existing paged loop is long and subtle (runtime-limit backoff, multi-line CSV `_read_last_csv_record`), the helper preserves it verbatim — only its entry/exit (the `first_page` seed and the destfile open) move out.
+
+- [ ] **Step 1: Write the failing test**
+
+This test mocks `_session.get` to serve canned CSV pages per RID-chunk URL, and asserts the chunk-append produces one clean CSV. It mirrors the mocked-session style.
+
+```python
+# add to tests/deriva/core/test_rid_set_fetch.py
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from deriva.core.ermrest_catalog import ErmrestCatalog
+
+
+class _FakeResponse:
+    """Minimal requests.Response stand-in for a CSV page."""
+
+    def __init__(self, text):
+        self._text = text
+        self.status_code = 200
+        self.headers = {"Content-Type": "text/csv"}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def close(self):
+        pass
+
+    def iter_lines(self, decode_unicode=False):
+        for line in self._text.splitlines():
+            yield line if decode_unicode else line.encode("utf-8")
+
+    @property
+    def text(self):
+        return self._text
+
+
+def _csv(header, rows):
+    return "\n".join([header] + rows) + "\n"
+
+
+def test_get_as_file_rid_set_appends_chunks_to_one_csv():
+    """Two RID chunks each return a CSV page; the result is ONE CSV with the
+    header once and all body rows, RID-distinct."""
+    # 3 RIDs, chunk size 2 -> 2 chunks: [r1, r2], [r3].
+    header = "RID,Name"
+    pages = {
+        "/entity/S:T/RID=any(r1,r2)": _csv(header, ["r1,Alice", "r2,Bob"]),
+        "/entity/S:T/RID=any(r3)": _csv(header, ["r3,Carol"]),
+    }
+
+    cat = ErmrestCatalog.__new__(ErmrestCatalog)  # bypass __init__/network
+    cat._server_uri = "https://example.org/ermrest/catalog/1"
+
+    def fake_get(url, headers=None, stream=False):
+        # url ends with one of the page paths; serve the matching CSV.
+        for path, body in pages.items():
+            if url.endswith(path):
+                return _FakeResponse(body)
+        raise AssertionError("unexpected URL: %s" % url)
+
+    cat._session = MagicMock()
+    cat._session.get.side_effect = fake_get
+    cat._response_raise_for_status = lambda r: None
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        out = f.name
+    try:
+        cat.get_as_file(
+            None, out, rid_set=["r1", "r2", "r3"], rid_table="S:T",
+        )
+        with open(out, encoding="utf-8") as fh:
+            content = fh.read()
+        # Header appears exactly once.
+        assert content.count("RID,Name") == 1
+        # All three body rows present.
+        for rid in ("r1", "r2", "r3"):
+            assert rid in content
+        # RID-distinct: 1 header + 3 data lines.
+        nonblank = [ln for ln in content.splitlines() if ln.strip()]
+        assert len(nonblank) == 4
+    finally:
+        os.unlink(out)
+```
+
+Note: this test exercises the chunking + append + header-skip with `page_size` large enough that each chunk is a single page (so the within-chunk `@after` loop terminates after one page). The within-chunk multi-page path is covered by the existing `test_csv_paging.py` machinery (the same loop body), so this task does not re-test paging itself — only the chunk-append wrapper.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/carl/GitHub/deriva-py && uv run pytest tests/deriva/core/test_rid_set_fetch.py::test_get_as_file_rid_set_appends_chunks_to_one_csv -v`
+Expected: FAIL — `get_as_file` doesn't accept `rid_set` (TypeError: unexpected keyword argument)
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `get_as_file`, add `rid_set=None, rid_table=None` to the signature (after `page_sort_columns`). At the top of the method body, validate and branch:
+
+```python
+        if rid_set is not None:
+            if not rid_table:
+                raise ValueError("rid_table is required when rid_set is provided")
+            return self._get_rid_set_as_file(
+                rid_set, rid_table, destfilename, headers=headers,
+                callback=callback, delete_if_empty=delete_if_empty,
+                page_size=page_size, page_sort_columns=page_sort_columns,
+            )
+```
+
+Add the new method `_get_rid_set_as_file`. It opens the destfile ONCE, then loops chunks, running the existing paged-CSV fetch body per chunk with a `first_page` flag that persists across chunks. To avoid duplicating the long paged loop, refactor: extract the body of the existing `else:` (paged) branch — from `first_page = True` through the page `while True:` loop — into a method `_fetch_paged_csv(destfile, base_path, headers, callback, page_size, page_sort_columns, first_page)` that takes the open destfile and the starting `first_page`, runs the page loop for ONE base path, and returns `(first_page, total_written)`. The existing `get_as_file` paged branch then calls it with `first_page=True` for the single path; `_get_rid_set_as_file` calls it once per chunk, threading `first_page` through:
+
+```python
+    def _get_rid_set_as_file(self, rid_set, rid_table, destfilename, *, headers,
+                             callback, delete_if_empty, page_size, page_sort_columns):
+        """Fetch a RID set as one CSV by chunk-append (see RID_SET_CHUNK_SIZE)."""
+        destfile = open(destfilename, 'w+b')
+        try:
+            first_page = True
+            total = 0
+            for chunk in self._rid_set_chunks(rid_set, RID_SET_CHUNK_SIZE):
+                base_path = self._rid_set_query_url(rid_table, chunk)
+                first_page, written = self._fetch_paged_csv(
+                    destfile, base_path, headers, callback,
+                    page_size, page_sort_columns, first_page,
+                )
+                total += written
+            destfile.flush()
+            # delete_if_empty: a header-only (or empty) CSV is "empty".
+            delete_file = (total == 0)
+            if delete_if_empty and total > 0:
+                destfile.seek(0)
+                reader = csv.reader(codecs.iterdecode(destfile, 'utf-8'))
+                rowcount = sum(1 for _ in reader)
+                delete_file = rowcount <= 1
+        finally:
+            destfile.close()
+        if delete_file and os.path.exists(destfilename):
+            os.remove(destfilename)
+            return None
+        return destfilename
+```
+
+Refactor the existing paged branch into `_fetch_paged_csv(self, destfile, base_path, headers, callback, page_size, page_sort_columns, first_page)`: move the code that is currently inside `get_as_file`'s `else:` (paged) branch — the `first_page`/`first_line`/`last_record` setup and the `while True:` page loop — into this method, parameterized by the supplied `destfile` and the incoming `first_page` (instead of always starting True), querying `base_path` (instead of `path`). It returns `(first_page, total)`. Keep the runtime-limit backoff, the CSV/JSON-stream branches, and the `_read_last_csv_record` call EXACTLY as they are — only the entry seed (`first_page` param) and the path source (`base_path`) change. Then in `get_as_file`'s own paged branch, replace the inlined loop with:
+
+```python
+            else:
+                _first_page, total = self._fetch_paged_csv(
+                    destfile, path, headers, callback,
+                    page_size, page_sort_columns, True,
+                )
+```
+
+> **Implementer note:** this refactor is the delicate part. Do it in two moves: (1) extract `_fetch_paged_csv` verbatim and make `get_as_file`'s paged branch call it (run the FULL existing suite — `tests/deriva/core/test_csv_paging.py` plus any get_as_file integration tests — to prove the extraction is behavior-preserving BEFORE adding rid_set). (2) Then add `_get_rid_set_as_file` + the signature branch. If the extraction can't be made cleanly behavior-preserving, STOP and report — do not force it.
+
+- [ ] **Step 4: Run test to verify it passes (and the extraction didn't break paging)**
+
+Run:
+```bash
+cd /Users/carl/GitHub/deriva-py && uv run pytest tests/deriva/core/test_rid_set_fetch.py tests/deriva/core/test_csv_paging.py -v
+```
+Expected: the new rid_set test PASSES and ALL existing `test_csv_paging.py` tests still PASS (proving the extraction preserved behavior).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/carl/GitHub/deriva-py && git add deriva/core/ermrest_catalog.py tests/deriva/core/test_rid_set_fetch.py && git commit -m "feat(ermrest): get_as_file rid_set chunk-append into one CSV"
+```
+
+---
+
+### Task 4: CSVQueryProcessor passes rid_set/rid_table through
+
+**Files:**
+- Modify: `deriva/transfer/download/processors/query/base_query_processor.py` (`__init__` ~39, `catalogQuery` ~74)
+- Test: `tests/deriva/core/test_rid_set_fetch.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/deriva/core/test_rid_set_fetch.py
+from deriva.transfer.download.processors.query.base_query_processor import (
+    BaseQueryProcessor,
+)
+
+
+def test_query_processor_reads_rid_set_from_params():
+    """rid_set/rid_table flow from processor_params onto the processor."""
+    proc = BaseQueryProcessor.__new__(BaseQueryProcessor)
+    proc.parameters = {
+        "query_path": "/entity/S:T",
+        "rid_set": ["r1", "r2"],
+        "rid_table": "S:T",
+    }
+    # Replicate the __init__ param reads (the lines under test).
+    proc.rid_set = proc.parameters.get("rid_set", None)
+    proc.rid_table = proc.parameters.get("rid_table", None)
+    assert proc.rid_set == ["r1", "r2"]
+    assert proc.rid_table == "S:T"
+```
+
+This test pins the param names; the real wiring is verified in Step 4 by a smoke import + a `catalogQuery` argument-forwarding check below.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/carl/GitHub/deriva-py && uv run pytest tests/deriva/core/test_rid_set_fetch.py::test_query_processor_reads_rid_set_from_params -v`
+Expected: PASS trivially (the test replicates the reads). The REAL gate is that the processor `__init__` and `catalogQuery` actually do this — implement that now and confirm via the forwarding assertion in Step 3's test.
+
+Add a second, behavior-pinning test that fails until the wiring exists:
+
+```python
+# add to tests/deriva/core/test_rid_set_fetch.py
+def test_catalog_query_forwards_rid_set_to_get_as_file():
+    """catalogQuery must pass rid_set/rid_table into get_as_file."""
+    proc = BaseQueryProcessor.__new__(BaseQueryProcessor)
+    proc.parameters = {"rid_set": ["r1"], "rid_table": "S:T"}
+    proc.envars = {}
+    proc.rid_set = proc.parameters.get("rid_set")
+    proc.rid_table = proc.parameters.get("rid_table")
+    proc.query = "/entity/S:T"
+    proc.output_abspath = "/tmp/ignored.csv"
+    proc.paged_query = False
+    proc.paged_query_size = 100000
+    proc.paged_query_sort_columns = ["RID"]
+    proc.HEADERS = {}
+    proc.callback = None
+    captured = {}
+    cat = MagicMock()
+
+    def fake_get_as_file(path, dest, **kwargs):
+        captured.update(kwargs)
+        return dest
+
+    cat.get_as_file.side_effect = fake_get_as_file
+    proc.catalog = cat
+    # Avoid mkdir on a real path.
+    with patch(
+        "deriva.transfer.download.processors.query.base_query_processor.make_dirs"
+    ):
+        proc.catalogQuery()
+    assert captured.get("rid_set") == ["r1"]
+    assert captured.get("rid_table") == "S:T"
+```
+
+Run: `cd /Users/carl/GitHub/deriva-py && uv run pytest tests/deriva/core/test_rid_set_fetch.py::test_catalog_query_forwards_rid_set_to_get_as_file -v`
+Expected: FAIL — `catalogQuery` doesn't pass `rid_set`/`rid_table` yet (captured lacks them).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `BaseQueryProcessor.__init__`, after the existing `self.paged_query_*` reads (~line 41), add:
+
+```python
+        self.rid_set = self.parameters.get("rid_set", None)
+        self.rid_table = self.parameters.get("rid_table", None)
+```
+
+In `catalogQuery`, in the `get_as_file` call (~line 74), add the two kwargs:
+
+```python
+                return self.catalog.get_as_file(self.query, self.output_abspath,
+                                                headers=headers,
+                                                callback=self.callback,
+                                                delete_if_empty=True,
+                                                paged=self.paged_query,
+                                                page_size=self.paged_query_size,
+                                                page_sort_columns=self.paged_query_sort_columns,
+                                                rid_set=self.rid_set,
+                                                rid_table=self.rid_table)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/carl/GitHub/deriva-py && uv run pytest tests/deriva/core/test_rid_set_fetch.py -v`
+Expected: PASS (all rid_set tests incl. the forwarding one)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/carl/GitHub/deriva-py && git add deriva/transfer/download/processors/query/base_query_processor.py tests/deriva/core/test_rid_set_fetch.py && git commit -m "feat(download): CSVQueryProcessor forwards rid_set/rid_table to get_as_file"
+```
+
+---
+
+### Task 5: CatalogBagBuilder emits rid-set processors when rid_sets supplied
+
+**Files:**
+- Modify: `deriva/bag/catalog_builder.py` (`__init__`, `_build_export_spec` ~495/584)
+- Test: `tests/deriva/bag/test_catalog_builder.py`
+
+When `rid_sets` is supplied, emit ONE rid-set csv processor per reached table (flat `output_path`, carrying `rid_table` + `rid_set`) instead of one-per-FK-path. When `rid_sets` is None, the current per-path behavior is untouched.
+
+- [ ] **Step 1: Write the failing test**
+
+First READ `tests/deriva/bag/test_catalog_builder.py` to reuse its existing mock-catalog/model fixtures (`_make_mock_table`, the builder construction helper). Then add a test that constructs a builder with `rid_sets` and asserts the spec shape. Use the file's existing fixture style — the test below shows the assertion contract; adapt the builder construction to match the file's helpers:
+
+```python
+# add to tests/deriva/bag/test_catalog_builder.py
+def test_rid_set_spec_emits_one_csv_processor_per_table(<existing fixture args>):
+    """With rid_sets supplied, the export spec has ONE csv processor per
+    reached table carrying rid_table+rid_set, not one-per-FK-path."""
+    # Build a mock model where table ('S','Image') is reached via TWO FK paths
+    # (so the per-path emission would produce 2 processors).
+    builder = <construct CatalogBagBuilder with the mock catalog/model,
+               anchors, policy AS THE EXISTING TESTS DO>,
+              rid_sets={("S", "Image"): ["r1", "r2", "r3"]})
+    spec = builder.get_export_spec()
+    csv_procs = [
+        p for p in spec["catalog"]["query_processors"]
+        if p["processor"] == "csv"
+        and p["processor_params"].get("output_path", "").endswith("Image")
+    ]
+    # Exactly ONE Image csv processor (not one-per-FK-path).
+    assert len(csv_procs) == 1
+    params = csv_procs[0]["processor_params"]
+    assert params["rid_table"] == "S:Image"
+    assert params["rid_set"] == ["r1", "r2", "r3"]
+    assert "query_path" not in params       # rid-set replaces query_path
+    assert params["output_path"] == "S/Image"   # flat, one file per table
+```
+
+> **Implementer note:** read the existing tests in `test_catalog_builder.py` to find the exact fixture/helper names and the builder constructor signature; mirror them. Do not invent fixture names — use what the file already provides. If the builder's constructor doesn't yet accept `rid_sets`, that's what Step 3 adds.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/carl/GitHub/deriva-py && uv run pytest tests/deriva/bag/test_catalog_builder.py::test_rid_set_spec_emits_one_csv_processor_per_table -v`
+Expected: FAIL — `CatalogBagBuilder` doesn't accept `rid_sets` (TypeError) or doesn't emit the rid-set shape.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `CatalogBagBuilder.__init__`, add a `rid_sets=None` parameter and store `self.rid_sets = rid_sets`.
+
+In `_build_export_spec`, in the per-reached-table loop, branch on `self.rid_sets`. The current code (~line 584) is:
+
+```python
+                for fk_path in self._fk_paths_for(key):
+                    qpath = self._table_query_path(schema_name, table_name, anchor_rid_filter, fk_path)
+                    dest = self._output_path_for(schema_name, table_name, fk_path)
+                    query_processors.append({
+                        "processor": "csv",
+                        "processor_params": {
+                            "query_path": qpath,
+                            "output_path": dest,
+                            "paged_query": True,
+                        },
+                    })
+```
+
+Wrap it:
+
+```python
+                if self.rid_sets is not None:
+                    # Format B: one rid-set csv processor per table — flat
+                    # output_path, RID set carried inline. The engine chunks
+                    # and appends to one clean CSV (see get_as_file rid_set).
+                    rids = self.rid_sets.get(key, [])
+                    query_processors.append({
+                        "processor": "csv",
+                        "processor_params": {
+                            "rid_table": "%s:%s" % (schema_name, table_name),
+                            "rid_set": rids,
+                            "output_path": "%s/%s" % (schema_name, table_name),
+                            "paged_query": True,
+                        },
+                    })
+                else:
+                    for fk_path in self._fk_paths_for(key):
+                        qpath = self._table_query_path(schema_name, table_name, anchor_rid_filter, fk_path)
+                        dest = self._output_path_for(schema_name, table_name, fk_path)
+                        query_processors.append({
+                            "processor": "csv",
+                            "processor_params": {
+                                "query_path": qpath,
+                                "output_path": dest,
+                                "paged_query": True,
+                            },
+                        })
+```
+
+> **Implementer note:** match the exact local variable names (`schema_name`, `table_name`, `key`, `anchor_rid_filter`) the surrounding method actually uses — READ the method first; the names above are from the spec inspection but verify against the live code. The vocab-full-export branch and the asset `fetch` branch are UNCHANGED (assets still emit a fetch processor; rid_sets only changes the non-vocab csv emission).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/carl/GitHub/deriva-py && uv run pytest tests/deriva/bag/test_catalog_builder.py -v`
+Expected: PASS — the new rid-set test passes AND all existing per-path tests still pass (rid_sets=None default keeps old behavior).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/carl/GitHub/deriva-py && git add deriva/bag/catalog_builder.py tests/deriva/bag/test_catalog_builder.py && git commit -m "feat(bag): CatalogBagBuilder emits rid-set csv processors when rid_sets supplied"
+```
+
+---
+
+### Task 6: Full suite, lint, PR
+
+**Files:** none (verification + PR)
+
+- [ ] **Step 1: Run the bag + core suites**
+
+Run:
+```bash
+cd /Users/carl/GitHub/deriva-py && uv run pytest tests/deriva/bag/ tests/deriva/core/test_csv_paging.py tests/deriva/core/test_rid_set_fetch.py -v
+```
+Expected: all pass. The existing bag tests prove the `rid_sets=None` default path is untouched; the new tests prove the rid_set path. If the repo uses a different runner than `uv` (check `Makefile`/`README` — deriva-py may use plain `pytest` or `python -m pytest`), use the repo's convention.
+
+- [ ] **Step 2: Lint (match the repo's tooling)**
+
+READ the repo's lint config (`setup.cfg`, `Makefile`, any `.flake8`/`ruff.toml`). Run whatever the repo uses (deriva-py historically uses `flake8`; if a `Makefile` `lint` target exists, use it):
+```bash
+cd /Users/carl/GitHub/deriva-py && make lint 2>/dev/null || python -m flake8 deriva/core/ermrest_catalog.py deriva/transfer/download/processors/query/base_query_processor.py deriva/bag/catalog_builder.py
+```
+Expected: clean on the touched files. Fix any new warnings this change introduced (don't fix pre-existing warnings on untouched lines).
+
+- [ ] **Step 3: Push the branch and open the deriva-py PR**
+
+This work lands on the `deriva-ml` branch (the branch deriva-ml pins). Confirm the current branch, then push and PR:
+
+```bash
+cd /Users/carl/GitHub/deriva-py && git status --short && git branch --show-current
+```
+
+If on `deriva-ml` directly, create a feature branch off it for the PR:
+```bash
+cd /Users/carl/GitHub/deriva-py && git checkout -b feature/rid-set-bag-generation && git push -u origin feature/rid-set-bag-generation
+gh pr create --base deriva-ml --title "feat(bag): RID-set fetch for fast one-CSV-per-table bag generation" --body "Adds get_as_file rid_set chunk-append + CatalogBagBuilder rid-set spec emission. Lets the bag exporter fetch a large explicit RID set as one logical query producing one clean CSV per table, eliminating the deep-FK-join cost and per-path fragmentation. Additive: existing query_path csv processors (incl. Chaise exports) are unaffected; rid_sets=None keeps current behavior. Consumer of deriva-ml's client-side reachability engine (PR #300). Per-RID-quoting gotcha pinned by test. Contract test upstream per the workspace cross-repo rule.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+> **Note:** the controller (not the subagent) decides whether to actually merge. The subagent's job ends at "PR opened". Do NOT bump version.
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (against `2026-06-14-stage-b-fast-portable-bag-design.md` D1–D4 and the contract spec):
+- D1 `get_as_file` rid_set chunk-append → Tasks 1–3. ✓
+- The per-RID-quoting gotcha → Task 2 (isolated + directly tested). ✓
+- D1 reuse of the page-append loop → Task 3 (extract `_fetch_paged_csv`, thread `first_page` across chunks). ✓
+- Processor passthrough → Task 4. ✓
+- D2 Format-B one-csv-per-table emission → Task 5. ✓
+- D2 loader unchanged (one CSV per table is a loader subset) → documented in File Structure; no task needed; B2 integration test confirms round-trip. ✓
+- D3 deriva-py stays domain-agnostic (consumes `rid_sets`, no reachability logic) → Task 5 takes a supplied map; no FK-reachability added upstream. ✓
+- D4 deriva-py PR first with upstream contract tests → Task 6 opens the PR; the contract tests are Tasks 1–5. ✓
+- Vocab full-export + asset fetch unchanged → Task 5 note. ✓
+- Chaise unaffected (additive param) → Task 5 (rid_sets=None default) + PR body. ✓
+
+**2. Placeholder scan:** No "TBD"/"handle edge cases". Tasks 5's test has explicit `<fixture>` placeholders BY DESIGN — they instruct the implementer to read and reuse the existing `test_catalog_builder.py` fixtures rather than invent names, with a clear note. Every code step shows complete code except where it explicitly defers to "match the live local variable names" (Task 3, Task 5) — these are flagged as READ-first because the surrounding method's exact identifiers must be verified against code, not transcribed from a plan. This is intentional precision, not a placeholder.
+
+**3. Type consistency:**
+- `rid_set` (list of RID strings) + `rid_table` ("schema:table") consistent across Tasks 1–5. ✓
+- `RID_SET_CHUNK_SIZE = 500` defined Task 1, used Task 3. ✓
+- `_rid_set_chunks` (Task 1), `_rid_set_query_url` (Task 2), `_fetch_paged_csv` + `_get_rid_set_as_file` (Task 3) — names consistent where cross-referenced. ✓
+- `CatalogBagBuilder(rid_sets=...)` keyed by `(schema, table)` tuple (Task 5) matches the `key` the reached-table loop iterates. ✓
+- The export-spec processor shape (`rid_table`, `rid_set`, `output_path`, no `query_path`) is identical between the contract spec, Task 4's forwarding, and Task 5's emission. ✓
+
+**Risk flagged for the implementer:** Task 3's `_fetch_paged_csv` extraction is the one delicate refactor — it moves a long, subtle loop (runtime-limit backoff, multi-line CSV cursor) out of `get_as_file`. The plan mandates a two-move approach (extract-and-prove-green FIRST, then add rid_set) and a STOP-and-report if the extraction can't be made behavior-preserving. This is the task most likely to need a more capable model.

--- a/tests/deriva/bag/test_catalog_builder.py
+++ b/tests/deriva/bag/test_catalog_builder.py
@@ -815,6 +815,116 @@ def test_rid_set_spec_emits_one_csv_processor_per_table(
     assert params["output_path"] == "demo/Image"  # flat, one file per table
 
 
+def test_rid_set_mode_excludes_referenced_only_vocab(
+    tmp_path: Path,
+) -> None:
+    """A REFERENCED_ONLY vocab table reached under ``rid_sets`` mode must NOT
+    be emitted as a rid-set processor.
+
+    Vocab tables are referenced by Name, not RID, so a reachability map carries
+    no RID set for them — a rid-set processor would emit an empty CSV and FK
+    references into the vocab would not resolve at the destination. The vocab
+    table must stay on the per-FK-path ``else`` branch (its existing, correct
+    behavior): the processor for the vocab carries a ``query_path`` and does
+    NOT carry a ``rid_set``.
+
+    Topology: ``Subject → Species`` (Subject has an FK to the Species vocab).
+    Anchoring at Subject under default (REFERENCED_ONLY) policy with
+    ``rid_sets`` supplied, the Species processor must remain per-path.
+    """
+    species = _make_mock_table(
+        "demo", "Species", is_vocabulary=True
+    )
+    subject = _make_mock_table("demo", "Subject")
+    # Subject → Species FK (Subject declares it; Species is referenced).
+    fk = _fk_mock(src_table=subject, pk_table=species)
+    subject.foreign_keys = [fk]
+    species.referenced_by = [fk]
+
+    model = _make_mock_model(
+        {"demo": {"Subject": subject, "Species": species}}
+    )
+    catalog = _make_mock_catalog(model)
+    cb = CatalogBagBuilder(
+        catalog=catalog,
+        anchors=[RIDAnchor(table="Subject", rids=["S1"])],
+        output_dir=tmp_path,
+        # Default policy ⇒ vocab_export == REFERENCED_ONLY.
+        rid_sets={
+            ("demo", "Subject"): ["S1"],
+            # Note: NO entry for Species — a reachability map never
+            # carries RID sets for vocab (referenced by Name).
+        },
+    )
+    cb._validate_anchors = lambda: None
+    cb._compute_reached_tables()
+    # Sanity: the vocab table really is in the reached set.
+    assert ("demo", "Species") in cb._reached_tables
+    spec = cb._build_export_spec()
+
+    species_procs = [
+        p
+        for p in spec["catalog"]["query_processors"]
+        if p["processor"] == "csv"
+        and p["processor_params"].get("output_path", "").endswith(
+            "/Species"
+        )
+    ]
+    assert len(species_procs) >= 1, [
+        p["processor_params"] for p in spec["catalog"]["query_processors"]
+    ]
+    # Every Species processor stayed on the per-FK-path branch: a
+    # query_path is present, and rid_set is absent. No empty rid-set CSV.
+    for p in species_procs:
+        params = p["processor_params"]
+        assert "rid_set" not in params, params
+        assert "rid_table" not in params, params
+        assert "query_path" in params, params
+
+
+def test_rid_set_mode_warns_on_missing_non_vocab_key(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A reached NON-vocab table absent from ``rid_sets`` logs a warning.
+
+    Silently emitting an empty rid-set CSV for a table the walker proved was
+    in scope is data loss. FIX 3 distinguishes "missing key" (a
+    map-completeness bug) from "present-but-empty" (legitimately
+    reached-but-empty) by warning only on the former.
+    """
+    a = _make_mock_table("demo", "A")
+    b = _make_mock_table("demo", "B")
+    fk = _fk_mock(src_table=a, pk_table=b)
+    a.foreign_keys = [fk]
+    b.referenced_by = [fk]
+    model = _make_mock_model({"demo": {"A": a, "B": b}})
+    catalog = _make_mock_catalog(model)
+    cb = CatalogBagBuilder(
+        catalog=catalog,
+        anchors=[RIDAnchor(table="A", rids=["A1"])],
+        output_dir=tmp_path,
+        # B is reached (FK from A) but absent from the map.
+        rid_sets={("demo", "A"): ["A1"]},
+    )
+    cb._validate_anchors = lambda: None
+    cb._compute_reached_tables()
+    assert ("demo", "B") in cb._reached_tables
+
+    with caplog.at_level("WARNING", logger="deriva.bag.catalog_builder"):
+        cb._build_export_spec()
+
+    assert any(
+        "no entry for reached table demo:B" in rec.message
+        for rec in caplog.records
+    ), [rec.message for rec in caplog.records]
+    # The present key (A) does NOT warn — only the missing one (B).
+    assert not any(
+        "no entry for reached table demo:A" in rec.message
+        for rec in caplog.records
+    )
+
+
 def test_terminal_table_blocks_inbound_but_follows_outbound(
     tmp_path: Path,
 ) -> None:

--- a/tests/deriva/bag/test_catalog_builder.py
+++ b/tests/deriva/bag/test_catalog_builder.py
@@ -745,6 +745,76 @@ def test_spec_multipath_emits_one_processor_per_fk_route(
     assert len(image_fetches) == 0
 
 
+def test_rid_set_spec_emits_one_csv_processor_per_table(
+    tmp_path: Path,
+) -> None:
+    """With rid_sets supplied, the export spec has ONE csv processor per
+    reached table carrying rid_table+rid_set, not one-per-FK-path.
+
+    Reuses the multi-path topology where ``Image`` is reachable via two
+    FK routes (Dataset → Dataset_Image → Image and the longer route
+    through Subject). Per-path emission would produce 2 csv processors
+    for Image; supplying ``rid_sets`` collapses it to one rid-set
+    processor.
+    """
+    ds = _make_mock_table("demo", "Dataset")
+    di = _make_mock_table("demo", "Dataset_Image")
+    ds_sub = _make_mock_table("demo", "Dataset_Subject")
+    sub = _make_mock_table("demo", "Subject")
+    si = _make_mock_table("demo", "Subject_Image")
+    img = _make_mock_table("demo", "Image")
+
+    di_to_ds = _fk_mock(src_table=di, pk_table=ds)
+    di_to_img = _fk_mock(src_table=di, pk_table=img)
+    dssub_to_ds = _fk_mock(src_table=ds_sub, pk_table=ds)
+    dssub_to_sub = _fk_mock(src_table=ds_sub, pk_table=sub)
+    si_to_sub = _fk_mock(src_table=si, pk_table=sub)
+    si_to_img = _fk_mock(src_table=si, pk_table=img)
+
+    ds.referenced_by = [di_to_ds, dssub_to_ds]
+    di.foreign_keys = [di_to_ds, di_to_img]
+    ds_sub.foreign_keys = [dssub_to_ds, dssub_to_sub]
+    sub.referenced_by = [dssub_to_sub, si_to_sub]
+    si.foreign_keys = [si_to_sub, si_to_img]
+    img.referenced_by = [di_to_img, si_to_img]
+
+    model = _make_mock_model(
+        {
+            "demo": {
+                "Dataset": ds,
+                "Dataset_Image": di,
+                "Dataset_Subject": ds_sub,
+                "Subject": sub,
+                "Subject_Image": si,
+                "Image": img,
+            }
+        }
+    )
+    catalog = _make_mock_catalog(model)
+    cb = CatalogBagBuilder(
+        catalog=catalog,
+        anchors=[RIDAnchor(table="Dataset", rids=["5HE"])],
+        output_dir=tmp_path,
+        rid_sets={("demo", "Image"): ["r1", "r2", "r3"]},
+    )
+    cb._validate_anchors = lambda: None
+    cb._compute_reached_tables()
+    spec = cb._build_export_spec()
+
+    csv_procs = [
+        p
+        for p in spec["catalog"]["query_processors"]
+        if p["processor"] == "csv"
+        and p["processor_params"].get("output_path", "") == "demo/Image"
+    ]
+    assert len(csv_procs) == 1  # ONE, not per-FK-path
+    params = csv_procs[0]["processor_params"]
+    assert params["rid_table"] == "demo:Image"
+    assert params["rid_set"] == ["r1", "r2", "r3"]
+    assert "query_path" not in params  # rid-set replaces query_path
+    assert params["output_path"] == "demo/Image"  # flat, one file per table
+
+
 def test_terminal_table_blocks_inbound_but_follows_outbound(
     tmp_path: Path,
 ) -> None:

--- a/tests/deriva/core/test_rid_set_fetch.py
+++ b/tests/deriva/core/test_rid_set_fetch.py
@@ -171,3 +171,60 @@ def test_catalog_query_forwards_rid_set_to_get_as_file():
         proc.catalogQuery()
     assert captured.get("rid_set") == ["r1"]
     assert captured.get("rid_table") == "S:T"
+
+
+def test_catalog_query_with_empty_query_but_rid_set_still_calls_get_as_file():
+    """Format-B processors carry NO query_path: ``self.query`` is empty but
+    ``self.rid_set`` is populated. ``catalogQuery`` must NOT short-circuit on
+    the empty query — it must proceed to ``get_as_file`` so the rid-set fetch
+    actually fires. (Pins FIX 2: the early-return guard only triggers when
+    there is NEITHER a query path NOR a rid_set.)"""
+    from unittest.mock import MagicMock, patch
+
+    proc = BaseQueryProcessor.__new__(BaseQueryProcessor)
+    proc.parameters = {"rid_set": ["r1"], "rid_table": "S:T"}
+    proc.envars = {}
+    proc.rid_set = proc.parameters.get("rid_set")
+    proc.rid_table = proc.parameters.get("rid_table")
+    proc.query = ""  # Format B: no query_path at all.
+    proc.output_abspath = "/tmp/ignored.csv"
+    proc.paged_query = False
+    proc.paged_query_size = 100000
+    proc.paged_query_sort_columns = ["RID"]
+    proc.HEADERS = {}
+    proc.callback = None
+    captured = {}
+    cat = MagicMock()
+
+    def fake_get_as_file(path, dest, **kwargs):
+        captured.update(kwargs)
+        return dest
+
+    cat.get_as_file.side_effect = fake_get_as_file
+    proc.catalog = cat
+    with patch(
+        "deriva.transfer.download.processors.query.base_query_processor.make_dirs"
+    ):
+        proc.catalogQuery()
+    # The guard did NOT return early: get_as_file ran with the rid_set.
+    cat.get_as_file.assert_called_once()
+    assert captured.get("rid_set") == ["r1"]
+    assert captured.get("rid_table") == "S:T"
+
+
+def test_catalog_query_returns_empty_when_no_query_and_no_rid_set():
+    """The early-return guard still fires when there is NEITHER a query path
+    NOR a rid_set — get_as_file must not be called in that case."""
+    from unittest.mock import MagicMock
+
+    proc = BaseQueryProcessor.__new__(BaseQueryProcessor)
+    proc.parameters = {}
+    proc.envars = {}
+    proc.rid_set = None
+    proc.rid_table = None
+    proc.query = ""
+    cat = MagicMock()
+    proc.catalog = cat
+
+    assert proc.catalogQuery() == {}
+    cat.get_as_file.assert_not_called()

--- a/tests/deriva/core/test_rid_set_fetch.py
+++ b/tests/deriva/core/test_rid_set_fetch.py
@@ -1,6 +1,88 @@
 """Tests for RID-set chunk-append fetch in get_as_file (no live catalog)."""
 
+import os
+import tempfile
+from unittest.mock import MagicMock
+
 from deriva.core.ermrest_catalog import ErmrestCatalog, RID_SET_CHUNK_SIZE
+
+
+class _FakeResponse:
+    """Minimal requests.Response stand-in for a CSV page."""
+
+    def __init__(self, text):
+        self._text = text
+        self.status_code = 200
+        self.headers = {"Content-Type": "text/csv"}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def close(self):
+        pass
+
+    def iter_lines(self, decode_unicode=False):
+        for line in self._text.splitlines():
+            yield line if decode_unicode else line.encode("utf-8")
+
+    @property
+    def text(self):
+        return self._text
+
+
+def _csv(header, rows):
+    return "\n".join([header] + rows) + "\n"
+
+
+def test_get_as_file_rid_set_appends_chunks_to_one_csv():
+    """Two RID chunks each return a CSV page; the result is ONE CSV with the
+    header once and all body rows, RID-distinct."""
+    header = "RID,Name"
+    pages = {
+        "/entity/S:T/RID=any(r1,r2)": _csv(header, ["r1,Alice", "r2,Bob"]),
+        "/entity/S:T/RID=any(r3)": _csv(header, ["r3,Carol"]),
+    }
+
+    cat = ErmrestCatalog.__new__(ErmrestCatalog)  # bypass __init__/network
+    cat._server_uri = "https://example.org/ermrest/catalog/1"
+
+    def fake_get(url, headers=None, stream=False):
+        if "@after" in url:
+            # Second page of any chunk: no more rows -> terminate the page loop.
+            return _FakeResponse(_csv(header, []))
+        for path, body in pages.items():
+            if path in url:
+                return _FakeResponse(body)
+        raise AssertionError("unexpected URL: %s" % url)
+
+    cat._session = MagicMock()
+    cat._session.get.side_effect = fake_get
+    cat._response_raise_for_status = lambda r: None
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        out = f.name
+    try:
+        # chunk size 2 -> 2 chunks: [r1,r2], [r3]. Patch the module constant
+        # so the test doesn't need 500+ RIDs.
+        import deriva.core.ermrest_catalog as ec
+        orig = ec.RID_SET_CHUNK_SIZE
+        ec.RID_SET_CHUNK_SIZE = 2
+        try:
+            cat.get_as_file(None, out, rid_set=["r1", "r2", "r3"], rid_table="S:T")
+        finally:
+            ec.RID_SET_CHUNK_SIZE = orig
+        with open(out, encoding="utf-8") as fh:
+            content = fh.read()
+        assert content.count("RID,Name") == 1            # header once
+        for rid in ("r1", "r2", "r3"):
+            assert rid in content                        # all rows present
+        nonblank = [ln for ln in content.splitlines() if ln.strip()]
+        assert len(nonblank) == 4                         # 1 header + 3 rows
+    finally:
+        os.unlink(out)
 
 
 def test_rid_set_chunks_splits_at_chunk_size():

--- a/tests/deriva/core/test_rid_set_fetch.py
+++ b/tests/deriva/core/test_rid_set_fetch.py
@@ -119,3 +119,55 @@ def test_rid_set_query_url_quotes_special_chars_in_rid():
     url = ErmrestCatalog._rid_set_query_url("S:T", ["a b", "c"])
     # space in the value is encoded; the comma separator is not.
     assert url == "/entity/S:T/RID=any(a%20b,c)"
+
+
+from deriva.transfer.download.processors.query.base_query_processor import (
+    BaseQueryProcessor,
+)
+
+
+def test_query_processor_reads_rid_set_from_params():
+    """rid_set/rid_table flow from processor_params onto the processor."""
+    proc = BaseQueryProcessor.__new__(BaseQueryProcessor)
+    proc.parameters = {
+        "query_path": "/entity/S:T",
+        "rid_set": ["r1", "r2"],
+        "rid_table": "S:T",
+    }
+    proc.rid_set = proc.parameters.get("rid_set", None)
+    proc.rid_table = proc.parameters.get("rid_table", None)
+    assert proc.rid_set == ["r1", "r2"]
+    assert proc.rid_table == "S:T"
+
+
+def test_catalog_query_forwards_rid_set_to_get_as_file():
+    """catalogQuery must pass rid_set/rid_table into get_as_file."""
+    from unittest.mock import MagicMock, patch
+
+    proc = BaseQueryProcessor.__new__(BaseQueryProcessor)
+    proc.parameters = {"rid_set": ["r1"], "rid_table": "S:T"}
+    proc.envars = {}
+    proc.rid_set = proc.parameters.get("rid_set")
+    proc.rid_table = proc.parameters.get("rid_table")
+    proc.query = "/entity/S:T"
+    proc.output_abspath = "/tmp/ignored.csv"
+    proc.paged_query = False
+    proc.paged_query_size = 100000
+    proc.paged_query_sort_columns = ["RID"]
+    proc.HEADERS = {}
+    proc.callback = None
+    captured = {}
+    cat = MagicMock()
+
+    def fake_get_as_file(path, dest, **kwargs):
+        captured.update(kwargs)
+        return dest
+
+    cat.get_as_file.side_effect = fake_get_as_file
+    proc.catalog = cat
+    with patch(
+        "deriva.transfer.download.processors.query.base_query_processor.make_dirs"
+    ):
+        proc.catalogQuery()
+    assert captured.get("rid_set") == ["r1"]
+    assert captured.get("rid_table") == "S:T"

--- a/tests/deriva/core/test_rid_set_fetch.py
+++ b/tests/deriva/core/test_rid_set_fetch.py
@@ -1,0 +1,21 @@
+"""Tests for RID-set chunk-append fetch in get_as_file (no live catalog)."""
+
+from deriva.core.ermrest_catalog import ErmrestCatalog, RID_SET_CHUNK_SIZE
+
+
+def test_rid_set_chunks_splits_at_chunk_size():
+    rids = [f"1-{i:04d}" for i in range(1250)]
+    chunks = list(ErmrestCatalog._rid_set_chunks(rids, 500))
+    assert len(chunks) == 3
+    assert [len(c) for c in chunks] == [500, 500, 250]
+    # No RID lost or duplicated across chunks.
+    flat = [r for c in chunks for r in c]
+    assert flat == rids
+
+
+def test_rid_set_chunks_empty():
+    assert list(ErmrestCatalog._rid_set_chunks([], 500)) == []
+
+
+def test_rid_set_chunk_size_default_is_500():
+    assert RID_SET_CHUNK_SIZE == 500

--- a/tests/deriva/core/test_rid_set_fetch.py
+++ b/tests/deriva/core/test_rid_set_fetch.py
@@ -19,3 +19,21 @@ def test_rid_set_chunks_empty():
 
 def test_rid_set_chunk_size_default_is_500():
     assert RID_SET_CHUNK_SIZE == 500
+
+
+def test_rid_set_query_url_quotes_each_rid_not_the_commas():
+    """Commas are any() SYNTAX separators, not values. Each RID is quoted
+    individually; the commas stay literal. Quoting the whole joined string
+    (%2C) would break the predicate and silently return zero rows."""
+    url = ErmrestCatalog._rid_set_query_url("eye-ai:Image", ["1-ABC", "1-DEF"])
+    assert url == "/entity/eye-ai:Image/RID=any(1-ABC,1-DEF)"
+    # The separating commas must be literal, never percent-encoded.
+    assert "%2C" not in url
+
+
+def test_rid_set_query_url_quotes_special_chars_in_rid():
+    """A RID value containing a reserved char IS quoted (the value, not the
+    comma)."""
+    url = ErmrestCatalog._rid_set_query_url("S:T", ["a b", "c"])
+    # space in the value is encoded; the comma separator is not.
+    assert url == "/entity/S:T/RID=any(a%20b,c)"

--- a/tests/deriva/core/test_rid_set_integration.py
+++ b/tests/deriva/core/test_rid_set_integration.py
@@ -1,0 +1,177 @@
+"""End-to-end Format-B rid-set integration test (no live catalog).
+
+The unit tests in ``test_rid_set_fetch.py`` prove each link in the chain in
+isolation: chunking, per-RID URL quoting, the chunk-append in ``get_as_file``,
+and the processor's forwarding of ``rid_set``/``rid_table`` into
+``get_as_file`` (with ``get_as_file`` itself mocked). None of them drive the
+*whole* chain — spec -> processor -> the REAL ``get_as_file`` -> a CSV file on
+disk. That gap is exactly why FIX 2 (the ``catalogQuery`` short-circuit that
+returned early for a query-less rid-set processor) survived five tasks.
+
+This test closes the gap. It builds a ``CSVQueryProcessor`` configured the way
+``CatalogBagBuilder`` emits a Format-B processor — ``rid_set`` in
+``processor_params``, NO ``query_path`` — backed by a real ``ErmrestCatalog``
+whose only mock is ``_session.get`` (serving CSV pages per RID-chunk URL). It
+then calls ``proc.catalogQuery()`` and asserts a real, chunk-appended CSV is on
+disk. Because the catalog's ``get_as_file`` is the genuine
+``ErmrestCatalog.get_as_file`` (not a ``MagicMock``), the full
+processor -> ``catalogQuery`` (FIX 2 guard) -> ``get_as_file`` ->
+``_get_rid_set_as_file`` -> ``_fetch_paged_csv`` path executes and writes
+correct bytes.
+"""
+
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from deriva.core.ermrest_catalog import ErmrestCatalog
+import deriva.core.ermrest_catalog as ec
+from deriva.transfer.download.processors.query.base_query_processor import (
+    BaseQueryProcessor,
+    CSVQueryProcessor,
+)
+
+# Reuse the CSV-page fake helpers that already drive the get_as_file unit test.
+from tests.deriva.core.test_rid_set_fetch import _FakeResponse, _csv
+
+
+def _make_catalog_serving(pages, header):
+    """Build a real ``ErmrestCatalog`` whose ``_session.get`` serves CSV pages.
+
+    The catalog is constructed via ``__new__`` to bypass ``__init__``/network,
+    then its ``_session.get`` is given the ``@after``-terminating fake from
+    ``test_rid_set_fetch.py``: a request whose URL contains ``@after`` returns
+    an empty CSV page (ending that chunk's cursor loop); otherwise the page body
+    keyed by the matching RID-chunk path is returned. Everything else on the
+    catalog — including ``get_as_file`` and its rid-set chunk-append helpers — is
+    the genuine class implementation.
+
+    Args:
+        pages: Mapping of RID-chunk path (e.g. ``/entity/S:T/RID=any(r1,r2)``)
+            to the CSV body that chunk should return.
+        header: The shared CSV header line (e.g. ``"RID,Name"``).
+
+    Returns:
+        A real ``ErmrestCatalog`` instance ready for ``get_as_file``.
+    """
+    cat = ErmrestCatalog.__new__(ErmrestCatalog)  # bypass __init__/network
+    cat._server_uri = "https://example.org/ermrest/catalog/1"
+
+    def fake_get(url, headers=None, stream=False):
+        if "@after" in url:
+            # Second page of any chunk: no more rows -> terminate the page loop.
+            return _FakeResponse(_csv(header, []))
+        for path, body in pages.items():
+            if path in url:
+                return _FakeResponse(body)
+        raise AssertionError("unexpected URL: %s" % url)
+
+    cat._session = MagicMock()
+    cat._session.get.side_effect = fake_get
+    cat._response_raise_for_status = lambda r: None
+    return cat
+
+
+def _make_format_b_processor(catalog, rid_set, rid_table, output_abspath):
+    """Hand-build a ``BaseQueryProcessor`` shaped like a Format-B emission.
+
+    Mirrors how ``CatalogBagBuilder`` configures the processor: ``rid_set`` and
+    ``rid_table`` come from ``processor_params``, and there is NO ``query_path``
+    (``self.query`` is empty). Built via ``__new__`` + manual attribute setup
+    — the same pattern the forwarding unit test uses — so we exercise
+    ``catalogQuery`` without ``CSVQueryProcessor.__init__``'s path-creation
+    machinery, while still pointing ``self.catalog`` at the REAL catalog so the
+    genuine ``get_as_file`` runs.
+
+    Args:
+        catalog: The real ``ErmrestCatalog`` whose ``get_as_file`` will run.
+        rid_set: The RIDs the processor should fetch.
+        rid_table: ``"schema:table"`` the RIDs belong to.
+        output_abspath: Real on-disk path the CSV is written to.
+
+    Returns:
+        A ready-to-run ``BaseQueryProcessor``.
+    """
+    proc = BaseQueryProcessor.__new__(BaseQueryProcessor)
+    proc.parameters = {"rid_set": rid_set, "rid_table": rid_table}
+    proc.envars = {}
+    proc.rid_set = proc.parameters.get("rid_set")
+    proc.rid_table = proc.parameters.get("rid_table")
+    proc.query = ""  # Format B: no query_path at all.
+    proc.output_abspath = output_abspath
+    proc.paged_query = False
+    proc.paged_query_size = 100000
+    proc.paged_query_sort_columns = ["RID"]
+    proc.HEADERS = {}
+    proc.callback = None
+    proc.catalog = catalog
+    # __init__ sets ``sessions`` (used by __del__); the __new__ build skips it,
+    # so set it here to keep teardown clean.
+    proc.sessions = {}
+    return proc
+
+
+def test_format_b_processor_writes_one_clean_csv_end_to_end():
+    """spec(rid_set) -> processor -> REAL get_as_file -> ONE clean CSV on disk.
+
+    Drives the full Format-B chain end-to-end with only ``_session.get`` mocked:
+
+    1. ``proc.catalogQuery()`` runs (FIX 2: the empty-query guard does NOT
+       short-circuit because ``self.rid_set`` is populated).
+    2. It calls the REAL ``ErmrestCatalog.get_as_file`` with the rid_set, which
+       chunk-appends across 2 chunks (3 RIDs, ``RID_SET_CHUNK_SIZE`` patched to
+       2) into one CSV.
+    3. The resulting file has the header exactly once and all three rows.
+
+    This is the test that would have caught FIX 2: ``get_as_file`` is the
+    genuine implementation, so a real CSV is produced — not a captured-kwargs
+    mock.
+    """
+    header = "RID,Name"
+    pages = {
+        "/entity/S:T/RID=any(r1,r2)": _csv(header, ["r1,Alice", "r2,Bob"]),
+        "/entity/S:T/RID=any(r3)": _csv(header, ["r3,Carol"]),
+    }
+    catalog = _make_catalog_serving(pages, header)
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        out = f.name
+    try:
+        proc = _make_format_b_processor(
+            catalog, ["r1", "r2", "r3"], "S:T", out
+        )
+
+        # Sanity-check the wiring: the processor calls the genuine bound method,
+        # NOT a MagicMock. (A mocked get_as_file would write nothing.)
+        assert proc.catalog.get_as_file.__func__ is ErmrestCatalog.get_as_file
+
+        # chunk size 2 -> 2 chunks: [r1,r2], [r3]. Patch the module constant so
+        # the chain spans multiple chunks without needing 500+ RIDs, proving the
+        # multi-chunk append fires through the processor path.
+        orig = ec.RID_SET_CHUNK_SIZE
+        ec.RID_SET_CHUNK_SIZE = 2
+        # Patch make_dirs (as the forwarding unit test does) so catalogQuery's
+        # mkdir-for-output-dir is a no-op for the temp file.
+        try:
+            with patch(
+                "deriva.transfer.download.processors.query."
+                "base_query_processor.make_dirs"
+            ):
+                proc.catalogQuery()
+        finally:
+            ec.RID_SET_CHUNK_SIZE = orig
+
+        # The REAL get_as_file wrote a real file: header once + all 3 rows.
+        assert os.path.exists(out)
+        with open(out, encoding="utf-8") as fh:
+            content = fh.read()
+        assert content.count("RID,Name") == 1  # header exactly once
+        for rid in ("r1", "r2", "r3"):
+            assert rid in content  # every chunk's row landed
+        nonblank = [ln for ln in content.splitlines() if ln.strip()]
+        assert len(nonblank) == 4  # 1 header + 3 rows, chunk-appended
+        # The mocked session was actually exercised (chain ran, not skipped).
+        assert catalog._session.get.called
+    finally:
+        if os.path.exists(out):
+            os.unlink(out)


### PR DESCRIPTION
## Summary
Adds RID-set fetch to the bag export engine so a large explicit RID set is fetched as ONE logical query producing ONE clean CSV per table — eliminating the deep-FK-join cost and the per-path CSV fragmentation.

## What changed
- **`ErmrestCatalog.get_as_file(rid_set=, rid_table=)`** — when `rid_set` is given, chunks the RIDs into URL-safe batches (~500), fetches `/entity/{rid_table}/RID=any(...)` per chunk (each RID individually URL-quoted — the commas are `any()` syntax, not values), and appends every chunk to one CSV by reusing the existing per-page header-skip append loop (extracted to `_fetch_paged_csv`). Solves the URL-length 414 a single large `RID=any(...)` would hit.
- **`CSVQueryProcessor`** forwards `rid_set`/`rid_table` from `processor_params` to `get_as_file`; the `catalogQuery` guard now proceeds for a query-less rid-set processor.
- **`CatalogBagBuilder(rid_sets=...)`** emits ONE rid-set csv processor per reached NON-VOCAB table (flat `output_path`, RID set inline) instead of one-per-FK-path. Vocab tables keep the full/per-path query so FK references resolve. A missing rid_sets key logs a warning (incomplete-map guard).

## Additive & safe
- All new behavior is opt-in: `rid_set=None` / `rid_sets=None` (the defaults) keep current behavior exactly. Existing `query_path` csv processors — including Chaise's annotation-driven exports — are unaffected (verified: the `get_as_file` signature change can't even raise on them).
- The per-RID-quoting gotcha (quoting the joined string → `%2C` → silently zero rows) is isolated in `_rid_set_query_url` and pinned by a test.
- The `get_as_file` paged-loop extraction was proven behavior-preserving (full `test_csv_paging.py` + bag suite green before any rid_set code was added).

## Consumer
This is the deriva-py half (Stage B1) of the fast-portable-bag effort. deriva-ml's client-side reachability engine (deriva-ml PR #300) computes the per-table RID sets; a follow-up deriva-ml PR (Stage B2) bumps the pin and wires `DatasetBagBuilder` → `compute_reachability` → this rid_sets spec.

## Tests
New `tests/deriva/core/test_rid_set_fetch.py` (chunking, per-RID-quoting, chunk-append, processor forwarding) + `test_rid_set_integration.py` (end-to-end: processor → get_as_file → one clean CSV on disk) + `test_catalog_builder.py` rid-set emission + vocab-exclusion + missing-key-warning tests. Full bag + core suites green.

## Note for reviewers
deriva-py has no linter/CI configured and Python 3.13 needs `setuptools` installed to import `deriva.transfer` (distutils removed in 3.13) — consider adding `setuptools` to a test/dev dependency group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)