### PR TITLE
fix(ermrest): default Accept to text/csv in get_as_file rid_set path

### DIFF
--- a/deriva/core/ermrest_catalog.py
+++ b/deriva/core/ermrest_catalog.py
@@ -865,8 +865,17 @@ class ErmrestCatalog(DerivaBinding):
         if rid_set is not None:
             if not rid_table:
                 raise ValueError("rid_table is required when rid_set is provided")
+            # The rid-set path is CSV-only by construction (the RID=any(...)
+            # entity query and the chunk-append/emptiness logic all assume
+            # text/csv). This dispatch runs BEFORE the accept-resolution the
+            # normal paged path does below, so default the Accept header to
+            # text/csv here — otherwise a caller without an explicit accept
+            # gets the server's JSON default, the CSV write-branch is skipped,
+            # and the result is silently empty.
+            rid_set_headers = dict(headers or {})
+            rid_set_headers.setdefault("accept", "text/csv")
             return self._get_rid_set_as_file(
-                rid_set, rid_table, destfilename, headers=headers,
+                rid_set, rid_table, destfilename, headers=rid_set_headers,
                 callback=callback, delete_if_empty=delete_if_empty,
                 page_size=page_size, page_sort_columns=page_sort_columns,
             )

--- a/tests/deriva/core/test_rid_set_fetch.py
+++ b/tests/deriva/core/test_rid_set_fetch.py
@@ -37,6 +37,71 @@ def _csv(header, rows):
     return "\n".join([header] + rows) + "\n"
 
 
+class _AcceptAwareResponse(_FakeResponse):
+    """Fake response that models the server's content-negotiation: it returns
+    CSV only when the request asked for ``Accept: text/csv``; otherwise it
+    returns JSON (the server's default). This reproduces the real server's
+    behavior that the plain ``_FakeResponse`` (hard-coded CSV) masks.
+    """
+
+    def __init__(self, csv_text, accept):
+        if accept == "text/csv":
+            super().__init__(csv_text)
+            self.headers = {"Content-Type": "text/csv"}
+        else:
+            # Server defaults to JSON when no/other Accept is sent.
+            super().__init__("[]")
+            self.headers = {"Content-Type": "application/json"}
+
+
+def test_get_as_file_rid_set_defaults_accept_to_csv():
+    """REGRESSION: the rid-set path must request ``Accept: text/csv`` even when
+    the caller passes no explicit accept header. Otherwise the server returns
+    JSON, the CSV write-branch is skipped, and the result is silently empty.
+
+    The bug: the ``if rid_set is not None:`` dispatch in ``get_as_file`` runs
+    BEFORE the accept-resolution logic the normal paged path uses, so the
+    rid-set path never defaulted the Accept header.
+    """
+    header = "RID,Name"
+    csv_body = _csv(header, ["r1,Alice", "r2,Bob"])
+
+    cat = ErmrestCatalog.__new__(ErmrestCatalog)
+    cat._server_uri = "https://example.org/ermrest/catalog/1"
+
+    seen_accepts = []
+
+    def fake_get(url, headers=None, stream=False):
+        accept = (headers or {}).get("accept")
+        seen_accepts.append(accept)
+        if "@after" in url:
+            return _AcceptAwareResponse(_csv(header, []), accept)
+        return _AcceptAwareResponse(csv_body, accept)
+
+    cat._session = MagicMock()
+    cat._session.get.side_effect = fake_get
+    cat._response_raise_for_status = lambda r: None
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        out = f.name
+    try:
+        # Call WITHOUT an explicit accept header (the bug-triggering path).
+        cat.get_as_file(None, out, rid_set=["r1", "r2"], rid_table="S:T")
+        # The fetch must have requested text/csv (the fix), so rows are written.
+        assert all(a == "text/csv" for a in seen_accepts), (
+            "rid-set fetch sent Accept=%r; expected text/csv on every request" % seen_accepts
+        )
+        with open(out, encoding="utf-8") as fh:
+            content = fh.read()
+        assert "r1,Alice" in content and "r2,Bob" in content, (
+            "rid-set fetch produced no rows (server returned JSON because Accept "
+            "was not text/csv): %r" % content
+        )
+    finally:
+        if os.path.exists(out):
+            os.unlink(out)
+
+
 def test_get_as_file_rid_set_appends_chunks_to_one_csv():
     """Two RID chunks each return a CSV page; the result is ONE CSV with the
     header once and all body rows, RID-distinct."""


### PR DESCRIPTION
## The bug

`get_as_file(rid_set=...)` **silently returns 0 rows** (and deletes the output file) when the caller does not pass an explicit `Accept: text/csv` header.

Root cause: the `if rid_set is not None:` dispatch in `get_as_file` runs **before** the accept-resolution logic the normal paged path uses (`accept = headers.get("accept")` + the fallback that follows). So the rid-set path never defaulted the Accept header. With no Accept sent, the server returns its JSON default; `_fetch_paged_csv`'s write-branch is gated on `content_type == "text/csv"`, so it's skipped — **no rows written, no error.**

## Impact

- **The bag export path was unaffected** — `CSVQueryProcessor.process()` always calls `catalogQuery(headers={'accept': 'text/csv'})`, so production Format-B bags got their data.
- **Any direct `get_as_file(rid_set=...)` caller without an explicit accept** hit the silent-empty bug. This also invalidated isolated rid-set benchmarks (they were silently fetching+discarding JSON), which masked a real performance investigation.

## The fix

Default the Accept header to `text/csv` in the rid-set dispatch — the rid-set path is CSV-only by construction (the `RID=any(...)` entity query, the chunk-append, and the `delete_if_empty` `csv.reader` check all assume CSV). One localized change; the normal path is untouched.

## Test

The prior `_FakeResponse` hard-coded `Content-Type: text/csv` regardless of the request, which is why the B1 unit tests passed despite this bug. The new regression test (`test_get_as_file_rid_set_defaults_accept_to_csv`) models the server's **content-negotiation** — CSV only when `text/csv` is requested — so it genuinely exercises the bug. It fails on the unfixed code (`Accept=[None]`) and passes after.

Verified live: `get_as_file(rid_set=1000, no accept)` → 1000 rows (was 0). Full bag + core suites green (347 passed / 3 skipped).

Found via systematic debugging of the Format-B bag-gen perf investigation ([deriva-py#270](https://github.com/informatics-isi-edu/deriva-py/issues/270)). Consumer: [deriva-ml#301](https://github.com/informatics-isi-edu/deriva-ml/pull/301).

🤖 Generated with [Claude Code](https://claude.com/claude-code)