### PR TITLE
fix(bag): scope the asset fetch processor to the reachable RID set

### DIFF
--- a/deriva/bag/catalog_builder.py
+++ b/deriva/bag/catalog_builder.py
@@ -48,7 +48,8 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from deriva.core import ErmrestCatalog
+from deriva.core import ErmrestCatalog, urlquote
+from deriva.core.ermrest_catalog import RID_SET_CHUNK_SIZE
 from deriva.core.ermrest_model import Table as DerivaTable
 
 from deriva.bag.anchors import (
@@ -649,26 +650,59 @@ class CatalogBagBuilder:
                 # The engine's ``fetch`` processor reads URL/length/
                 # filename/md5 columns from each asset row and
                 # downloads the bytes to the templated output_path.
-                # One fetch processor per table is enough — assets
-                # are addressed by RID at the destination so the
-                # rows the multi-path CSVs landed already carry
-                # everything ``fetch`` needs.
-                query_processors.append(
-                    {
-                        "processor": "fetch",
-                        "processor_params": {
-                            "query_path": (
-                                f"/attribute/{schema_name}:{table_name}"
-                                f"/url:=URL,length:=Length,"
-                                f"filename:=Filename,md5:=MD5,"
-                                f"asset_rid:=RID"
-                            ),
-                            "output_path": (
-                                f"asset/{{asset_rid}}/{table_name}"
-                            ),
-                        },
-                    }
+                #
+                # The fetch query MUST be scoped to the reachable RID set,
+                # exactly like the csv processor above — otherwise the bag
+                # fetches the bytes of EVERY row in the asset table, not just
+                # the rows reachable from the dataset (a multi-x
+                # over-download on large catalogs). The projection
+                # (url/length/filename/md5/asset_rid) is preserved; only a
+                # ``RID=any(...)`` filter is inserted.
+                #
+                # ``RID=any(...)`` URLs are length-capped, so a large rid set
+                # is split into ``RID_SET_CHUNK_SIZE`` batches — one fetch
+                # processor per chunk. The fetch processors all append to the
+                # same remote-file manifest, so the union across chunks is the
+                # full (scoped) asset set. When no rid set is available
+                # (rid_sets is None), fall back to the unscoped full-table
+                # query — the historical behaviour for non-rid-set callers.
+                projection = (
+                    "url:=URL,length:=Length,filename:=Filename,md5:=MD5,asset_rid:=RID"
                 )
+                output_path = f"asset/{{asset_rid}}/{table_name}"
+                rid_set = None if self.rid_sets is None else self.rid_sets.get(key, [])
+                if rid_set is None:
+                    # No rid-set scoping requested: full-table fetch (legacy).
+                    query_processors.append(
+                        {
+                            "processor": "fetch",
+                            "processor_params": {
+                                "query_path": (
+                                    f"/attribute/{schema_name}:{table_name}/{projection}"
+                                ),
+                                "output_path": output_path,
+                            },
+                        }
+                    )
+                else:
+                    # RID-scoped fetch, chunked to stay under URL-length caps.
+                    # Each RID value is URL-quoted individually; the commas are
+                    # ``any()`` syntax and stay literal (quoting the joined
+                    # string would encode commas and silently return no rows).
+                    for chunk in ErmrestCatalog._rid_set_chunks(rid_set, RID_SET_CHUNK_SIZE):
+                        joined = ",".join(urlquote(str(rid)) for rid in chunk)
+                        query_processors.append(
+                            {
+                                "processor": "fetch",
+                                "processor_params": {
+                                    "query_path": (
+                                        f"/attribute/{schema_name}:{table_name}"
+                                        f"/RID=any({joined})/{projection}"
+                                    ),
+                                    "output_path": output_path,
+                                },
+                            }
+                        )
 
         spec: dict[str, Any] = {
             "bag": {

--- a/tests/deriva/bag/test_catalog_builder.py
+++ b/tests/deriva/bag/test_catalog_builder.py
@@ -815,6 +815,95 @@ def test_rid_set_spec_emits_one_csv_processor_per_table(
     assert params["output_path"] == "demo/Image"  # flat, one file per table
 
 
+def test_rid_set_scopes_asset_fetch_processor(tmp_path: Path) -> None:
+    """With rid_sets supplied, an asset table's ``fetch`` processor is
+    RID-scoped — its query_path filters to the rid_set via ``RID=any(...)``,
+    not a bare full-table ``/attribute/{schema}:{table}/...`` scan.
+
+    Regression: previously the csv processor was rid_set-scoped but the
+    fetch processor (which drives fetch.txt / the actual byte download)
+    queried the whole asset table, so a bag downloaded every asset in the
+    table regardless of dataset membership.
+    """
+    img = _make_mock_table("demo", "Image", is_asset=True)
+    model = _make_mock_model({"demo": {"Image": img}})
+    catalog = _make_mock_catalog(model)
+    cb = CatalogBagBuilder(
+        catalog=catalog,
+        anchors=[RIDAnchor(table="Image", rids=["r1", "r2", "r3"])],
+        output_dir=tmp_path,
+        rid_sets={("demo", "Image"): ["r1", "r2", "r3"]},
+    )
+    cb._validate_anchors = lambda: None
+    cb._compute_reached_tables()
+    spec = cb._build_export_spec()
+
+    fetch_procs = [
+        p
+        for p in spec["catalog"]["query_processors"]
+        if p["processor"] == "fetch"
+    ]
+    assert fetch_procs, "asset table must still get a fetch processor"
+    for p in fetch_procs:
+        qpath = p["processor_params"]["query_path"]
+        # Scoped: filters to the rid_set, keeping the asset-column projection.
+        assert "RID=any(" in qpath, (
+            f"fetch processor is not RID-scoped (full-table scan): {qpath!r}"
+        )
+        # The projection (url/length/filename/md5/asset_rid aliases) survives.
+        assert "url:=URL" in qpath and "asset_rid:=RID" in qpath, qpath
+
+    # The union of all fetch chunks' RIDs equals the rid_set exactly.
+    import re
+
+    fetched_rids: set[str] = set()
+    for p in fetch_procs:
+        m = re.search(r"RID=any\(([^)]*)\)", p["processor_params"]["query_path"])
+        assert m, p["processor_params"]["query_path"]
+        fetched_rids |= {r for r in m.group(1).split(",") if r}
+    assert fetched_rids == {"r1", "r2", "r3"}
+
+
+def test_rid_set_chunks_large_asset_fetch(tmp_path: Path) -> None:
+    """An asset rid_set larger than RID_SET_CHUNK_SIZE is split across
+    multiple fetch processors so no single query_path URL grows unbounded
+    (the same URL-length cap get_as_file chunks for)."""
+    from deriva.core.ermrest_catalog import RID_SET_CHUNK_SIZE
+
+    img = _make_mock_table("demo", "Image", is_asset=True)
+    model = _make_mock_model({"demo": {"Image": img}})
+    catalog = _make_mock_catalog(model)
+    big = [f"r{i}" for i in range(RID_SET_CHUNK_SIZE + 50)]
+    cb = CatalogBagBuilder(
+        catalog=catalog,
+        anchors=[RIDAnchor(table="Image", rids=big)],
+        output_dir=tmp_path,
+        rid_sets={("demo", "Image"): big},
+    )
+    cb._validate_anchors = lambda: None
+    cb._compute_reached_tables()
+    spec = cb._build_export_spec()
+
+    fetch_procs = [
+        p
+        for p in spec["catalog"]["query_processors"]
+        if p["processor"] == "fetch"
+    ]
+    # More than one chunk → more than one fetch processor.
+    assert len(fetch_procs) >= 2
+    # No chunk exceeds the chunk size, and together they cover every RID once.
+    import re
+
+    seen: list[str] = []
+    for p in fetch_procs:
+        m = re.search(r"RID=any\(([^)]*)\)", p["processor_params"]["query_path"])
+        assert m
+        chunk = [r for r in m.group(1).split(",") if r]
+        assert len(chunk) <= RID_SET_CHUNK_SIZE
+        seen.extend(chunk)
+    assert sorted(seen) == sorted(big)
+
+
 def test_rid_set_mode_excludes_referenced_only_vocab(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What

`CatalogBagBuilder.get_export_spec()` emitted a `rid_set`-scoped **csv** processor for each reachable asset table, but an **unscoped fetch** processor — its `query_path` was a bare full-table `/attribute/{schema}:{table}/url:=URL,...` scan with no RID filter.

The fetch processor drives the remote-file manifest (`fetch.txt`) and therefore the actual asset byte downloads. So a dataset bag fetched the bytes of **every row in the asset table**, not just the rows reachable from the dataset.

## Impact

On a large catalog this is a multi-x over-download. Observed on eye-ai `2-277G`: the dataset reaches ~29,734 images, but the bag's `fetch.txt` had 225,345 image entries (every image in the catalog) → ~6-8x over-fetch and a correspondingly huge, slow download. deriva-ml's bag-size **estimate** (which scopes asset bytes to reachable RIDs) was correct; the **bag** over-fetched — the two disagreed, estimate right.

## Fix

When `rid_sets` carries a RID set for an asset table, scope the fetch `query_path` with a `RID=any(...)` filter, preserving the `url/length/filename/md5/asset_rid` projection. `RID=any(...)` URLs are length-capped, so a large rid set is split into `RID_SET_CHUNK_SIZE` batches — one fetch processor per chunk, each appending to the same remote-file manifest, so the union across chunks is the full scoped asset set. RIDs are URL-quoted individually (the commas are `any()` syntax; quoting the joined string would encode the commas and silently return zero rows — the same gotcha the csv rid-set path guards against).

When `rid_sets is None` (non-rid-set callers), the unscoped full-table fetch is preserved unchanged.

The path grammar `/attribute/T/RID=any(...)/proj:=Col` is the documented **filter-then-projection** form already exercised by the download test fixtures (`test6.json`, `test12.json`).

## Tests

- `test_rid_set_scopes_asset_fetch_processor` — the asset fetch query_path is RID-scoped (`RID=any(...)`, projection preserved); the union of all fetch chunks' RIDs equals the rid_set exactly.
- `test_rid_set_chunks_large_asset_fetch` — a rid set larger than `RID_SET_CHUNK_SIZE` splits across multiple fetch processors; no chunk exceeds the cap; the union covers every RID once.
- The legacy unscoped path stays pinned by the existing `test_spec_includes_fetch_processor_for_asset_table`.

Full bag suite: 331 passed, 3 skipped. `test_catalog_builder.py` + `test_rid_set_fetch.py`: 60 passed.

## Downstream

This fixes the bag over-fetch for the deriva-ml client `build_bag` path immediately (it runs the export engine locally). deriva-ml will bump its deriva-py pin to include this; a downstream consumer test that asserts `fetch.txt` entry count == the estimate's reachable asset count will pin the contract from the deriva-ml side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)