### PR TITLE
fix(ermrest): thread CSV header across rid-set chunks — fixes O(n²) bag fetch (#270)

### DIFF
--- a/deriva/core/ermrest_catalog.py
+++ b/deriva/core/ermrest_catalog.py
@@ -644,7 +644,8 @@ class ErmrestCatalog(DerivaBinding):
             return last_record
 
     def _fetch_paged_csv(self, destfile, base_path, headers, callback,
-                         page_size, page_sort_columns, first_page):
+                         page_size, page_sort_columns, first_page,
+                         csv_header=None):
         """Page through ``base_path`` and append rows to an open ``destfile``.
 
         This is the paged-fetch loop extracted verbatim from
@@ -676,13 +677,24 @@ class ErmrestCatalog(DerivaBinding):
             first_page: Whether the next page processed is the first one (i.e.
                 whether to emit the CSV header).
 
+            csv_header: The CSV header row (list of column names) from a prior
+                call, threaded across chunked calls. Used as the ``fieldnames``
+                for :meth:`_read_last_csv_record` on pages that do not re-read
+                the header (every page after the first chunk). Without it, the
+                reverse-read cannot identify a record near EOF and scans back
+                through the entire accumulated file each call -> O(n^2).
+
         Returns:
-            A ``(first_page, total)`` tuple where ``first_page`` is the updated
-            flag (``False`` once any page has been processed) and ``total`` is
-            the number of bytes written by this call.
+            A ``(first_page, total, csv_header)`` tuple: ``first_page`` is the
+            updated flag (``False`` once any page has been processed),
+            ``total`` is the bytes written by this call, and ``csv_header`` is
+            the CSV header (captured here on the first page, or the threaded
+            value passed in) for the caller to thread into subsequent calls.
         """
         total = 0
-        first_line = None
+        # Seed first_line from the threaded header so _read_last_csv_record gets
+        # correct fieldnames even on chunks that don't re-read the header.
+        first_line = csv_header
         last_record = None
         usr = urlsplit(self._server_uri + base_path)
         path = str(usr.path.split('@sort')[0])
@@ -707,7 +719,7 @@ class ErmrestCatalog(DerivaBinding):
                     if callback:
                         if not callback(progress="Retrying query: %s" % url):
                             destfile.close()
-                            return first_page, total
+                            return first_page, total, first_line
                     continue
                 else:
                     self._response_raise_for_status(r)
@@ -773,9 +785,9 @@ class ErmrestCatalog(DerivaBinding):
                     if not callback(progress="Downloading: %.2f MB transferred" %
                                              (float(total) / float(Megabyte))):
                         destfile.close()
-                        return first_page, total
+                        return first_page, total, first_line
 
-        return first_page, total
+        return first_page, total, first_line
 
     def _get_rid_set_as_file(self, rid_set, rid_table, destfilename, *, headers,
                              callback, delete_if_empty, page_size, page_sort_columns):
@@ -809,11 +821,18 @@ class ErmrestCatalog(DerivaBinding):
         try:
             first_page = True
             total = 0
+            csv_header = None
             for chunk in self._rid_set_chunks(rid_set, RID_SET_CHUNK_SIZE):
                 base_path = self._rid_set_query_url(rid_table, chunk)
-                first_page, written = self._fetch_paged_csv(
+                # Thread csv_header across chunks: the header is captured on the
+                # first chunk's first page and reused on every later chunk so
+                # _read_last_csv_record always has correct fieldnames. Without
+                # it, later chunks pass fieldnames=None and the reverse-read
+                # scans the whole accumulated file each time -> O(n^2).
+                first_page, written, csv_header = self._fetch_paged_csv(
                     destfile, base_path, headers, callback,
                     page_size, page_sort_columns, first_page,
+                    csv_header=csv_header,
                 )
                 total += written
             destfile.flush()
@@ -925,7 +944,7 @@ class ErmrestCatalog(DerivaBinding):
                 # here preserves the delete-if-empty epilogue's behavior, which
                 # inspects ``content_type``.
                 content_type = accept
-                _first_page, total = self._fetch_paged_csv(
+                _first_page, total, _csv_header = self._fetch_paged_csv(
                     destfile, path, headers, callback,
                     page_size, page_sort_columns, True,
                 )

--- a/tests/deriva/core/test_rid_set_fetch.py
+++ b/tests/deriva/core/test_rid_set_fetch.py
@@ -54,6 +54,79 @@ class _AcceptAwareResponse(_FakeResponse):
             self.headers = {"Content-Type": "application/json"}
 
 
+def test_rid_set_read_last_record_gets_header_on_every_chunk():
+    """REGRESSION (O(n^2) bug): ``_read_last_csv_record`` must receive the CSV
+    header (fieldnames) on EVERY chunk, not just the first.
+
+    Bug: ``_fetch_paged_csv`` captured the header only when ``first_page`` was
+    True. In the rid-set chunk-append, only the first chunk is the first page;
+    every later chunk passed ``fieldnames=None`` to ``_read_last_csv_record``,
+    which then could not identify a record near EOF and scanned back through
+    the ENTIRE accumulated file each call -> O(n^2). With the header threaded,
+    the reverse-read finds a valid record in the first window (bounded, O(1)).
+    """
+    import deriva.core.ermrest_catalog as ec
+
+    header = "RID,Name,Notes"
+    # Three chunks, each returning a multi-row page (so last-record extraction
+    # actually runs — it only runs when last_line != first_line).
+    pages = {
+        "/entity/S:T/RID=any(a1,a2)": _csv(header, ["a1,A,x", "a2,B,y"]),
+        "/entity/S:T/RID=any(a3,a4)": _csv(header, ["a3,C,z", "a4,D,w"]),
+        "/entity/S:T/RID=any(a5,a6)": _csv(header, ["a5,E,v", "a6,F,u"]),
+    }
+
+    cat = ErmrestCatalog.__new__(ErmrestCatalog)
+    cat._server_uri = "https://example.org/ermrest/catalog/1"
+
+    def fake_get(url, headers=None, stream=False):
+        if "@after" in url:
+            return _FakeResponse(_csv(header, []))
+        for path, body in pages.items():
+            if path in url:
+                return _FakeResponse(body)
+        raise AssertionError("unexpected URL: %s" % url)
+
+    cat._session = MagicMock()
+    cat._session.get.side_effect = fake_get
+    cat._response_raise_for_status = lambda r: None
+
+    # Capture the fieldnames passed to _read_last_csv_record on every call.
+    seen_fieldnames = []
+    orig_rlcr = ec.ErmrestCatalog._read_last_csv_record
+
+    def spy_rlcr(filepath, fieldnames):
+        seen_fieldnames.append(fieldnames)
+        return orig_rlcr(filepath, fieldnames)
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        out = f.name
+    orig_chunk = ec.RID_SET_CHUNK_SIZE
+    ec.ErmrestCatalog._read_last_csv_record = staticmethod(spy_rlcr)
+    ec.RID_SET_CHUNK_SIZE = 2  # 6 RIDs -> 3 chunks
+    try:
+        cat.get_as_file(
+            None, out, rid_set=["a1", "a2", "a3", "a4", "a5", "a6"],
+            rid_table="S:T", headers={"accept": "text/csv"},
+        )
+        # Every _read_last_csv_record call must have received the real header,
+        # never None (None forces the O(n^2) full-file scan).
+        assert seen_fieldnames, "expected _read_last_csv_record to be called"
+        assert all(fn is not None for fn in seen_fieldnames), (
+            "_read_last_csv_record was called with fieldnames=None on some "
+            "chunk (the O(n^2) bug): %r" % seen_fieldnames
+        )
+        # And the threaded header is the real one.
+        assert all(fn == header.split(",") for fn in seen_fieldnames), (
+            "fieldnames threaded incorrectly: %r" % seen_fieldnames
+        )
+    finally:
+        ec.ErmrestCatalog._read_last_csv_record = staticmethod(orig_rlcr)
+        ec.RID_SET_CHUNK_SIZE = orig_chunk
+        if os.path.exists(out):
+            os.unlink(out)
+
+
 def test_get_as_file_rid_set_defaults_accept_to_csv():
     """REGRESSION: the rid-set path must request ``Accept: text/csv`` even when
     the caller passes no explicit accept header. Otherwise the server returns


### PR DESCRIPTION
## The bug (the root cause of [#270](https://github.com/informatics-isi-edu/deriva-py/issues/270))

`get_as_file(rid_set=...)` was **O(n²)** in the number of chunks, making large-table bag fetches extremely slow.

`_fetch_paged_csv` captures the CSV header (`first_line`, used as `fieldnames` for `_read_last_csv_record`'s `@after`-cursor extraction) **only when `first_page=True`**. In the rid-set chunk-append, only the *first* chunk is the first page; every later chunk passed `fieldnames=None`. With no fieldnames, `csv.DictReader` treats a mid-file reverse-read window's first row as the header, never finds a valid record near EOF, and the reverse-read loop scans back through the **entire accumulated file** every call.

## Evidence (eye-ai Dataset_Image, 107k RIDs)

Found via systematic debugging with per-call instrumentation:
- A single `_read_last_csv_record` on a 3.96 MB file read **34.7 MB** (16 reverse-read iterations).
- 40 chunks read **492 MB total** to extract 40 last-records from a 4 MB file.
- Per-chunk time grew 2 ms → 368 ms, tracking file size — the O(n²) signature.
- This dominated Dataset_Image's fetch (~534 s of a ~1120 s build).

## The fix

Thread the header across chunked `_fetch_paged_csv` calls: add a `csv_header` param (seeds `first_line`) and return it in the tuple; `_get_rid_set_as_file` captures it from the first chunk and passes it to every later chunk. `_read_last_csv_record` then always gets correct `fieldnames` → finds a valid record in the first 256 KB window (one iteration, bounded) → **O(n)**.

## Verified

- **Per-call read now flat at 256 KB** regardless of file size (was up to 34.7 MB); 30k-row fetch reads **15 MB total** vs 492 MB.
- **Live 2-277G `build_bag`: ~1120 s → 325 s (3.4×)** — recovers the regression vs the ~280 s deep-join baseline, while keeping the Format-B portability win (64 CSVs, one per table).
- Behavior unchanged (same last-record/cursor; the normal paged path unpacks the new 3-tuple and discards the header). Full bag + core suites green (348 passed / 3 skipped).
- Regression test (`test_rid_set_read_last_record_gets_header_on_every_chunk`) asserts every chunk's `_read_last_csv_record` receives the real header, not `None` — fails on the unfixed code (`[header, None, None]`), passes after.

Stacked on the Accept-header fix ([#271](https://github.com/informatics-isi-edu/deriva-py/pull/271), merged). Consumer: deriva-ml Format-B bags ([deriva-ml#301](https://github.com/informatics-isi-edu/deriva-ml/pull/301)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)