### PR TITLE
fix(bag): add_asset resolves symlink sources (Linux bag corruption)

### DIFF
--- a/deriva/bag/builder.py
+++ b/deriva/bag/builder.py
@@ -405,6 +405,12 @@ class BagBuilder:
           staging that wants the bag layout but doesn't need to
           be archived to a different machine.
 
+        If ``source_path`` is a symlink, it is resolved to its
+        target before linking/copying — so the bag payload is
+        always a regular file, never a symlink — while the bag
+        entry keeps the symlink's own name unless ``filename``
+        overrides it.
+
         Args:
             table: Asset table name (e.g., ``"Image"``).
             rid: RID of the asset row this file belongs to.
@@ -421,12 +427,22 @@ class BagBuilder:
                 same RID + filename pair).
         """
         self._check_not_finalized()
+        # Resolve symlinks so link=True hardlinks the REAL file, not the symlink
+        # inode. os.link() follows symlinks on macOS/BSD but not on Linux, where
+        # it would otherwise put a symlink-to-an-external-path in the bag payload
+        # (corrupting the bag and tripping bagit's path-safety check
+        # (_path_is_dangerous, run by _validate_bag_contents)). Resolving here
+        # keeps the documented invariant — "hardlinks live
+        # inside the bag as regular files" — true on every platform. We resolve
+        # the *link target* but keep the caller-provided name for the bag entry,
+        # so the asset is still named after the source the caller passed in.
         source_path = Path(source_path)
+        name = filename or source_path.name
+        source_path = source_path.resolve()
         if not source_path.is_file():
             raise FileNotFoundError(
                 f"Asset source not found: {source_path}"
             )
-        name = filename or source_path.name
         rel = ASSET_FILE_TEMPLATE.format(
             table=table, rid=rid, filename=name
         )

--- a/tests/deriva/bag/test_builder.py
+++ b/tests/deriva/bag/test_builder.py
@@ -248,6 +248,38 @@ def test_builder_add_asset_link_mode_hardlinks_source(tmp_path: Path) -> None:
     assert dest.read_bytes() == b"original bytes"
 
 
+def test_builder_add_asset_link_mode_resolves_symlink_source(
+    tmp_path: Path,
+) -> None:
+    """link=True must embed the REAL file as a regular file in the bag even when
+    the source is a SYMLINK.
+
+    asset_file_path() in deriva-ml stages assets as absolute symlinks. os.link()
+    follows the symlink on macOS/BSD (hardlinks the real file) but hardlinks the
+    SYMLINK INODE on Linux — putting a symlink-to-an-external-path in the bag
+    payload, which corrupts the bag and trips bagit's _path_is_dangerous(). The
+    bag payload must contain the real file's bytes as a regular file on every
+    platform.
+    """
+    real = tmp_path / "real.bin"
+    real.write_bytes(b"real bytes")
+    link = tmp_path / "link.bin"
+    link.symlink_to(real.resolve())  # absolute symlink, as asset_file_path makes
+    assert link.is_symlink()
+
+    out = tmp_path / "bag"
+    bb = BagBuilder(metadata=_two_table_metadata(), output_dir=out)
+    bb.add_asset("Image", "I1", link, link=True)
+    bb.finalize(make_bdbag=False)
+
+    dest = out / "data" / "asset" / "Image" / "I1" / "link.bin"
+    assert dest.is_file()
+    # The load-bearing assertion: the bag payload must not be a symlink.
+    # Fails on Linux pre-fix (hardlink to the symlink inode), passes after.
+    assert not dest.is_symlink(), f"bag payload must not contain a symlink: {dest}"
+    assert dest.read_bytes() == b"real bytes"
+
+
 def test_builder_add_asset_link_mode_survives_source_deletion(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

`BagBuilder.add_asset(src, link=True)` did `os.link(src, dest)`. When `src` is a
**symlink** — which deriva-ml's `asset_file_path` creates by default when staging
assets — `os.link` follows it on macOS/BSD (the bag gets the real bytes) but
hardlinks the **symlink inode** on Linux (the bag gets a symlink pointing at an
external absolute path).

Two failure modes result from this one defect:
- **Linux:** the bag payload is a hardlink to the symlink inode → when the bag is
  hashed, zipped, moved, or loaded elsewhere, the asset bytes are missing/broken.
- **Any OS:** `bdbag.make_bag(update=True)` → bagit's `_path_is_dangerous()` calls
  `realpath()`, follows the symlink outside the bag root, and rejects it as an
  "unsafe path."

Both violate `add_asset`'s own documented invariant ("hardlinks live inside the
bag as regular files, so bagit's safety model is satisfied").

## Fix

Resolve `source_path` to its real target before linking/copying, so the hardlink
always targets the real file on every platform — **but derive the bag entry's
name from the unresolved path first**, so the asset keeps the caller's filename
(a symlink `link.bin` → real `real.bin` keeps the bag entry named `link.bin`):

```python
source_path = Path(source_path)
name = filename or source_path.name   # caller's name, from the UNRESOLVED path
source_path = source_path.resolve()   # resolve the link target for link/copy
```

The bag-entry naming uses the unresolved name; the link/copy and the idempotency
`source_path` use the resolved path. Two symlinks pointing at the same real file
now correctly de-dupe as the same source.

## Test

`test_builder_add_asset_link_mode_resolves_symlink_source` links a symlink source
with `link=True` and asserts the bag payload is a **regular file** (`not
dest.is_symlink()`) named after the symlink, containing the real bytes.

Verified on **Linux via Docker** (`python:3.13-slim`): **FAILS before the fix**
(bag payload is a symlink), **PASSES after**. macOS passes both ways — which is
exactly why the bug was invisible on dev machines. Full `tests/deriva/bag/` suite
green on Linux (332 passed), including the idempotency / duplicate-source /
custom-filename / bagit-validation tests.

The contract test lives here (upstream), alongside the fix, per the
deriva-ml/deriva-py cross-repo rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)