### PR TITLE
Sync 2.0-dev with latest master

### DIFF
--- a/deriva/core/__init__.py
+++ b/deriva/core/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.7.12"
+__version__ = "1.7.13"
 
 from deriva.core.utils.core_utils import *
 from deriva.core.base_cli import BaseCLI, KeyValuePairArgs

--- a/deriva/core/ermrest_catalog.py
+++ b/deriva/core/ermrest_catalog.py
@@ -149,6 +149,11 @@ _clone_state_url = "tag:isrd.isi.edu,2018:clone-status"
 
 DEFAULT_PAGE_SIZE = 100000
 
+RID_SET_CHUNK_SIZE = 500
+"""URL-safe batch size for RID-set fetches. A ``RID=any(...)`` filter over
+thousands of RIDs exceeds the server's URI length limit (a 225k-RID URL is
+~1.9 MB → HTTP 414); chunking keeps each request URL well within limits."""
+
 class ResolveRidResult (NamedTuple):
     datapath: datapath.DataPath
     table: ermrest_model.Table
@@ -492,6 +497,281 @@ class ErmrestCatalog(DerivaBinding):
         """
         self.get_as_file(path, destfilename, headers, callback, delete_if_empty, paged, page_size, page_sort_columns)
 
+    @staticmethod
+    def _rid_set_chunks(rid_set, chunk_size):
+        """Yield successive ``chunk_size``-length lists from ``rid_set``.
+
+        Args:
+            rid_set: Iterable of RID strings.
+            chunk_size: Max RIDs per chunk.
+
+        Yields:
+            Lists of at most ``chunk_size`` RIDs, preserving order, no RID
+            lost or duplicated.
+        """
+        rids = list(rid_set)
+        for i in range(0, len(rids), chunk_size):
+            yield rids[i:i + chunk_size]
+
+    @staticmethod
+    def _rid_set_query_url(rid_table, rid_chunk):
+        """Build a ``/entity/{rid_table}/RID=any(...)`` path for one RID chunk.
+
+        Each RID *value* is URL-quoted individually; the comma separators are
+        ``any()`` syntax and stay literal. Quoting the joined string instead
+        (encoding commas to ``%2C``) breaks the predicate and silently returns
+        zero rows — the bug this function exists to prevent.
+
+        Args:
+            rid_table: ``"schema:table"`` of the table being queried.
+            rid_chunk: List of RID strings (one URL-safe batch).
+
+        Returns:
+            Catalog-relative path string starting at ``/entity/``.
+        """
+        joined = ",".join(urlquote(str(rid)) for rid in rid_chunk)
+        return "/entity/%s/RID=any(%s)" % (rid_table, joined)
+
+    def _fetch_paged_content(self, destfile, base_path, headers, callback,
+                             page_size, page_sort_columns, first_page,
+                             first_line=None):
+        """Page through ``base_path`` and append rows to an open ``destfile``.
+
+        This is the general paged-fetch loop extracted from :meth:`get_as_file`
+        (it serves both content types, hence ``_content`` not ``_csv``). It
+        walks ``base_path`` page by page using the ``@sort``/``@after``/``limit``
+        cursor, applies the query-runtime-limit page-size backoff, and handles
+        both ``text/csv`` and ``application/x-json-stream`` responses. The CSV
+        header is written only on the first page processed; every later page
+        (including the first page of each later chunk in a RID-set fetch) skips
+        the header line(s).
+
+        The ``@after()`` cursor for each CSV page is the page's last complete
+        record, recovered by parsing the page's data lines forward through one
+        csv.reader so a multi-line quoted field (RFC 4180) reassembles into one
+        record rather than being mistaken for several -- a wrong cursor would
+        skip rows or re-fetch the page forever.
+
+        **Abort contract:** if the progress ``callback`` returns falsy, the loop
+        closes ``destfile`` and returns early. Every caller MUST check
+        ``destfile.closed`` after the call and stop touching the file (see both
+        call sites in :meth:`get_as_file` and :meth:`_get_rid_set_as_file`).
+
+        Passing the caller-managed ``first_page`` in and returning the updated
+        value lets multiple calls append into one CSV with the header written
+        exactly once (used by :meth:`_get_rid_set_as_file` to chunk-append a
+        RID set). ``first_line`` (the parsed CSV header) and the (possibly
+        backed-off) ``page_size`` are likewise threaded in and back out so later
+        chunks reuse the column names and do not re-incur a backoff the previous
+        chunk already paid.
+
+        Returns:
+            A ``(first_page, total, first_line, page_size, content_type)`` tuple:
+            ``first_page`` is the updated flag (``False`` once any page has been
+            processed), ``total`` is the bytes written by this call, ``first_line``
+            is the CSV header (captured here on the first page, or the threaded
+            value passed in), ``page_size`` is the current (possibly reduced) page
+            size to carry into the next call, and ``content_type`` is the response
+            Content-Type observed on the last page (``None`` if no page was
+            processed) -- callers use it to drive their delete-if-empty epilogue
+            instead of guessing from the request ``accept``.
+        """
+        total = 0
+        last_record = None
+        content_type = None
+        usr = urlsplit(self._server_uri + base_path)
+        path = str(usr.path.split('@sort')[0])
+        while True:
+            sort = "@sort(%s)%s" % (",".join(page_sort_columns or ["RID"]),
+                                    ("@after(%s)" % ",".join(last_record)) if last_record is not None else "")
+            limit = "limit=%s" % int(page_size) if page_size > 0 else "none"
+            query = re.sub(r"([^.]*)(limit=.*?)($|[&;])([^.]*)$", r"\1%s\3\4" % limit, usr.query, flags=re.I)
+            url = urlunsplit((usr.scheme, usr.netloc, path + sort, query if query else limit, usr.fragment))
+
+            # 1. Try to get a page worth of data, back-off page size if query run time errors are encountered
+            with self._session.get(url, headers=headers) as r:
+                if r.status_code == 400 and "Query run time limit exceeded" in r.text:
+                    if page_size == 1:
+                        self._response_raise_for_status(r)
+                    r.close()
+                    page_size //= 2
+                    page_size = 1 if page_size < 1 else page_size
+                    logging.warning("Query runtime exceeded while attempting to transfer rows from %s to file "
+                                    "[%s]. The page size is being reduced to %s and the query will be retried."
+                                    % (url, destfile.name, page_size))
+                    if callback:
+                        if not callback(progress="Retrying query: %s" % url):
+                            destfile.close()
+                            return first_page, total, first_line, page_size, content_type
+                    continue
+                else:
+                    self._response_raise_for_status(r)
+
+                # 2. Write the page to disk and check the last record processed in order to get the next page
+                last_line = {}
+                content_type = r.headers.get("Content-Type")
+                logging.debug("Transferring data from [%s] to %s" % (url, destfile.name))
+                if content_type == "text/csv":
+                    skip = 1
+                    line_num = 0
+                    page_lines = []
+                    if first_page:
+                        lines = r.iter_lines(decode_unicode=True)
+                        reader = csv.reader(lines)
+                        first_line = next(reader)
+                        skip = reader.line_num
+                    for line in r.iter_lines():
+                        line_num += 1
+                        # The header line(s) appear on every page; the first page writes them to
+                        # the file but they are never data, so they are excluded from page_lines
+                        # on every page (data cursor only). Subsequent pages also skip writing them.
+                        is_header = line_num <= skip
+                        if not first_page and is_header:
+                            continue
+                        tline = line + b"\n"
+                        destfile.write(tline)
+                        total += len(tline)
+                        if not is_header:
+                            page_lines.append(line.decode("utf-8"))
+                    # Parse this page's data lines forward through a single csv.reader so a multi-line
+                    # quoted field is reassembled into one record; retain only the last record.
+                    last_row = None
+                    for row in csv.reader(page_lines):
+                        last_row = row
+                    last_line = dict(zip(first_line, last_row)) if last_row else {}
+                    first_page = False
+                # JSON-Stream processing writes the entire buffer to the destination file. The last line is
+                # captured by reverse seeking in the buffer from right before the last b'\n' newline to the next
+                # newline or buf[0], then calling readline from the current position
+                elif content_type == "application/x-json-stream":
+                    buf = r.content
+                    # An empty result may be zero bytes OR an empty-array/object marker
+                    # ("[]\n" / "{}\n"). In a chunk-append (RID-set) fetch, writing that
+                    # marker mid-stream would leave a stray "[]" between real records, so
+                    # treat it as an empty page: do not write it, and terminate this call.
+                    if not buf or buf in (b"[]\n", b"{}\n", b"[]", b"{}"):
+                        break
+                    destfile.write(buf)
+                    total += len(buf)
+                    b = io.BytesIO(buf)
+                    b.seek(-2, os.SEEK_END)
+                    while b.read(1) != b'\n':
+                        b.seek(-2, os.SEEK_CUR)
+                        if b.tell() == os.SEEK_SET:
+                            break
+                    last_line = json.loads(b.readline().decode('utf-8'))
+
+                # 3. Save the last record key and flush the destination file buffers to disk.
+                if not last_line:
+                    break
+                destfile.flush()
+                last_record = [urlquote(str(last_line.get(key))) for key in page_sort_columns]
+                if callback:
+                    if not callback(progress="Downloading: %.2f MB transferred" %
+                                             (float(total) / float(Megabyte))):
+                        destfile.close()
+                        return first_page, total, first_line, page_size, content_type
+
+        return first_page, total, first_line, page_size, content_type
+
+    @staticmethod
+    def _is_empty_content(destfile, total, content_type):
+        """Return True when a downloaded file should be treated as "empty".
+
+        Shared by :meth:`get_as_file` and :meth:`_get_rid_set_as_file` so both
+        apply the same delete-if-empty rule keyed on the actual response
+        ``content_type``: zero bytes is always empty; a json/json-stream result
+        is empty when it is just ``[]`` / ``{}``; a CSV result is empty when it
+        holds only the header row (no data). The file is rewound before reading.
+
+        Args:
+            destfile: The open destination file (rewound and read here).
+            total: Bytes written for the transfer.
+            content_type: The response Content-Type observed by the fetch.
+        """
+        if total == 0:
+            return True
+        destfile.seek(0)
+        if content_type in ("application/json", "application/x-json-stream"):
+            buf = destfile.read(16)
+            return buf == b"[]\n" or buf == b"{}\n"
+        if content_type == "text/csv":
+            reader = csv.reader(codecs.iterdecode(destfile, 'utf-8'))
+            rowcount = 0
+            for _ in reader:
+                rowcount += 1
+                if rowcount > 1:
+                    break  # early-break: only need to know "more than the header row?"
+            return rowcount <= 1
+        return False
+
+    def _get_rid_set_as_file(self, rid_set, rid_table, destfilename, *, headers,
+                             callback, delete_if_empty, page_size, page_sort_columns):
+        """Fetch a RID set as one file by chunk-append (see RID_SET_CHUNK_SIZE).
+
+        Chunks ``rid_set`` into URL-safe batches, fetches each chunk's
+        ``RID=any(...)`` page(s) via :meth:`_fetch_paged_content`, and appends
+        all chunks into one file. ``first_page`` persists across chunks so a CSV
+        header is written exactly once, and ``first_line`` (the CSV header) is
+        threaded so every chunk builds its cursor with the right column names.
+
+        The content type follows the caller's ``accept`` header (resolved by
+        :meth:`get_as_file` to ``text/csv`` or ``application/x-json-stream``),
+        so this path supports both formats; the shared emptiness rule
+        (:meth:`_is_empty_content`) is keyed on the actual response type.
+
+        Args:
+            rid_set: The RIDs to fetch rows for.
+            rid_table: Catalog-relative table path the RIDs belong to.
+            destfilename: Path of the file to write.
+            headers: Request headers (accept already resolved by the caller).
+            callback: Optional progress callback; same contract as
+                :meth:`get_as_file`.
+            delete_if_empty: When ``True``, delete the file if the result is
+                empty.
+            page_size: Initial page size for each chunk's paged fetch.
+            page_sort_columns: Columns used for the ``@sort``/``@after`` cursor.
+
+        Returns:
+            The ``destfilename`` on success, or ``None`` when the result was
+            empty and ``delete_if_empty`` deletion applied.
+        """
+        destfile = open(destfilename, 'w+b')
+        content_type = None
+        try:
+            first_page = True
+            first_line = None
+            total = 0
+            for chunk in self._rid_set_chunks(rid_set, RID_SET_CHUNK_SIZE):
+                base_path = self._rid_set_query_url(rid_table, chunk)
+                # Thread first_line (header) and the possibly backed-off page_size across chunks so the
+                # header is written once and a later chunk doesn't re-pay a backoff the previous one earned.
+                first_page, written, first_line, page_size, chunk_ct = self._fetch_paged_content(
+                    destfile, base_path, headers, callback,
+                    page_size, page_sort_columns, first_page,
+                    first_line=first_line,
+                )
+                total += written
+                if chunk_ct is not None:
+                    content_type = chunk_ct
+                if destfile.closed:
+                    # Honor the _fetch_paged_content abort contract: a falsy callback closed destfile and
+                    # aborted early, so stop before writing to (or flushing) a closed file in the next chunk.
+                    return None
+            destfile.flush()
+            # Same rule as get_as_file: always drop a zero-byte file; drop "empty" content
+            # (header-only CSV, []/{} json) only when the caller asked via delete_if_empty.
+            delete_file = True if total == 0 else False
+            if delete_if_empty and total > 0:
+                delete_file = self._is_empty_content(destfile, total, content_type)
+        finally:
+            if not destfile.closed:
+                destfile.close()
+        if delete_file and os.path.exists(destfilename):
+            os.remove(destfilename)
+            return None
+        return destfilename
+
     def get_as_file(self,
                     path,
                     destfilename,
@@ -500,7 +780,9 @@ class ErmrestCatalog(DerivaBinding):
                     delete_if_empty=False,
                     paged=False,
                     page_size=DEFAULT_PAGE_SIZE,
-                    page_sort_columns=frozenset(["RID"])):
+                    page_sort_columns=frozenset(["RID"]),
+                    rid_set=None,
+                    rid_table=None):
         """
            Retrieve catalog data streamed to destination file.
            Caller is responsible to clean up file even on error, when the file may or may not exist.
@@ -508,13 +790,47 @@ class ErmrestCatalog(DerivaBinding):
            json/json-stream content, the presence of a single empty JSON object will be tested for. In the case of
            CSV content, the file will be parsed with CSV reader to determine that only a single header line and no row
            data is present.
+
+           When "rid_set" is provided, "path" is ignored and the rows for those
+           RIDs are fetched from "rid_table" by chunking the RID set into
+           URL-safe ``RID=any(...)`` batches and appending every chunk's page(s)
+           into one file (for CSV the header is written exactly once).
+           "rid_table" is required in this mode. The output format follows the
+           caller's Accept header -- "text/csv" (the default when none is given)
+           or "application/x-json-stream". Returns the destination filename, or
+           None if the result was empty and "delete_if_empty" applied. In this
+           mode the result is always paged, so "paged" is ignored. Rows are
+           sorted by "page_sort_columns" within each chunk but not globally
+           across the RID set, and a RID supplied more than once (or appearing
+           in more than one chunk) yields a duplicated row -- callers that need a
+           globally sorted or de-duplicated result must do so themselves.
         """
+        # Normalize page_size before any dispatch so page_size=0 ("use the default") behaves the same
+        # on the rid-set path as on the normal paged path, rather than becoming an unbounded limit=none.
+        page_size = page_size if page_size > 0 else DEFAULT_PAGE_SIZE
+
+        if rid_set is not None:
+            if not rid_table:
+                raise ValueError("rid_table is required when rid_set is provided")
+            # Resolve the caller's accept the same way the normal paged path does: honor an explicit
+            # text/csv or application/x-json-stream, default to text/csv when unset or unsupported.
+            # Defaulting matters because without it a caller with no accept gets the server's JSON
+            # default, the paged write-branches are skipped, and the result is silently empty.
+            rid_set_headers = dict(headers or {})
+            accept = rid_set_headers.get("accept")
+            if accept not in ("text/csv", "application/x-json-stream"):
+                rid_set_headers["accept"] = "text/csv"
+            return self._get_rid_set_as_file(
+                rid_set, rid_table, destfilename, headers=rid_set_headers,
+                callback=callback, delete_if_empty=delete_if_empty,
+                page_size=page_size, page_sort_columns=page_sort_columns,
+            )
+
         self.check_path(path)
 
         # Only entity API supported with paged mode at this time, otherwise fallback. We fallback rather than raise an
         # exception in the case that the caller might be trying to perform an opportunistic paged request without
         # knowing a priori if paged support for the given query is available.
-        page_size = page_size if page_size > 0 else DEFAULT_PAGE_SIZE
         if not (path.startswith("/entity") or path.startswith("/attribute")) and paged:
             logging.warning("Paged data retrieval only supported for entity or attribute API queries.")
             paged = False
@@ -548,130 +864,27 @@ class ErmrestCatalog(DerivaBinding):
                                 return
                 destfile.flush()
             else:
-                first_page = True
-                first_line = None
-                last_record = None
-                usr = urlsplit(self._server_uri + path)
-                path = str(usr.path.split('@sort')[0])
-                while True:
-                    sort = "@sort(%s)%s" % (",".join(page_sort_columns or ["RID"]),
-                                            ("@after(%s)" % ",".join(last_record)) if last_record is not None else "")
-                    limit = "limit=%s" % int(page_size) if page_size > 0 else "none"
-                    query = re.sub(r"([^.]*)(limit=.*?)($|[&;])([^.]*)$", r"\1%s\3\4" % limit, usr.query, flags=re.I)
-                    url = urlunsplit((usr.scheme, usr.netloc, path + sort, query if query else limit, usr.fragment))
-
-                    # 1. Try to get a page worth of data, back-off page size if query run time errors are encountered
-                    with self._session.get(url, headers=headers) as r:
-                        if r.status_code == 400 and "Query run time limit exceeded" in r.text:
-                            if page_size == 1:
-                                self._response_raise_for_status(r)
-                            r.close()
-                            page_size //= 2
-                            page_size = 1 if page_size < 1 else page_size
-                            logging.warning("Query runtime exceeded while attempting to transfer rows from %s to file "
-                                            "[%s]. The page size is being reduced to %s and the query will be retried."
-                                            % (url, destfilename, page_size))
-                            if callback:
-                                if not callback(progress="Retrying query: %s" % url):
-                                    destfile.close()
-                                    return
-                            continue
-                        else:
-                            self._response_raise_for_status(r)
-
-                        # 2. Write the page to disk and check the last record processed in order to get the next page
-                        last_line = {}
-                        content_type = r.headers.get("Content-Type")
-                        logging.debug("Transferring data from [%s] to %s" % (url, destfilename))
-                        # CSV processing iterates over lines in the response, skipping the header line(s) in all but
-                        # the first page, and captures this page's data lines to determine the last record processed.
-                        # The last complete record cannot be taken from the last raw byte line: a CSV field may contain
-                        # embedded newlines inside a quoted value (RFC 4180, e.g. OCR text with grid data), so the last
-                        # raw line can be a fragment of the record. Instead, the page's kept data lines are parsed
-                        # forward with the csv module -- starting from a known record boundary, it tracks quote state
-                        # correctly across embedded newlines. Using an incorrect record for the @after() cursor would
-                        # skip rows or re-fetch the same page forever.
-                        if content_type == "text/csv":
-                            skip = 1
-                            line_num = 0
-                            page_lines = []
-                            if first_page:
-                                lines = r.iter_lines(decode_unicode=True)
-                                reader = csv.reader(lines)
-                                first_line = next(reader)
-                                skip = reader.line_num
-                            for line in r.iter_lines():
-                                line_num += 1
-                                # The header line(s) appear on every page; the first page writes them to
-                                # the file but they are never data, so they are excluded from page_lines
-                                # on every page (data cursor only). Subsequent pages also skip writing them.
-                                is_header = line_num <= skip
-                                if not first_page and is_header:
-                                    continue
-                                tline = line + b"\n"
-                                destfile.write(tline)
-                                total += len(tline)
-                                if not is_header:
-                                    # Keep this page's data lines so the last complete record can be
-                                    # parsed forward; bounded by one page.
-                                    page_lines.append(line.decode("utf-8"))
-                            # Parse the page's data lines forward through a single csv.reader: starting from
-                            # a known record boundary, it tracks quote state across embedded newlines, so a
-                            # multi-line quoted field is reassembled into one record rather than mistaken
-                            # for several. Retain only the last record for the @after() cursor.
-                            last_row = None
-                            for row in csv.reader(page_lines):
-                                last_row = row
-                            last_line = dict(zip(first_line, last_row)) if last_row else {}
-                            first_page = False
-                        # JSON-Stream processing writes the entire buffer to the destination file. The last line is
-                        # captured by reverse seeking in the buffer from right before the last b'\n' newline to the next
-                        # newline or buf[0], then calling readline from the current position
-                        elif content_type == "application/x-json-stream":
-                            buf = r.content
-                            if not buf:
-                                break
-                            destfile.write(buf)
-                            total += len(buf)
-                            b = io.BytesIO(buf)
-                            b.seek(-2, os.SEEK_END)
-                            while b.read(1) != b'\n':
-                                b.seek(-2, os.SEEK_CUR)
-                                if b.tell() == os.SEEK_SET:
-                                    break
-                            last_line = json.loads(b.readline().decode('utf-8'))
-
-                        # 3. Save the last record key and flush the destination file buffers to disk.
-                        if not last_line:
-                            break
-                        destfile.flush()
-                        last_record = [urlquote(str(last_line.get(key))) for key in page_sort_columns]
-                        if callback:
-                            if not callback(progress="Downloading: %.2f MB transferred" %
-                                                     (float(total) / float(Megabyte))):
-                                destfile.close()
-                                return
+                # _fetch_paged_content returns the response Content-Type it observed; the
+                # delete-if-empty epilogue keys off it. page_size is unused here (only the
+                # rid-set chunk loop threads the backed-off value across calls).
+                _first_page, total, _first_line, _page_size, content_type = self._fetch_paged_content(
+                    destfile, path, headers, callback,
+                    page_size, page_sort_columns, True,
+                )
+                # Honor the _fetch_paged_content abort contract: a falsy callback closed destfile and
+                # aborted early (as the inlined "destfile.close(); return" did before extraction), so
+                # bail out without touching the closed file in the epilogue.
+                if destfile.closed:
+                    return
 
             elapsed = datetime.datetime.now() - start
             summary = get_transfer_summary(total, elapsed)
 
-            # perform automatic file deletion on detected "empty" content, if requested
+            # Always delete a zero-byte file; additionally delete "empty" content (header-only CSV,
+            # []/{} json) only when requested. Shared rule keyed on the response content_type.
             delete_file = True if total == 0 else False
             if delete_if_empty and total > 0:
-                destfile.seek(0)
-                if content_type == "application/json" or content_type == "application/x-json-stream":
-                    buf = destfile.read(16)
-                    if buf == b"[]\n" or buf == b"{}\n":
-                        delete_file = True
-                elif content_type == "text/csv":
-                    reader = csv.reader(codecs.iterdecode(destfile, 'utf-8'))
-                    rowcount = 0
-                    for row in reader:
-                        rowcount += 1
-                        if rowcount > 1:
-                            break
-                    if rowcount <= 1:
-                        delete_file = True
+                delete_file = self._is_empty_content(destfile, total, content_type)
 
             # automatically delete zero-length files or detected "empty" content
             if delete_file:

--- a/deriva/core/ermrest_catalog.py
+++ b/deriva/core/ermrest_catalog.py
@@ -492,6 +492,51 @@ class ErmrestCatalog(DerivaBinding):
         """
         self.get_as_file(path, destfilename, headers, callback, delete_if_empty, paged, page_size, page_sort_columns)
 
+    @staticmethod
+    def _read_last_csv_record(filepath, fieldnames):
+        """Read the last complete CSV record from a file.
+
+        Uses a chunked reverse-read strategy to find the last complete CSV
+        record without loading the entire file into memory.  Python's csv
+        module handles multi-line quoted fields (RFC 4180) correctly, so this
+        avoids the bug where a raw byte-line inside a quoted field is
+        misinterpreted as a complete record.
+
+        Args:
+            filepath: Path to the CSV file.
+            fieldnames: List of column names (the CSV header row).
+
+        Returns:
+            A dict mapping column names to values for the last record,
+            or ``{}`` if the file has no data rows.
+        """
+        chunk_size = 256 * 1024  # 256 KB — enough for most records
+        max_read = 10 * 1024 * 1024  # 10 MB cap to avoid unbounded reads
+        with open(filepath, "r", newline="", encoding="utf-8") as f:
+            f.seek(0, os.SEEK_END)
+            file_size = f.tell()
+            if file_size == 0:
+                return {}
+
+            read_so_far = 0
+            last_record = {}
+            while read_so_far < min(file_size, max_read):
+                read_so_far = min(read_so_far + chunk_size, file_size)
+                f.seek(max(file_size - read_so_far, 0))
+                tail = f.read()
+                # Parse the tail as CSV using the known header.
+                # csv.DictReader handles multi-line quoted fields correctly.
+                reader = csv.DictReader(io.StringIO(tail), fieldnames=fieldnames)
+                records = list(reader)
+                if records:
+                    last_record = records[-1]
+                    # Verify we got a valid record (RID should not be empty or
+                    # start with whitespace, which indicates a partial read)
+                    rid = last_record.get("RID", "")
+                    if rid and not rid[0].isspace():
+                        return last_record
+            return last_record
+
     def get_as_file(self,
                     path,
                     destfilename,
@@ -584,7 +629,9 @@ class ErmrestCatalog(DerivaBinding):
                         content_type = r.headers.get("Content-Type")
                         logging.debug("Transferring data from [%s] to %s" % (url, destfilename))
                         # CSV processing iterates over lines in the response, skipping the header line(s) in all but
-                        # the first page, and captures the last line of each page to determine the last record processed
+                        # the first page, and captures the last line of each page to determine the last record processed.
+                        # After writing, the last complete CSV record is found by reading back from the destination file
+                        # using Python's csv module, which correctly handles multi-line quoted fields (RFC 4180).
                         if content_type == "text/csv":
                             skip = 1
                             line_num = 0
@@ -603,8 +650,14 @@ class ErmrestCatalog(DerivaBinding):
                                 total += len(tline)
                                 last_line = tline
                             if last_line and last_line != first_line:
-                                reader = csv.DictReader([last_line.decode('utf-8')], first_line)
-                                last_line = next(reader)
+                                # Read back the last complete CSV record from the file.
+                                # We cannot rely on the last raw byte line because CSV
+                                # fields may contain embedded newlines inside quoted
+                                # values (e.g., OCR text with grid data).  Parsing the
+                                # last raw line as a record would produce an incorrect
+                                # RID for the @after() cursor, causing an infinite loop.
+                                destfile.flush()
+                                last_line = self._read_last_csv_record(destfilename, first_line)
                             first_page = False
                         # JSON-Stream processing writes the entire buffer to the destination file. The last line is
                         # captured by reverse seeking in the buffer from right before the last b'\n' newline to the next

--- a/deriva/core/ermrest_catalog.py
+++ b/deriva/core/ermrest_catalog.py
@@ -492,51 +492,6 @@ class ErmrestCatalog(DerivaBinding):
         """
         self.get_as_file(path, destfilename, headers, callback, delete_if_empty, paged, page_size, page_sort_columns)
 
-    @staticmethod
-    def _read_last_csv_record(filepath, fieldnames):
-        """Read the last complete CSV record from a file.
-
-        Uses a chunked reverse-read strategy to find the last complete CSV
-        record without loading the entire file into memory.  Python's csv
-        module handles multi-line quoted fields (RFC 4180) correctly, so this
-        avoids the bug where a raw byte-line inside a quoted field is
-        misinterpreted as a complete record.
-
-        Args:
-            filepath: Path to the CSV file.
-            fieldnames: List of column names (the CSV header row).
-
-        Returns:
-            A dict mapping column names to values for the last record,
-            or ``{}`` if the file has no data rows.
-        """
-        chunk_size = 256 * 1024  # 256 KB — enough for most records
-        max_read = 10 * 1024 * 1024  # 10 MB cap to avoid unbounded reads
-        with open(filepath, "r", newline="", encoding="utf-8") as f:
-            f.seek(0, os.SEEK_END)
-            file_size = f.tell()
-            if file_size == 0:
-                return {}
-
-            read_so_far = 0
-            last_record = {}
-            while read_so_far < min(file_size, max_read):
-                read_so_far = min(read_so_far + chunk_size, file_size)
-                f.seek(max(file_size - read_so_far, 0))
-                tail = f.read()
-                # Parse the tail as CSV using the known header.
-                # csv.DictReader handles multi-line quoted fields correctly.
-                reader = csv.DictReader(io.StringIO(tail), fieldnames=fieldnames)
-                records = list(reader)
-                if records:
-                    last_record = records[-1]
-                    # Verify we got a valid record (RID should not be empty or
-                    # start with whitespace, which indicates a partial read)
-                    rid = last_record.get("RID", "")
-                    if rid and not rid[0].isspace():
-                        return last_record
-            return last_record
-
     def get_as_file(self,
                     path,
                     destfilename,
@@ -629,35 +584,45 @@ class ErmrestCatalog(DerivaBinding):
                         content_type = r.headers.get("Content-Type")
                         logging.debug("Transferring data from [%s] to %s" % (url, destfilename))
                         # CSV processing iterates over lines in the response, skipping the header line(s) in all but
-                        # the first page, and captures the last line of each page to determine the last record processed.
-                        # After writing, the last complete CSV record is found by reading back from the destination file
-                        # using Python's csv module, which correctly handles multi-line quoted fields (RFC 4180).
+                        # the first page, and captures this page's data lines to determine the last record processed.
+                        # The last complete record cannot be taken from the last raw byte line: a CSV field may contain
+                        # embedded newlines inside a quoted value (RFC 4180, e.g. OCR text with grid data), so the last
+                        # raw line can be a fragment of the record. Instead, the page's kept data lines are parsed
+                        # forward with the csv module -- starting from a known record boundary, it tracks quote state
+                        # correctly across embedded newlines. Using an incorrect record for the @after() cursor would
+                        # skip rows or re-fetch the same page forever.
                         if content_type == "text/csv":
                             skip = 1
                             line_num = 0
+                            page_lines = []
                             if first_page:
                                 lines = r.iter_lines(decode_unicode=True)
                                 reader = csv.reader(lines)
                                 first_line = next(reader)
                                 skip = reader.line_num
                             for line in r.iter_lines():
-                                if not first_page:
-                                    line_num += 1
-                                    if line_num <= skip:
-                                        continue
+                                line_num += 1
+                                # The header line(s) appear on every page; the first page writes them to
+                                # the file but they are never data, so they are excluded from page_lines
+                                # on every page (data cursor only). Subsequent pages also skip writing them.
+                                is_header = line_num <= skip
+                                if not first_page and is_header:
+                                    continue
                                 tline = line + b"\n"
                                 destfile.write(tline)
                                 total += len(tline)
-                                last_line = tline
-                            if last_line and last_line != first_line:
-                                # Read back the last complete CSV record from the file.
-                                # We cannot rely on the last raw byte line because CSV
-                                # fields may contain embedded newlines inside quoted
-                                # values (e.g., OCR text with grid data).  Parsing the
-                                # last raw line as a record would produce an incorrect
-                                # RID for the @after() cursor, causing an infinite loop.
-                                destfile.flush()
-                                last_line = self._read_last_csv_record(destfilename, first_line)
+                                if not is_header:
+                                    # Keep this page's data lines so the last complete record can be
+                                    # parsed forward; bounded by one page.
+                                    page_lines.append(line.decode("utf-8"))
+                            # Parse the page's data lines forward through a single csv.reader: starting from
+                            # a known record boundary, it tracks quote state across embedded newlines, so a
+                            # multi-line quoted field is reassembled into one record rather than mistaken
+                            # for several. Retain only the last record for the @after() cursor.
+                            last_row = None
+                            for row in csv.reader(page_lines):
+                                last_row = row
+                            last_line = dict(zip(first_line, last_row)) if last_row else {}
                             first_page = False
                         # JSON-Stream processing writes the entire buffer to the destination file. The last line is
                         # captured by reverse seeking in the buffer from right before the last b'\n' newline to the next

--- a/deriva/core/utils/credenza_auth_utils.py
+++ b/deriva/core/utils/credenza_auth_utils.py
@@ -355,7 +355,7 @@ class CredenzaAuthUtilCLI(BaseCLI):
         self.parser.add_argument('--host', required=True, metavar='<host>', help="Fully qualified host name.")
         self.parser.add_argument("--pretty", "-p", action="store_true", help="Pretty-print all result output.")
         self.args = None
-        self.api = None
+        self._api = None
 
         # init subparsers and corresponding functions
         self.subparsers = self.parser.add_subparsers(title='sub-commands', dest='subcmd')
@@ -458,22 +458,23 @@ class CredenzaAuthUtilCLI(BaseCLI):
         parser.set_defaults(func=self.service_login)
 
 
-    def _api(self):
-        if self.api is None:
+    @property
+    def api(self):
+        if self._api is None:
             credential_file = (
                 self.args.credential_file) if hasattr(self.args, "credential_file") else DEFAULT_CREDENTIAL_FILE
-            self.api = CredenzaAuthUtil(credential_file=credential_file)
-        return self.api
+            self._api = CredenzaAuthUtil(credential_file=credential_file)
+        return self._api
 
 
     def show_token(self, args):
-        return self._api().show_token(args.host)
+        return self.api.show_token(args.host)
 
 
     def get_session(self, args, check_only=False):
         # Default resource if omitted
         resources = args.resource if hasattr(args, "resource") else [DEFAULT_SERVICE_RESOURCE]
-        result = self._api().get_session(args.host, resources=resources)
+        result = self.api.get_session(args.host, resources=resources)
         if not result and check_only:
             return None
         if result is None and not check_only:
@@ -483,7 +484,7 @@ class CredenzaAuthUtilCLI(BaseCLI):
 
     def put_session(self, args):
         resources = args.resource if hasattr(args, "resource") else [DEFAULT_SERVICE_RESOURCE]
-        result = self._api().put_session(args.host, refresh_upstream=args.refresh_upstream, resources=resources)
+        result = self.api.put_session(args.host, refresh_upstream=args.refresh_upstream, resources=resources)
         if result is None:
             return f"No valid session found for host '{args.host}'."
         return result
@@ -552,9 +553,9 @@ class CredenzaAuthUtilCLI(BaseCLI):
         body = token_response.json()
         token = body["access_token"]
 
-        self._api().save_credential(args.host, token)
+        self.api.save_credential(args.host, token)
         if not args.no_bdbag_keychain:
-            self._api().update_bdbag_keychain(host=args.host,
+            self.api.update_bdbag_keychain(host=args.host,
                                               token=token,
                                               keychain_file=args.bdbag_keychain_file or bdbkc.DEFAULT_KEYCHAIN_FILE)
         token_display = f"Bearer token: {token}" if args.show_token else ""
@@ -562,7 +563,7 @@ class CredenzaAuthUtilCLI(BaseCLI):
 
 
     def logout(self, args):
-        credential = self._api().load_credential(args.host)
+        credential = self.api.load_credential(args.host)
         if not credential:
             return "Credential not found. Not logged in."
         token = credential.get("bearer-token")
@@ -574,9 +575,9 @@ class CredenzaAuthUtilCLI(BaseCLI):
         response = session.post(url, data=[("token", token), ("client_id", CLIENT_ID)])
         response.raise_for_status()
 
-        self._api().save_credential(args.host, None)
+        self.api.save_credential(args.host, None)
         if not args.no_bdbag_keychain:
-            self._api().update_bdbag_keychain(host=args.host,
+            self.api.update_bdbag_keychain(host=args.host,
                                               token=token,
                                               delete=True,
                                               keychain_file=args.bdbag_keychain_file or bdbkc.DEFAULT_KEYCHAIN_FILE)
@@ -598,10 +599,10 @@ class CredenzaAuthUtilCLI(BaseCLI):
         bdbag_keychain_file = kw.pop("bdbag_keychain_file", None)
 
 
-        if credential_file and (self.api is None or self.api.credential_file != credential_file):
-            self.api = CredenzaAuthUtil(credential_file)
+        if credential_file and (self._api is None or self._api.credential_file != credential_file):
+            self._api = CredenzaAuthUtil(credential_file)
 
-        response = self._api().service_login(
+        response = self.api.service_login(
             host,
             auth_method=auth_method,
             scope=scope,

--- a/deriva/core/utils/credenza_auth_utils.py
+++ b/deriva/core/utils/credenza_auth_utils.py
@@ -1,5 +1,6 @@
 import sys
 import json
+import base64
 import logging
 import traceback
 from argparse import SUPPRESS
@@ -13,14 +14,21 @@ from deriva.core.utils import eprint
 
 logger = logging.getLogger(__name__)
 
+CLIENT_ID = "deriva-py"
 
-# Default resource hint for service/M2M introspection calls when the caller
+# Default resource hint for token introspection calls when the caller
 # doesn't provide any explicit --resource values. This is an umbrella resource
 # and will only succeed if the token was minted to include it.
 DEFAULT_SERVICE_RESOURCE = "urn:deriva:rest:service:all"
 
-# Required as the grant_type when requesting a service token from Credenza
-CREDENZA_SERVICE_AUTH_URN = "urn:credenza:service:auth"
+# Possible grant_type values for use with Credenza auth requests
+AUTHORIZATION_CODE_GRANT    = "authorization_code"
+CLIENT_CREDENTIALS_GRANT    = "client_credentials"
+TOKEN_EXCHANGE_GRANT        = "urn:ietf:params:oauth:grant-type:token-exchange"
+DEVICE_CODE_GRANT           = "urn:ietf:params:oauth:grant-type:device_code"
+
+# Where we request tokens when authenticating as confidential client
+TOKEN_ENDPOINT_PATH = "/authn/token"
 
 
 def host_to_url(host, path="/", protocol="https"):
@@ -57,8 +65,8 @@ class UsageException(ValueError):
         super(UsageException, self).__init__(message)
 
 
-class ServiceAuthClient:
-    """Interface for client-side service-auth methods."""
+class ConfidentialClient:
+    """Interface for Confidential Client auth methods."""
 
     def name(self):
         raise NotImplementedError
@@ -78,18 +86,18 @@ class ServiceAuthClient:
         raise NotImplementedError
 
 
-_SERVICE_AUTH_CLIENTS = {}  # name -> instance
+_CONFIDENTIAL_CLIENTS = {}  # name -> instance
 
 
-def register_service_auth_client(adapter: ServiceAuthClient):
-    _SERVICE_AUTH_CLIENTS[adapter.name()] = adapter
+def register_confidential_client(adapter: ConfidentialClient):
+    _CONFIDENTIAL_CLIENTS[adapter.name()] = adapter
 
 
-def get_service_auth_client(name):
+def get_confidential_client(name):
     try:
-        return _SERVICE_AUTH_CLIENTS[name]
+        return _CONFIDENTIAL_CLIENTS[name]
     except KeyError:
-        raise UsageException(f"Unknown auth method: {name}. Available: {', '.join(sorted(_SERVICE_AUTH_CLIENTS))}")
+        raise UsageException(f"Unknown auth method: {name}. Available: {', '.join(sorted(_CONFIDENTIAL_CLIENTS))}")
 
 def add_argument_once(parser, *option_strings, **kwargs):
     """
@@ -103,7 +111,7 @@ def add_argument_once(parser, *option_strings, **kwargs):
     parser.add_argument(*option_strings, **kwargs)
 
 
-class AwsPresignedClient(ServiceAuthClient):
+class AwsPresignedClient(ConfidentialClient):
     def name(self):
         return "aws_presigned"
 
@@ -112,10 +120,13 @@ class AwsPresignedClient(ServiceAuthClient):
                        help="STS signing region (default: us-west-2).")
         parser.add_argument("--aws-expires", type=int, default=60,
                        help="Presigned URL validity seconds (default: 60).")
+        parser.add_argument("--client-id", help="The client ID. Defaults to %s" % CLIENT_ID, default=CLIENT_ID)
 
     def prepare(self, session, form, **kwargs):
         aws_region = kwargs.get("aws_region", "us-west-2")
         aws_expires = int(kwargs.get("aws_expires", 60))
+        client_id = kwargs.get("client_id")
+        form.append(("client_id", client_id))
         try:
             from botocore.session import get_session
             from botocore.awsrequest import AWSRequest
@@ -133,9 +144,10 @@ class AwsPresignedClient(ServiceAuthClient):
             HttpMethod="GET",
         )
         form.append(("subject_token", url))
-        logger.debug("Successfully generated AWS presigned GetCallerIdentity URL: %s" % url)
+        logger.debug(
+            "Successfully generated AWS presigned GetCallerIdentity for client_id %s. URL: %s" % (client_id, url))
 
-class ClientSecretBasicClient(ServiceAuthClient):
+class ClientSecretBasicClient(ConfidentialClient):
     def name(self):
         return "client_secret_basic"
 
@@ -148,14 +160,14 @@ class ClientSecretBasicClient(ServiceAuthClient):
         client_secret = kwargs.get("client_secret")
         if not client_id or client_secret is None:
             raise UsageException("client_secret_basic requires client_id and client_secret.")
-        import base64
+
         b64 = base64.b64encode(f"{client_id}:{client_secret}".encode("utf-8")).decode("ascii")
         session.headers.update({"Authorization": f"Basic {b64}"})
         # Optional hint; server detects Basic regardless:
         form.append(("auth_method", "client_secret_basic"))
 
 
-class ClientSecretPostClient(ServiceAuthClient):
+class ClientSecretPostClient(ConfidentialClient):
     def name(self):
         return "client_secret_post"
 
@@ -176,9 +188,9 @@ class ClientSecretPostClient(ServiceAuthClient):
 
 
 # Register built-ins at import time so CLI choices are populated
-register_service_auth_client(AwsPresignedClient())
-register_service_auth_client(ClientSecretBasicClient())
-register_service_auth_client(ClientSecretPostClient())
+register_confidential_client(AwsPresignedClient())
+register_confidential_client(ClientSecretBasicClient())
+register_confidential_client(ClientSecretPostClient())
 
 
 class CredenzaAuthUtil:
@@ -288,25 +300,25 @@ class CredenzaAuthUtil:
             return None
 
 
-    def issue_service_token(self,
-                            host: str,
-                            resources = None,
-                            *,
-                            auth_method,
-                            scope = None,
-                            requested_ttl_seconds = None,
-                            no_bdbag_keychain= False,
-                            bdbag_keychain_file = None,
-                            **method_kwargs):
+    def service_login(self,
+                     host: str,
+                     *,
+                     auth_method,
+                     resources=None,
+                     scope = None,
+                     requested_ttl_seconds = None,
+                     no_bdbag_keychain= False,
+                     bdbag_keychain_file = None,
+                     **method_kwargs):
         """
-        Issue a service/M2M token via /authn/service/token.
+        Issue a service/M2M token via /authn/token.
 
         """
-        base = host_to_url(host, "/authn/service/token")
+        base = host_to_url(host, TOKEN_ENDPOINT_PATH)
         session = get_new_requests_session(base)
 
         # Common body
-        form = [("grant_type", CREDENZA_SERVICE_AUTH_URN)]
+        form = [("grant_type", CLIENT_CREDENTIALS_GRANT)]
         # Default to umbrella resource if caller omitted resources
         resources = resources or [DEFAULT_SERVICE_RESOURCE]
         for r in resources:
@@ -317,7 +329,7 @@ class CredenzaAuthUtil:
             form.append(("requested_ttl_seconds", str(int(requested_ttl_seconds))))
 
         # Delegate method-specific preparation
-        adapter = get_service_auth_client(auth_method)
+        adapter = get_confidential_client(auth_method)
         adapter.prepare(session, form, **method_kwargs)
 
         resp = session.post(base, data=form)
@@ -352,7 +364,7 @@ class CredenzaAuthUtilCLI(BaseCLI):
         self.get_session_init()
         self.put_session_init()
         self.show_token_init()
-        self.service_token_init()
+        self.service_login_init()
 
 
     def login_init(self):
@@ -369,6 +381,11 @@ class CredenzaAuthUtilCLI(BaseCLI):
                             help="Force a login flow even if the current access token is valid.")
         parser.add_argument("--show-token", action="store_true",
                             help="Display the token from the authorization response.")
+        parser.add_argument("--scope", metavar='<scope>',
+                            help="Space-delimited scope string to request at device authorization time.")
+        parser.add_argument("--resource", dest="resource", action="append", default=SUPPRESS,
+                            metavar='<resource>',
+                            help="Resource URI to request (repeatable). Server policy applies if omitted.")
         parser.set_defaults(func=self.login)
 
 
@@ -414,10 +431,10 @@ class CredenzaAuthUtilCLI(BaseCLI):
         parser.set_defaults(func=self.show_token)
 
 
-    def service_token_init(self):
+    def service_login_init(self):
         parser = self.subparsers.add_parser(
-            "service-token",
-            help="Issue a service/M2M token via /authn/service/token using a pluggable auth method."
+            "service-login",
+            help=f"Authenticate as a service/M2M client via {TOKEN_ENDPOINT_PATH} and store the resulting token."
         )
         parser.add_argument(
             "--resource", dest="resource", action="append", default=SUPPRESS,
@@ -430,16 +447,15 @@ class CredenzaAuthUtilCLI(BaseCLI):
                             help="Display the token from the authorization response.")
         # Method selection
         parser.add_argument("--auth-method",
-                       choices=sorted(_SERVICE_AUTH_CLIENTS) or ["aws_presigned", "client_secret_basic",
-                                                                 "client_secret_post"],
-                       required=True,
-                       help="Service auth method to use.")
+                            choices=sorted(_CONFIDENTIAL_CLIENTS),
+                            required=True,
+                            help="Service auth method to use.")
 
         # Each adapter contributes its own flags
-        for adapter in _SERVICE_AUTH_CLIENTS.values():
+        for adapter in _CONFIDENTIAL_CLIENTS.values():
             adapter.add_cli_args(parser)
 
-        parser.set_defaults(func=self.service_token)
+        parser.set_defaults(func=self.service_login)
 
 
     def _api(self):
@@ -485,12 +501,16 @@ class CredenzaAuthUtilCLI(BaseCLI):
                 token_display = f"Bearer token: {token}" if args.show_token else ""
                 return f"You are already logged in to host '{args.host}'. {token_display}"
 
-        path = "/authn/device/start"
-        if args.refresh:
-            path += "?refresh=true"
-        url = host_to_url(args.host, path)
+        url = host_to_url(args.host, "/authn/device_authorization")
         session = get_new_requests_session(url)
-        response = session.post(url)
+        form = [("client_id", CLIENT_ID)]
+        if args.refresh:
+            form.append(("refresh", "true"))
+        if getattr(args, "scope", None):
+            form.append(("scope", args.scope))
+        for r in getattr(args, "resource", []):
+            form.append(("resource", r))
+        response = session.post(url, data=form)
         response.raise_for_status()
         body = response.json()
         verification_url = body["verification_uri"]
@@ -521,8 +541,12 @@ class CredenzaAuthUtilCLI(BaseCLI):
             return f"Login cancelled for '{args.host}'."
 
         token_response = session.post(
-            f"https://{args.host}/authn/device/token",
-            json={"device_code": body["device_code"]}
+            host_to_url(args.host, TOKEN_ENDPOINT_PATH),
+            data=[
+                ("grant_type",  DEVICE_CODE_GRANT),
+                ("client_id",   CLIENT_ID),
+                ("device_code", body["device_code"]),
+            ]
         )
         token_response.raise_for_status()
         body = token_response.json()
@@ -542,13 +566,12 @@ class CredenzaAuthUtilCLI(BaseCLI):
         if not credential:
             return "Credential not found. Not logged in."
         token = credential.get("bearer-token")
-        auth_type = credential.get("auth_type", "user")
 
-        url_path = "/authn/service/token" if auth_type == "service" else "/authn/device/logout"
-        url = host_to_url(args.host, url_path)
+        # RFC 7009: token and client_id go in the form body; no Authorization header.
+        # Public clients (like deriva-py) only need to supply client_id.
+        url = host_to_url(args.host, "/authn/revoke")
         session = get_new_requests_session(url)
-        session.headers.update({"Authorization": f"Bearer {token}"})
-        response = session.delete(url) if auth_type == "service" else session.post(url)
+        response = session.post(url, data=[("token", token), ("client_id", CLIENT_ID)])
         response.raise_for_status()
 
         self._api().save_credential(args.host, None)
@@ -561,7 +584,7 @@ class CredenzaAuthUtilCLI(BaseCLI):
         return f"Successfully logged out of host '{args.host}'."
 
 
-    def service_token(self, args):
+    def service_login(self, args):
         kw = vars(args).copy()
         host = kw.pop("host")
         resources = None
@@ -574,23 +597,25 @@ class CredenzaAuthUtilCLI(BaseCLI):
         credential_file = kw.pop("credential_file", None)  # honored by API init, not per-call
         bdbag_keychain_file = kw.pop("bdbag_keychain_file", None)
 
+
         if credential_file and (self.api is None or self.api.credential_file != credential_file):
             self.api = CredenzaAuthUtil(credential_file)
 
-        response = self._api().issue_service_token(
+        response = self._api().service_login(
             host,
-            resources,
             auth_method=auth_method,
             scope=scope,
+            resources=resources,
             requested_ttl_seconds=requested_ttl_seconds,
             no_bdbag_keychain=no_bdbag_keychain,
             bdbag_keychain_file=bdbag_keychain_file,
             **kw  # remaining CLI params become method_kwargs for adapters
         )
         token = response["access_token"]
-        token_display = f"Bearer token: {token}" if args.show_token else ""
+        token_type = response["token_type"]
+        token_display = f"Token: {token}" if args.show_token else ""
 
-        return f"Service API token granted by host '{args.host}'. {token_display}"
+        return f"Access token ({token_type}) granted by host '{args.host}'. {token_display}"
 
 
     def main(self):

--- a/deriva/transfer/download/processors/query/base_query_processor.py
+++ b/deriva/transfer/download/processors/query/base_query_processor.py
@@ -39,6 +39,8 @@ class BaseQueryProcessor(BaseProcessor):
         self.paged_query = self.parameters.get("paged_query", False)
         self.paged_query_size = self.parameters.get("paged_query_size", 100000)
         self.paged_query_sort_columns = self.parameters.get("paged_query_sort_columns", ["RID"])
+        self.rid_set = self.parameters.get("rid_set", None)
+        self.rid_table = self.parameters.get("rid_table", None)
 
     def process(self):
         resp = self.catalogQuery(headers={'accept': self.content_type})
@@ -58,7 +60,10 @@ class BaseQueryProcessor(BaseProcessor):
         return self.outputs
 
     def catalogQuery(self, headers=None, as_file=True):
-        if not self.query:
+        # A rid_set-bearing processor (Format B) carries no query_path —
+        # get_as_file ignores ``self.query`` and fetches by RID set. Only
+        # short-circuit when there is NEITHER a query path NOR a rid_set.
+        if not self.query and not self.rid_set:
             return {}
 
         if not headers:
@@ -77,7 +82,9 @@ class BaseQueryProcessor(BaseProcessor):
                                                 delete_if_empty=True,
                                                 paged=self.paged_query,
                                                 page_size=self.paged_query_size,
-                                                page_sort_columns=self.paged_query_sort_columns)
+                                                page_sort_columns=self.paged_query_sort_columns,
+                                                rid_set=self.rid_set,
+                                                rid_table=self.rid_table)
             else:
                 return self.catalog.get(self.query, headers=headers).json()
         except requests.HTTPError as e:

--- a/deriva/transfer/upload/deriva_upload.py
+++ b/deriva/transfer/upload/deriva_upload.py
@@ -88,7 +88,8 @@ class DerivaUpload(object):
     DefaultTransferStateBaseName = ".deriva-upload-state"
     DefaultTransferStateFileName = "%s-%s.json"
 
-    def __init__(self, config_file=None, credential_file=None, server=None, dcctx_cid=None):
+    def __init__(self, config_file=None, credential_file=None, server=None, dcctx_cid=None,
+                 session_config_overrides=None, chunk_size=None):
         self.server_url = None
         self.catalog = None
         self.catalog_model = None
@@ -109,6 +110,11 @@ class DerivaUpload(object):
         self.skipped_files = set()
         self.override_config_file = config_file
         self.override_credential_file = credential_file
+        # Instance-level overrides that take precedence over server/deployed configuration without mutating it.
+        # session_config_overrides: dict shallow-merged onto the resolved session config (e.g. {"timeout": [120, 120]}).
+        # chunk_size_override: integer byte count that overrides any per-asset-mapping hatrac_options.chunk_size value.
+        self.session_config_overrides = session_config_overrides
+        self.chunk_size_override = chunk_size
         self.server = self.getDefaultServer() if not server else server
         self.dcctx_cid = dcctx_cid if dcctx_cid else self.__class__.__name__
         signal.signal(signal.SIGINT, self.interrupt_handler)
@@ -144,6 +150,10 @@ class DerivaUpload(object):
         self.server_url = protocol + "://" + host
         catalog_id = self.server.get("catalog_id", "1")
         session_config = self.server.get('session', DEFAULT_SESSION_CONFIG.copy())
+        # Apply any instance-level session config overrides (e.g. a longer timeout for slow/high-latency networks).
+        # Merge into a new dict so the underlying server/default config object is never mutated.
+        if self.session_config_overrides:
+            session_config = {**session_config, **self.session_config_overrides}
         # default credential initialization
         self.credentials = get_credential(host, self.override_credential_file or DEFAULT_CREDENTIAL_FILE)
 
@@ -695,7 +705,11 @@ class DerivaUpload(object):
         # 6. Perform the Hatrac upload
         self._getFileHatracMetadata(asset_mapping)
         hatrac_options = asset_mapping.get("hatrac_options", {})
-        v = hatrac_options.get("chunk_size")
+        # An instance-level chunk_size override takes precedence over any per-asset-mapping configured value.
+        if self.chunk_size_override is not None:
+            v = self.chunk_size_override
+        else:
+            v = hatrac_options.get("chunk_size")
         try:
             chunk_size = int(v) if v not in (None, "") else DEFAULT_CHUNK_SIZE
         except (TypeError, ValueError):
@@ -705,6 +719,9 @@ class DerivaUpload(object):
             logger.warning(
                 "Specified chunk_size must be a positive integer (> 0) - falling back to default chunk size: %d." %
                 DEFAULT_CHUNK_SIZE)
+        # The threshold for switching to chunked (resumable) upload normally tracks the default chunk size, but when an
+        # explicit override is supplied, honor it so that files larger than the override are still chunked.
+        chunked_threshold = chunk_size if self.chunk_size_override is not None else DEFAULT_CHUNK_SIZE
         file_size = self.metadata["file_size"]
         versioned_uri = \
             self._hatracUpload(self.metadata["URI"],
@@ -713,7 +730,7 @@ class DerivaUpload(object):
                                sha256=self.metadata.get("sha256_base64"),
                                content_type=self.guessContentType(file_path),
                                content_disposition=self.metadata.get("content-disposition"),
-                               chunked=True if (file_size > DEFAULT_CHUNK_SIZE or file_size == 0) else False,
+                               chunked=True if (file_size > chunked_threshold or file_size == 0) else False,
                                chunk_size=chunk_size,
                                create_parents=stob(hatrac_options.get("create_parents", True)),
                                allow_versioning=stob(hatrac_options.get("allow_versioning", True)),
@@ -1301,12 +1318,15 @@ class DerivaUpload(object):
 
 class GenericUploader(DerivaUpload):
 
-    def __init__(self, config_file=None, credential_file=None, server=None, dcctx_cid=None):
+    def __init__(self, config_file=None, credential_file=None, server=None, dcctx_cid=None,
+                 session_config_overrides=None, chunk_size=None):
         DerivaUpload.__init__(self,
                               config_file=config_file,
                               credential_file=credential_file,
                               server=server,
-                              dcctx_cid=dcctx_cid)
+                              dcctx_cid=dcctx_cid,
+                              session_config_overrides=session_config_overrides,
+                              chunk_size=chunk_size)
 
     @classmethod
     def getVersion(cls):

--- a/deriva/transfer/upload/deriva_upload_cli.py
+++ b/deriva/transfer/upload/deriva_upload_cli.py
@@ -4,7 +4,8 @@ import json
 import traceback
 from deriva.transfer import DerivaUpload, DerivaUploadError, DerivaUploadConfigurationError, \
     DerivaUploadCatalogCreateError, DerivaUploadCatalogUpdateError, DerivaUploadAuthenticationError
-from deriva.core import BaseCLI, write_config, format_credential, format_exception, urlparse
+from deriva.core import BaseCLI, write_config, format_credential, format_exception, urlparse, \
+    DEFAULT_REQUESTS_TIMEOUT
 
 
 class DerivaUploadCLI(BaseCLI):
@@ -25,6 +26,16 @@ class DerivaUploadCLI(BaseCLI):
                                  help="Optional path where a JSON-formatted output file will be written, "
                                       "containing file upload status and associated metadata.")
         self.parser.add_argument("--catalog", default=1, metavar="<1>", help="Catalog number. Default: 1")
+        self.parser.add_argument("--connect-timeout", type=float, metavar="<seconds>",
+                                 help="Override the connection timeout, in seconds (default: %d). For uploads this "
+                                      "also bounds the time allowed to write each request body / chunk, so increase "
+                                      "it for slow or high-latency networks." % DEFAULT_REQUESTS_TIMEOUT[0])
+        self.parser.add_argument("--read-timeout", type=float, metavar="<seconds>",
+                                 help="Override the read (response) timeout, in seconds (default: %d)."
+                                      % DEFAULT_REQUESTS_TIMEOUT[1])
+        self.parser.add_argument("--chunk-size", type=int, metavar="<bytes>",
+                                 help="Override the chunked-upload chunk size, in bytes. Smaller chunks reduce the "
+                                      "amount of data resent on retry over unreliable networks.")
         self.parser.add_argument("path", metavar="<input dir>", help="Path to an input directory.")
         self.uploader = uploader
 
@@ -39,7 +50,10 @@ class DerivaUploadCLI(BaseCLI):
                no_update=False,
                purge=False,
                dry_run=False,
-               output_file=None):
+               output_file=None,
+               connect_timeout=None,
+               read_timeout=None,
+               chunk_size=None):
 
         if not issubclass(uploader, DerivaUpload):
             raise TypeError("DerivaUpload subclass required")
@@ -55,7 +69,18 @@ class DerivaUploadCLI(BaseCLI):
             server["protocol"] = "https"
             server["host"] = hostname
 
-        deriva_uploader = uploader(config_file, credential_file, server, dcctx_cid="cli/" + DerivaUploadCLI.__name__)
+        # Build session config overrides from any supplied timeout values, falling back to the library defaults for the
+        # component(s) not specified. These are applied per-invocation and do not modify the server/deployed config.
+        session_config_overrides = None
+        if connect_timeout is not None or read_timeout is not None:
+            default_connect, default_read = DEFAULT_REQUESTS_TIMEOUT
+            session_config_overrides = {
+                "timeout": [connect_timeout if connect_timeout is not None else default_connect,
+                            read_timeout if read_timeout is not None else default_read]
+            }
+
+        deriva_uploader = uploader(config_file, credential_file, server, dcctx_cid="cli/" + DerivaUploadCLI.__name__,
+                                   session_config_overrides=session_config_overrides, chunk_size=chunk_size)
         if token:
             deriva_uploader.setCredentials(format_credential(token))
         if not config_file and not no_update:
@@ -93,7 +118,10 @@ class DerivaUploadCLI(BaseCLI):
                                    args.no_config_update,
                                    args.purge_state,
                                    args.dry_run,
-                                   args.output_file)
+                                   args.output_file,
+                                   args.connect_timeout,
+                                   args.read_timeout,
+                                   args.chunk_size)
         except (RuntimeError, FileNotFoundError, DerivaUploadError, DerivaUploadConfigurationError,
                 DerivaUploadCatalogCreateError, DerivaUploadCatalogUpdateError, DerivaUploadAuthenticationError) as e:
             sys.stderr.write(("\n" if not args.quiet else "") + format_exception(e))

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,8 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.12'
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14'
     ]
 )

--- a/tests/deriva/core/test_csv_paging.py
+++ b/tests/deriva/core/test_csv_paging.py
@@ -1,0 +1,141 @@
+"""Tests for CSV paging with multi-line quoted fields.
+
+Verifies that _read_last_csv_record correctly extracts the last complete
+CSV record from files containing multi-line quoted fields (RFC 4180),
+which previously caused an infinite paging loop in get_as_file().
+"""
+
+import csv
+import io
+import os
+import tempfile
+
+from deriva.core.ermrest_catalog import ErmrestCatalog
+
+
+def _write_csv(filepath, header, rows):
+    """Write rows to a CSV file with proper quoting."""
+    with open(filepath, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(header)
+        writer.writerows(rows)
+
+
+class TestReadLastCsvRecord:
+    """Test _read_last_csv_record handles multi-line quoted fields."""
+
+    def test_simple_single_line_records(self):
+        """Basic case: all fields are single-line."""
+        header = ["RID", "Name", "Value"]
+        rows = [
+            ["2-ABC", "Alice", "100"],
+            ["2-DEF", "Bob", "200"],
+            ["2-GHI", "Carol", "300"],
+        ]
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            filepath = f.name
+        try:
+            _write_csv(filepath, header, rows)
+            result = ErmrestCatalog._read_last_csv_record(filepath, header)
+            assert result["RID"] == "2-GHI"
+            assert result["Name"] == "Carol"
+            assert result["Value"] == "300"
+        finally:
+            os.unlink(filepath)
+
+    def test_multiline_quoted_field(self):
+        """Fields with embedded newlines must not break last-record detection."""
+        header = ["RID", "Name", "Notes"]
+        rows = [
+            ["2-ABC", "Alice", "Line 1\nLine 2\nLine 3"],
+            ["2-DEF", "Bob", "Simple note"],
+            ["2-GHI", "Carol", "Grid data:\n  1  2  3\n  4  5  6\n  7  8  9"],
+        ]
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            filepath = f.name
+        try:
+            _write_csv(filepath, header, rows)
+            result = ErmrestCatalog._read_last_csv_record(filepath, header)
+            assert result["RID"] == "2-GHI"
+            assert result["Name"] == "Carol"
+            assert "Grid data:" in result["Notes"]
+        finally:
+            os.unlink(filepath)
+
+    def test_large_multiline_field(self):
+        """Very large multi-line fields (simulating OCR visual field grids)."""
+        header = ["RID", "Data", "Side"]
+        # Simulate OCR data with a large grid (~100KB per record)
+        large_grid = "\n".join(
+            "  ".join(f"{x:3d}" for x in range(i * 10, i * 10 + 10))
+            for i in range(1000)
+        )
+        rows = [
+            ["2-AAA", "small", "Left"],
+            ["2-BBB", large_grid, "Right"],
+            ["2-CCC", large_grid, "Left"],
+        ]
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            filepath = f.name
+        try:
+            _write_csv(filepath, header, rows)
+            result = ErmrestCatalog._read_last_csv_record(filepath, header)
+            assert result["RID"] == "2-CCC"
+            assert result["Side"] == "Left"
+        finally:
+            os.unlink(filepath)
+
+    def test_empty_file(self):
+        """Empty file returns empty dict."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            filepath = f.name
+        try:
+            result = ErmrestCatalog._read_last_csv_record(filepath, ["RID", "Name"])
+            assert result == {}
+        finally:
+            os.unlink(filepath)
+
+    def test_header_only_file(self):
+        """File with only a header row returns empty dict."""
+        header = ["RID", "Name"]
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            filepath = f.name
+        try:
+            _write_csv(filepath, header, [])
+            result = ErmrestCatalog._read_last_csv_record(filepath, header)
+            # The header line gets parsed as a data row mapping header[0]->"RID"
+            # which is a valid-looking record, but there's no real data
+            assert result == {} or result.get("RID") == "RID"
+        finally:
+            os.unlink(filepath)
+
+    def test_single_data_row(self):
+        """File with exactly one data row."""
+        header = ["RID", "Name"]
+        rows = [["2-XYZ", "Only"]]
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            filepath = f.name
+        try:
+            _write_csv(filepath, header, rows)
+            result = ErmrestCatalog._read_last_csv_record(filepath, header)
+            assert result["RID"] == "2-XYZ"
+            assert result["Name"] == "Only"
+        finally:
+            os.unlink(filepath)
+
+    def test_field_with_commas_and_quotes(self):
+        """Fields with commas and escaped quotes."""
+        header = ["RID", "Description", "Value"]
+        rows = [
+            ["2-AAA", 'He said "hello, world"', "100"],
+            ["2-BBB", "Line 1,\nLine 2,\nLine 3", "200"],
+        ]
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            filepath = f.name
+        try:
+            _write_csv(filepath, header, rows)
+            result = ErmrestCatalog._read_last_csv_record(filepath, header)
+            assert result["RID"] == "2-BBB"
+            assert result["Value"] == "200"
+        finally:
+            os.unlink(filepath)

--- a/tests/deriva/core/test_csv_paging.py
+++ b/tests/deriva/core/test_csv_paging.py
@@ -1,141 +1,167 @@
-"""Tests for CSV paging with multi-line quoted fields.
+"""Tests for CSV paging with multi-line quoted fields (no live catalog).
 
-Verifies that _read_last_csv_record correctly extracts the last complete
-CSV record from files containing multi-line quoted fields (RFC 4180),
-which previously caused an infinite paging loop in get_as_file().
+The paged CSV path in ``get_as_file`` builds the ``@after()`` cursor for the
+next page from the last complete record of the current page. The record is
+recovered by parsing the page's data lines forward with the csv module, which
+tracks quote state across embedded newlines (RFC 4180). Taking the last raw
+``\\n``-delimited line instead would, for a record whose quoted field contains
+a newline, yield a fragment -> a wrong cursor -> skipped rows or an infinite
+re-fetch loop. These tests drive ``get_as_file`` through mocked paged
+responses and assert the cursor is byte-exact, including when a multi-line
+quoted field straddles a page boundary.
 """
 
 import csv
 import io
 import os
 import tempfile
+from unittest.mock import MagicMock
 
 from deriva.core.ermrest_catalog import ErmrestCatalog
 
 
-def _write_csv(filepath, header, rows):
-    """Write rows to a CSV file with proper quoting."""
-    with open(filepath, "w", newline="", encoding="utf-8") as f:
-        writer = csv.writer(f)
-        writer.writerow(header)
-        writer.writerows(rows)
+def _csv(header, rows):
+    """Render a CSV body (header + rows) with RFC 4180 quoting."""
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(header)
+    writer.writerows(rows)
+    return buf.getvalue()
 
 
-class TestReadLastCsvRecord:
-    """Test _read_last_csv_record handles multi-line quoted fields."""
+class _FakeResponse:
+    """Minimal requests.Response stand-in for one CSV page."""
 
-    def test_simple_single_line_records(self):
-        """Basic case: all fields are single-line."""
-        header = ["RID", "Name", "Value"]
-        rows = [
-            ["2-ABC", "Alice", "100"],
-            ["2-DEF", "Bob", "200"],
-            ["2-GHI", "Carol", "300"],
-        ]
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
-            filepath = f.name
-        try:
-            _write_csv(filepath, header, rows)
-            result = ErmrestCatalog._read_last_csv_record(filepath, header)
-            assert result["RID"] == "2-GHI"
-            assert result["Name"] == "Carol"
-            assert result["Value"] == "300"
-        finally:
-            os.unlink(filepath)
+    def __init__(self, text):
+        self._text = text
+        self.status_code = 200
+        self.headers = {"Content-Type": "text/csv"}
 
-    def test_multiline_quoted_field(self):
-        """Fields with embedded newlines must not break last-record detection."""
-        header = ["RID", "Name", "Notes"]
-        rows = [
-            ["2-ABC", "Alice", "Line 1\nLine 2\nLine 3"],
-            ["2-DEF", "Bob", "Simple note"],
-            ["2-GHI", "Carol", "Grid data:\n  1  2  3\n  4  5  6\n  7  8  9"],
-        ]
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
-            filepath = f.name
-        try:
-            _write_csv(filepath, header, rows)
-            result = ErmrestCatalog._read_last_csv_record(filepath, header)
-            assert result["RID"] == "2-GHI"
-            assert result["Name"] == "Carol"
-            assert "Grid data:" in result["Notes"]
-        finally:
-            os.unlink(filepath)
+    def __enter__(self):
+        return self
 
-    def test_large_multiline_field(self):
-        """Very large multi-line fields (simulating OCR visual field grids)."""
-        header = ["RID", "Data", "Side"]
-        # Simulate OCR data with a large grid (~100KB per record)
-        large_grid = "\n".join(
-            "  ".join(f"{x:3d}" for x in range(i * 10, i * 10 + 10))
-            for i in range(1000)
+    def __exit__(self, *a):
+        return False
+
+    def close(self):
+        pass
+
+    def iter_lines(self, decode_unicode=False):
+        # Split on physical newlines, exactly like requests' iter_lines -- a
+        # quoted field containing a newline is therefore split across yields,
+        # which is the hazard get_as_file's forward parse must absorb.
+        for line in self._text.split("\n"):
+            if line == "" and self._text.endswith("\n"):
+                continue
+            yield line if decode_unicode else line.encode("utf-8")
+
+    @property
+    def text(self):
+        return self._text
+
+
+def _run_paged_get(pages, page_sort_columns=frozenset(["RID"])):
+    """Drive get_as_file in paged CSV mode against a scripted page sequence.
+
+    ``pages`` is a list of CSV bodies returned in order. The cursor each page
+    yields is captured from the outgoing ``@after(...)`` URL so the test can
+    assert it is the real last record, not a fragment.
+    """
+    cat = ErmrestCatalog.__new__(ErmrestCatalog)
+    cat._server_uri = "https://example.org/ermrest/catalog/1"
+
+    seen_after = []
+    state = {"i": 0}
+
+    def fake_get(url, headers=None, stream=False):
+        if "@after" in url:
+            after = url.split("@after(")[1].split(")")[0]
+            seen_after.append(after)
+        idx = state["i"]
+        state["i"] += 1
+        if idx < len(pages):
+            return _FakeResponse(pages[idx])
+        # Past the last scripted page: empty page (header only) ends the loop.
+        return _FakeResponse(pages[-1].split("\n")[0] + "\n")
+
+    cat._session = MagicMock()
+    cat._session.get.side_effect = fake_get
+    cat._response_raise_for_status = lambda r: None
+
+    fd, path = tempfile.mkstemp(suffix=".csv")
+    os.close(fd)
+    try:
+        cat.get_as_file(
+            "/entity/S:T", path,
+            headers={"accept": "text/csv"},
+            paged=True, page_size=10,
+            page_sort_columns=page_sort_columns,
         )
-        rows = [
-            ["2-AAA", "small", "Left"],
-            ["2-BBB", large_grid, "Right"],
-            ["2-CCC", large_grid, "Left"],
-        ]
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
-            filepath = f.name
-        try:
-            _write_csv(filepath, header, rows)
-            result = ErmrestCatalog._read_last_csv_record(filepath, header)
-            assert result["RID"] == "2-CCC"
-            assert result["Side"] == "Left"
-        finally:
-            os.unlink(filepath)
+        with open(path, "r", newline="", encoding="utf-8") as f:
+            written = f.read()
+    finally:
+        os.unlink(path)
+    return seen_after, written
 
-    def test_empty_file(self):
-        """Empty file returns empty dict."""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
-            filepath = f.name
-        try:
-            result = ErmrestCatalog._read_last_csv_record(filepath, ["RID", "Name"])
-            assert result == {}
-        finally:
-            os.unlink(filepath)
 
-    def test_header_only_file(self):
-        """File with only a header row returns empty dict."""
-        header = ["RID", "Name"]
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
-            filepath = f.name
-        try:
-            _write_csv(filepath, header, [])
-            result = ErmrestCatalog._read_last_csv_record(filepath, header)
-            # The header line gets parsed as a data row mapping header[0]->"RID"
-            # which is a valid-looking record, but there's no real data
-            assert result == {} or result.get("RID") == "RID"
-        finally:
-            os.unlink(filepath)
+def test_cursor_from_simple_single_line_records():
+    """Plain single-line rows: cursor is the last row's RID."""
+    header = ["RID", "Name", "Value"]
+    page = _csv(header, [["2-ABC", "Alice", "100"],
+                         ["2-DEF", "Bob", "200"],
+                         ["2-GHI", "Carol", "300"]])
+    seen_after, _ = _run_paged_get([page])
+    assert seen_after[0] == "2-GHI"
 
-    def test_single_data_row(self):
-        """File with exactly one data row."""
-        header = ["RID", "Name"]
-        rows = [["2-XYZ", "Only"]]
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
-            filepath = f.name
-        try:
-            _write_csv(filepath, header, rows)
-            result = ErmrestCatalog._read_last_csv_record(filepath, header)
-            assert result["RID"] == "2-XYZ"
-            assert result["Name"] == "Only"
-        finally:
-            os.unlink(filepath)
 
-    def test_field_with_commas_and_quotes(self):
-        """Fields with commas and escaped quotes."""
-        header = ["RID", "Description", "Value"]
-        rows = [
-            ["2-AAA", 'He said "hello, world"', "100"],
-            ["2-BBB", "Line 1,\nLine 2,\nLine 3", "200"],
-        ]
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
-            filepath = f.name
-        try:
-            _write_csv(filepath, header, rows)
-            result = ErmrestCatalog._read_last_csv_record(filepath, header)
-            assert result["RID"] == "2-BBB"
-            assert result["Value"] == "200"
-        finally:
-            os.unlink(filepath)
+def test_cursor_with_multiline_quoted_last_field():
+    """A multi-line quoted field in the LAST record must not corrupt the cursor."""
+    header = ["RID", "Name", "Notes"]
+    page = _csv(header, [["2-ABC", "Alice", "Simple"],
+                         ["2-GHI", "Carol", "Grid:\n 1 2 3\n 4 5 6\n 7 8 9"]])
+    seen_after, _ = _run_paged_get([page])
+    # Wrong (raw-last-line) behavior would yield "9" or "" here, not the RID.
+    assert seen_after[0] == "2-GHI"
+
+
+def test_cursor_when_quoted_field_straddles_page_boundary():
+    """REGRESSION (Mike D'Arcy review on #274): the record this PR exists to
+    handle is one whose quoted multi-line field is large. Each page is parsed
+    forward from its own header, so the embedded newlines reassemble into one
+    record and the cursor is the record's real RID -- never a front-truncated
+    fragment of the quoted field.
+    """
+    header = ["RID", "Data", "Side"]
+    big = "\n".join("  ".join(f"{x:3d}" for x in range(i * 10, i * 10 + 10))
+                    for i in range(2000))  # ~140 KB quoted field
+    # Page 1 ends on the big-field record; page 2 has plain rows then ends.
+    page1 = _csv(header, [["2-AAA", "small", "Left"],
+                          ["2-BBB", big, "Right"]])
+    page2 = _csv(header, [["2-CCC", "small", "Left"],
+                          ["2-DDD", "small", "Right"]])
+    seen_after, written = _run_paged_get([page1, page2])
+    assert seen_after[0] == "2-BBB"   # not a fragment of the grid
+    assert seen_after[1] == "2-DDD"
+    # The on-disk file must contain the big field intact (bytes preserved).
+    assert big.split("\n")[-1] in written
+
+
+def test_cursor_honors_non_rid_sort_column():
+    """Cursor must use page_sort_columns, not a hardcoded RID, so paging by a
+    different column still produces the right @after value.
+    """
+    header = ["RID", "Name", "Seq"]
+    page = _csv(header, [["2-ABC", "Alice", "001"],
+                         ["2-DEF", "Bob", "002"]])
+    seen_after, _ = _run_paged_get([page], page_sort_columns=["Seq"])
+    assert seen_after[0] == "002"
+
+
+def test_empty_page_terminates_without_cursor():
+    """A header-only page yields no data rows, so paging stops and no @after
+    cursor is built from a phantom record (which would loop forever).
+    """
+    header = ["RID", "Name"]
+    page = _csv(header, [])  # header only
+    seen_after, _ = _run_paged_get([page])
+    assert seen_after == []

--- a/tests/deriva/core/test_rid_set_fetch.py
+++ b/tests/deriva/core/test_rid_set_fetch.py
@@ -1,0 +1,604 @@
+"""Tests for RID-set chunk-append fetch in get_as_file (no live catalog)."""
+
+import os
+import tempfile
+from unittest.mock import MagicMock
+
+from deriva.core.ermrest_catalog import ErmrestCatalog, RID_SET_CHUNK_SIZE
+
+
+class _FakeResponse:
+    """Minimal requests.Response stand-in for a CSV page."""
+
+    def __init__(self, text):
+        self._text = text
+        self.status_code = 200
+        self.headers = {"Content-Type": "text/csv"}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def close(self):
+        pass
+
+    def iter_lines(self, decode_unicode=False):
+        for line in self._text.splitlines():
+            yield line if decode_unicode else line.encode("utf-8")
+
+    @property
+    def text(self):
+        return self._text
+
+
+def _csv(header, rows):
+    return "\n".join([header] + rows) + "\n"
+
+
+class _AcceptAwareResponse(_FakeResponse):
+    """Fake response that models the server's content-negotiation: it returns
+    CSV only when the request asked for ``Accept: text/csv``; otherwise it
+    returns JSON (the server's default). This reproduces the real server's
+    behavior that the plain ``_FakeResponse`` (hard-coded CSV) masks.
+    """
+
+    def __init__(self, csv_text, accept):
+        if accept == "text/csv":
+            super().__init__(csv_text)
+            self.headers = {"Content-Type": "text/csv"}
+        else:
+            # Server defaults to JSON when no/other Accept is sent.
+            super().__init__("[]")
+            self.headers = {"Content-Type": "application/json"}
+
+
+class _JsonStreamResponse:
+    """Minimal requests.Response stand-in for an application/x-json-stream page.
+
+    The json-stream branch of ``_fetch_paged_content`` reads ``r.content`` (the
+    raw bytes), not ``iter_lines``, so this fake exposes ``content``.
+    """
+
+    def __init__(self, content_bytes):
+        self.content = content_bytes
+        self.status_code = 200
+        self.headers = {"Content-Type": "application/x-json-stream"}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def close(self):
+        pass
+
+    @property
+    def text(self):
+        return self.content.decode("utf-8")
+
+
+def _jstream(*objs):
+    """Render newline-delimited JSON objects (one per line) as bytes."""
+    import json
+    return ("".join(json.dumps(o) + "\n" for o in objs)).encode("utf-8")
+
+
+def test_rid_set_threads_header_across_chunks_for_correct_cursor():
+    """The CSV header is captured on the first chunk and threaded into every
+    later chunk so each chunk builds its ``@after()`` cursor from the real
+    column names.
+
+    Only the first chunk is the "first page"; later chunks skip the re-emitted
+    header. If the header (``first_line``) were not threaded, a later chunk's
+    cursor dict would be built against the wrong (or empty) column names and
+    yield a bad ``@after`` value -> skipped rows or an infinite loop. Here each
+    chunk's ``@after`` must equal its last RID, and the merged CSV must have a
+    single header with every requested row present exactly once.
+    """
+    import deriva.core.ermrest_catalog as ec
+
+    header = "RID,Name,Notes"
+    pages = {
+        "/entity/S:T/RID=any(a1,a2)": _csv(header, ["a1,A,x", "a2,B,y"]),
+        "/entity/S:T/RID=any(a3,a4)": _csv(header, ["a3,C,z", "a4,D,w"]),
+        "/entity/S:T/RID=any(a5,a6)": _csv(header, ["a5,E,v", "a6,F,u"]),
+    }
+
+    cat = ErmrestCatalog.__new__(ErmrestCatalog)
+    cat._server_uri = "https://example.org/ermrest/catalog/1"
+
+    seen_after = []
+
+    def fake_get(url, headers=None, stream=False):
+        if "@after" in url:
+            seen_after.append(url.split("@after(")[1].split(")")[0])
+            return _FakeResponse(_csv(header, []))
+        for path, body in pages.items():
+            if path in url:
+                return _FakeResponse(body)
+        raise AssertionError("unexpected URL: %s" % url)
+
+    cat._session = MagicMock()
+    cat._session.get.side_effect = fake_get
+    cat._response_raise_for_status = lambda r: None
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        out = f.name
+    orig_chunk = ec.RID_SET_CHUNK_SIZE
+    ec.RID_SET_CHUNK_SIZE = 2  # 6 RIDs -> 3 chunks
+    try:
+        cat.get_as_file(
+            None, out, rid_set=["a1", "a2", "a3", "a4", "a5", "a6"],
+            rid_table="S:T", headers={"accept": "text/csv"},
+        )
+        # Each chunk's cursor is the chunk's last RID -- correct only if the
+        # threaded header let the cursor dict resolve the RID column.
+        assert seen_after == ["a2", "a4", "a6"], seen_after
+        with open(out, "r", newline="", encoding="utf-8") as f:
+            rows = list(__import__("csv").reader(f))
+        assert rows[0] == ["RID", "Name", "Notes"]   # exactly one header
+        assert [r[0] for r in rows[1:]] == ["a1", "a2", "a3", "a4", "a5", "a6"]
+    finally:
+        ec.RID_SET_CHUNK_SIZE = orig_chunk
+        if os.path.exists(out):
+            os.unlink(out)
+
+
+def test_get_as_file_rid_set_defaults_accept_to_csv():
+    """REGRESSION: the rid-set path must request ``Accept: text/csv`` even when
+    the caller passes no explicit accept header. Otherwise the server returns
+    JSON, the CSV write-branch is skipped, and the result is silently empty.
+
+    The bug: the ``if rid_set is not None:`` dispatch in ``get_as_file`` runs
+    BEFORE the accept-resolution logic the normal paged path uses, so the
+    rid-set path never defaulted the Accept header.
+    """
+    header = "RID,Name"
+    csv_body = _csv(header, ["r1,Alice", "r2,Bob"])
+
+    cat = ErmrestCatalog.__new__(ErmrestCatalog)
+    cat._server_uri = "https://example.org/ermrest/catalog/1"
+
+    seen_accepts = []
+
+    def fake_get(url, headers=None, stream=False):
+        accept = (headers or {}).get("accept")
+        seen_accepts.append(accept)
+        if "@after" in url:
+            return _AcceptAwareResponse(_csv(header, []), accept)
+        return _AcceptAwareResponse(csv_body, accept)
+
+    cat._session = MagicMock()
+    cat._session.get.side_effect = fake_get
+    cat._response_raise_for_status = lambda r: None
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        out = f.name
+    try:
+        # Call WITHOUT an explicit accept header (the bug-triggering path).
+        cat.get_as_file(None, out, rid_set=["r1", "r2"], rid_table="S:T")
+        # The fetch must have requested text/csv (the fix), so rows are written.
+        assert all(a == "text/csv" for a in seen_accepts), (
+            "rid-set fetch sent Accept=%r; expected text/csv on every request" % seen_accepts
+        )
+        with open(out, encoding="utf-8") as fh:
+            content = fh.read()
+        assert "r1,Alice" in content and "r2,Bob" in content, (
+            "rid-set fetch produced no rows (server returned JSON because Accept "
+            "was not text/csv): %r" % content
+        )
+    finally:
+        if os.path.exists(out):
+            os.unlink(out)
+
+
+def test_get_as_file_rid_set_appends_chunks_to_one_csv():
+    """Two RID chunks each return a CSV page; the result is ONE CSV with the
+    header once and all body rows, RID-distinct."""
+    header = "RID,Name"
+    pages = {
+        "/entity/S:T/RID=any(r1,r2)": _csv(header, ["r1,Alice", "r2,Bob"]),
+        "/entity/S:T/RID=any(r3)": _csv(header, ["r3,Carol"]),
+    }
+
+    cat = ErmrestCatalog.__new__(ErmrestCatalog)  # bypass __init__/network
+    cat._server_uri = "https://example.org/ermrest/catalog/1"
+
+    def fake_get(url, headers=None, stream=False):
+        if "@after" in url:
+            # Second page of any chunk: no more rows -> terminate the page loop.
+            return _FakeResponse(_csv(header, []))
+        for path, body in pages.items():
+            if path in url:
+                return _FakeResponse(body)
+        raise AssertionError("unexpected URL: %s" % url)
+
+    cat._session = MagicMock()
+    cat._session.get.side_effect = fake_get
+    cat._response_raise_for_status = lambda r: None
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        out = f.name
+    try:
+        # chunk size 2 -> 2 chunks: [r1,r2], [r3]. Patch the module constant
+        # so the test doesn't need 500+ RIDs.
+        import deriva.core.ermrest_catalog as ec
+        orig = ec.RID_SET_CHUNK_SIZE
+        ec.RID_SET_CHUNK_SIZE = 2
+        try:
+            cat.get_as_file(None, out, rid_set=["r1", "r2", "r3"], rid_table="S:T")
+        finally:
+            ec.RID_SET_CHUNK_SIZE = orig
+        with open(out, encoding="utf-8") as fh:
+            content = fh.read()
+        assert content.count("RID,Name") == 1            # header once
+        for rid in ("r1", "r2", "r3"):
+            assert rid in content                        # all rows present
+        nonblank = [ln for ln in content.splitlines() if ln.strip()]
+        assert len(nonblank) == 4                         # 1 header + 3 rows
+    finally:
+        os.unlink(out)
+
+
+def test_rid_set_header_only_keeps_file_unless_delete_if_empty():
+    """REGRESSION (deep-review gap): the rid-set path must honor delete_if_empty
+    the same way get_as_file's normal path does.
+
+    A header-only result (no data rows) should be deleted ONLY when
+    delete_if_empty=True. Previously _get_rid_set_as_file ran the emptiness
+    check unconditionally, so it deleted a header-only file even when the caller
+    passed delete_if_empty=False -- contradicting the parameter.
+    """
+    header = "RID,Name"
+
+    def make_cat():
+        cat = ErmrestCatalog.__new__(ErmrestCatalog)
+        cat._server_uri = "https://example.org/ermrest/catalog/1"
+
+        def fake_get(url, headers=None, stream=False):
+            # Every page is header-only: a non-empty (so not zero-byte) but
+            # data-less CSV. The first page writes the header; @after pages end it.
+            return _FakeResponse(_csv(header, []))
+
+        cat._session = MagicMock()
+        cat._session.get.side_effect = fake_get
+        cat._response_raise_for_status = lambda r: None
+        return cat
+
+    # delete_if_empty=False (the default): the header-only file must be KEPT.
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        out = f.name
+    try:
+        result = make_cat().get_as_file(
+            None, out, rid_set=["r1"], rid_table="S:T", delete_if_empty=False,
+        )
+        assert result == out
+        assert os.path.exists(out), "header-only file deleted despite delete_if_empty=False"
+        with open(out, encoding="utf-8") as fh:
+            assert fh.read().strip() == "RID,Name"   # header present, no data
+    finally:
+        if os.path.exists(out):
+            os.unlink(out)
+
+    # delete_if_empty=True: the same header-only result must be DELETED.
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        out = f.name
+    try:
+        result = make_cat().get_as_file(
+            None, out, rid_set=["r1"], rid_table="S:T", delete_if_empty=True,
+        )
+        assert result is None
+        assert not os.path.exists(out), "header-only file kept despite delete_if_empty=True"
+    finally:
+        if os.path.exists(out):
+            os.unlink(out)
+
+
+def test_rid_set_callback_cancel_aborts_cleanly_without_error():
+    """REGRESSION (Mike D'Arcy review on #273): cancelling via the progress
+    callback mid-fetch in rid-set mode must abort cleanly, not raise.
+
+    The paged loop honors a falsy callback by closing destfile and returning.
+    _get_rid_set_as_file must notice the closed file and stop -- otherwise the
+    next chunk's write (or the final flush) raises ``ValueError: I/O operation
+    on closed file``. Cancellation here fires during the FIRST of two chunks,
+    so a missing guard would blow up on the second chunk.
+    """
+    import deriva.core.ermrest_catalog as ec
+
+    header = "RID,Name"
+    pages = {
+        "/entity/S:T/RID=any(r1,r2)": _csv(header, ["r1,Alice", "r2,Bob"]),
+        "/entity/S:T/RID=any(r3,r4)": _csv(header, ["r3,Carol", "r4,Dave"]),
+    }
+
+    cat = ErmrestCatalog.__new__(ErmrestCatalog)
+    cat._server_uri = "https://example.org/ermrest/catalog/1"
+
+    def fake_get(url, headers=None, stream=False):
+        if "@after" in url:
+            return _FakeResponse(_csv(header, []))
+        for path, body in pages.items():
+            if path in url:
+                return _FakeResponse(body)
+        raise AssertionError("unexpected URL: %s" % url)
+
+    cat._session = MagicMock()
+    cat._session.get.side_effect = fake_get
+    cat._response_raise_for_status = lambda r: None
+
+    # Cancel after the first progress report (i.e. during the first chunk).
+    calls = {"n": 0}
+
+    def cancelling_callback(**kw):
+        if "progress" in kw:
+            calls["n"] += 1
+            return calls["n"] < 1  # falsy on the very first progress callback
+        return True
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        out = f.name
+    orig = ec.RID_SET_CHUNK_SIZE
+    ec.RID_SET_CHUNK_SIZE = 2  # 4 RIDs -> 2 chunks
+    try:
+        # Must NOT raise (the headline bug was ValueError on the closed file).
+        result = cat.get_as_file(
+            None, out, rid_set=["r1", "r2", "r3", "r4"], rid_table="S:T",
+            callback=cancelling_callback,
+        )
+        assert result is None  # aborted fetch reports no completed file
+        assert calls["n"] >= 1  # the callback actually fired (cancellation path ran)
+    finally:
+        ec.RID_SET_CHUNK_SIZE = orig
+        if os.path.exists(out):
+            os.unlink(out)
+
+
+def test_rid_set_json_stream_appends_chunks():
+    """rid-set mode honors Accept: application/x-json-stream and appends every
+    chunk's newline-delimited JSON objects into one stream (no CSV header
+    handling needed for this format)."""
+    import deriva.core.ermrest_catalog as ec
+
+    pages = {
+        "/entity/S:T/RID=any(r1,r2)": _jstream({"RID": "r1", "Name": "Alice"},
+                                               {"RID": "r2", "Name": "Bob"}),
+        "/entity/S:T/RID=any(r3,r4)": _jstream({"RID": "r3", "Name": "Carol"},
+                                               {"RID": "r4", "Name": "Dave"}),
+    }
+
+    cat = ErmrestCatalog.__new__(ErmrestCatalog)
+    cat._server_uri = "https://example.org/ermrest/catalog/1"
+
+    def fake_get(url, headers=None, stream=False):
+        assert (headers or {}).get("accept") == "application/x-json-stream"
+        if "@after" in url:
+            return _JsonStreamResponse(b"")        # no more rows -> end this chunk
+        for path, body in pages.items():
+            if path in url:
+                return _JsonStreamResponse(body)
+        raise AssertionError("unexpected URL: %s" % url)
+
+    cat._session = MagicMock()
+    cat._session.get.side_effect = fake_get
+    cat._response_raise_for_status = lambda r: None
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        out = f.name
+    orig = ec.RID_SET_CHUNK_SIZE
+    ec.RID_SET_CHUNK_SIZE = 2
+    try:
+        cat.get_as_file(
+            None, out, rid_set=["r1", "r2", "r3", "r4"], rid_table="S:T",
+            headers={"accept": "application/x-json-stream"},
+        )
+        with open(out, encoding="utf-8") as fh:
+            lines = [ln for ln in fh.read().splitlines() if ln.strip()]
+        assert len(lines) == 4                          # all rows, no CSV header
+        assert [__import__("json").loads(ln)["RID"] for ln in lines] == \
+            ["r1", "r2", "r3", "r4"]
+    finally:
+        ec.RID_SET_CHUNK_SIZE = orig
+        if os.path.exists(out):
+            os.unlink(out)
+
+
+def test_rid_set_json_stream_empty_middle_chunk_leaves_no_stray_marker():
+    """REGRESSION (Mike D'Arcy review on #273): a chunk whose json-stream result
+    is an empty marker (``[]``) between two non-empty chunks must not leave a
+    stray ``[]`` in the concatenated output.
+
+    ``_fetch_paged_content`` writes ``r.content`` before inspecting it, so an
+    unguarded empty page would emit ``[]`` mid-stream. The guard treats an
+    empty-array/object body as an empty page and skips writing it.
+    """
+    import deriva.core.ermrest_catalog as ec
+
+    pages = {
+        "/entity/S:T/RID=any(r1,r2)": _jstream({"RID": "r1"}, {"RID": "r2"}),
+        "/entity/S:T/RID=any(r3,r4)": b"[]\n",                  # empty middle chunk
+        "/entity/S:T/RID=any(r5,r6)": _jstream({"RID": "r5"}, {"RID": "r6"}),
+    }
+
+    cat = ErmrestCatalog.__new__(ErmrestCatalog)
+    cat._server_uri = "https://example.org/ermrest/catalog/1"
+
+    def fake_get(url, headers=None, stream=False):
+        if "@after" in url:
+            return _JsonStreamResponse(b"")
+        for path, body in pages.items():
+            if path in url:
+                return _JsonStreamResponse(body)
+        raise AssertionError("unexpected URL: %s" % url)
+
+    cat._session = MagicMock()
+    cat._session.get.side_effect = fake_get
+    cat._response_raise_for_status = lambda r: None
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        out = f.name
+    orig = ec.RID_SET_CHUNK_SIZE
+    ec.RID_SET_CHUNK_SIZE = 2
+    try:
+        cat.get_as_file(
+            None, out, rid_set=["r1", "r2", "r3", "r4", "r5", "r6"], rid_table="S:T",
+            headers={"accept": "application/x-json-stream"},
+        )
+        with open(out, encoding="utf-8") as fh:
+            content = fh.read()
+        assert "[]" not in content                      # no stray empty marker mid-stream
+        lines = [ln for ln in content.splitlines() if ln.strip()]
+        assert [__import__("json").loads(ln)["RID"] for ln in lines] == \
+            ["r1", "r2", "r5", "r6"]
+    finally:
+        ec.RID_SET_CHUNK_SIZE = orig
+        if os.path.exists(out):
+            os.unlink(out)
+
+
+def test_rid_set_chunks_splits_at_chunk_size():
+    rids = [f"1-{i:04d}" for i in range(1250)]
+    chunks = list(ErmrestCatalog._rid_set_chunks(rids, 500))
+    assert len(chunks) == 3
+    assert [len(c) for c in chunks] == [500, 500, 250]
+    # No RID lost or duplicated across chunks.
+    flat = [r for c in chunks for r in c]
+    assert flat == rids
+
+
+def test_rid_set_chunks_empty():
+    assert list(ErmrestCatalog._rid_set_chunks([], 500)) == []
+
+
+def test_rid_set_chunk_size_default_is_500():
+    assert RID_SET_CHUNK_SIZE == 500
+
+
+def test_rid_set_query_url_quotes_each_rid_not_the_commas():
+    """Commas are any() SYNTAX separators, not values. Each RID is quoted
+    individually; the commas stay literal. Quoting the whole joined string
+    (%2C) would break the predicate and silently return zero rows."""
+    url = ErmrestCatalog._rid_set_query_url("eye-ai:Image", ["1-ABC", "1-DEF"])
+    assert url == "/entity/eye-ai:Image/RID=any(1-ABC,1-DEF)"
+    # The separating commas must be literal, never percent-encoded.
+    assert "%2C" not in url
+
+
+def test_rid_set_query_url_quotes_special_chars_in_rid():
+    """A RID value containing a reserved char IS quoted (the value, not the
+    comma)."""
+    url = ErmrestCatalog._rid_set_query_url("S:T", ["a b", "c"])
+    # space in the value is encoded; the comma separator is not.
+    assert url == "/entity/S:T/RID=any(a%20b,c)"
+
+
+from deriva.transfer.download.processors.query.base_query_processor import (
+    BaseQueryProcessor,
+)
+
+
+def test_query_processor_reads_rid_set_from_params():
+    """rid_set/rid_table flow from processor_params onto the processor."""
+    proc = BaseQueryProcessor.__new__(BaseQueryProcessor)
+    proc.parameters = {
+        "query_path": "/entity/S:T",
+        "rid_set": ["r1", "r2"],
+        "rid_table": "S:T",
+    }
+    proc.rid_set = proc.parameters.get("rid_set", None)
+    proc.rid_table = proc.parameters.get("rid_table", None)
+    assert proc.rid_set == ["r1", "r2"]
+    assert proc.rid_table == "S:T"
+
+
+def test_catalog_query_forwards_rid_set_to_get_as_file():
+    """catalogQuery must pass rid_set/rid_table into get_as_file."""
+    from unittest.mock import MagicMock, patch
+
+    proc = BaseQueryProcessor.__new__(BaseQueryProcessor)
+    proc.parameters = {"rid_set": ["r1"], "rid_table": "S:T"}
+    proc.envars = {}
+    proc.rid_set = proc.parameters.get("rid_set")
+    proc.rid_table = proc.parameters.get("rid_table")
+    proc.query = "/entity/S:T"
+    proc.output_abspath = "/tmp/ignored.csv"
+    proc.paged_query = False
+    proc.paged_query_size = 100000
+    proc.paged_query_sort_columns = ["RID"]
+    proc.HEADERS = {}
+    proc.callback = None
+    captured = {}
+    cat = MagicMock()
+
+    def fake_get_as_file(path, dest, **kwargs):
+        captured.update(kwargs)
+        return dest
+
+    cat.get_as_file.side_effect = fake_get_as_file
+    proc.catalog = cat
+    with patch(
+        "deriva.transfer.download.processors.query.base_query_processor.make_dirs"
+    ):
+        proc.catalogQuery()
+    assert captured.get("rid_set") == ["r1"]
+    assert captured.get("rid_table") == "S:T"
+
+
+def test_catalog_query_with_empty_query_but_rid_set_still_calls_get_as_file():
+    """Format-B processors carry NO query_path: ``self.query`` is empty but
+    ``self.rid_set`` is populated. ``catalogQuery`` must NOT short-circuit on
+    the empty query — it must proceed to ``get_as_file`` so the rid-set fetch
+    actually fires. (Pins FIX 2: the early-return guard only triggers when
+    there is NEITHER a query path NOR a rid_set.)"""
+    from unittest.mock import MagicMock, patch
+
+    proc = BaseQueryProcessor.__new__(BaseQueryProcessor)
+    proc.parameters = {"rid_set": ["r1"], "rid_table": "S:T"}
+    proc.envars = {}
+    proc.rid_set = proc.parameters.get("rid_set")
+    proc.rid_table = proc.parameters.get("rid_table")
+    proc.query = ""  # Format B: no query_path at all.
+    proc.output_abspath = "/tmp/ignored.csv"
+    proc.paged_query = False
+    proc.paged_query_size = 100000
+    proc.paged_query_sort_columns = ["RID"]
+    proc.HEADERS = {}
+    proc.callback = None
+    captured = {}
+    cat = MagicMock()
+
+    def fake_get_as_file(path, dest, **kwargs):
+        captured.update(kwargs)
+        return dest
+
+    cat.get_as_file.side_effect = fake_get_as_file
+    proc.catalog = cat
+    with patch(
+        "deriva.transfer.download.processors.query.base_query_processor.make_dirs"
+    ):
+        proc.catalogQuery()
+    # The guard did NOT return early: get_as_file ran with the rid_set.
+    cat.get_as_file.assert_called_once()
+    assert captured.get("rid_set") == ["r1"]
+    assert captured.get("rid_table") == "S:T"
+
+
+def test_catalog_query_returns_empty_when_no_query_and_no_rid_set():
+    """The early-return guard still fires when there is NEITHER a query path
+    NOR a rid_set — get_as_file must not be called in that case."""
+    from unittest.mock import MagicMock
+
+    proc = BaseQueryProcessor.__new__(BaseQueryProcessor)
+    proc.parameters = {}
+    proc.envars = {}
+    proc.rid_set = None
+    proc.rid_table = None
+    proc.query = ""
+    cat = MagicMock()
+    proc.catalog = cat
+
+    assert proc.catalogQuery() == {}
+    cat.get_as_file.assert_not_called()

--- a/tests/deriva/core/test_rid_set_integration.py
+++ b/tests/deriva/core/test_rid_set_integration.py
@@ -1,0 +1,177 @@
+"""End-to-end Format-B rid-set integration test (no live catalog).
+
+The unit tests in ``test_rid_set_fetch.py`` prove each link in the chain in
+isolation: chunking, per-RID URL quoting, the chunk-append in ``get_as_file``,
+and the processor's forwarding of ``rid_set``/``rid_table`` into
+``get_as_file`` (with ``get_as_file`` itself mocked). None of them drive the
+*whole* chain — spec -> processor -> the REAL ``get_as_file`` -> a CSV file on
+disk. That gap is exactly why FIX 2 (the ``catalogQuery`` short-circuit that
+returned early for a query-less rid-set processor) survived five tasks.
+
+This test closes the gap. It builds a ``CSVQueryProcessor`` configured the way
+``CatalogBagBuilder`` emits a Format-B processor — ``rid_set`` in
+``processor_params``, NO ``query_path`` — backed by a real ``ErmrestCatalog``
+whose only mock is ``_session.get`` (serving CSV pages per RID-chunk URL). It
+then calls ``proc.catalogQuery()`` and asserts a real, chunk-appended CSV is on
+disk. Because the catalog's ``get_as_file`` is the genuine
+``ErmrestCatalog.get_as_file`` (not a ``MagicMock``), the full
+processor -> ``catalogQuery`` (FIX 2 guard) -> ``get_as_file`` ->
+``_get_rid_set_as_file`` -> ``_fetch_paged_content`` path executes and writes
+correct bytes.
+"""
+
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from deriva.core.ermrest_catalog import ErmrestCatalog
+import deriva.core.ermrest_catalog as ec
+from deriva.transfer.download.processors.query.base_query_processor import (
+    BaseQueryProcessor,
+    CSVQueryProcessor,
+)
+
+# Reuse the CSV-page fake helpers that already drive the get_as_file unit test.
+from tests.deriva.core.test_rid_set_fetch import _FakeResponse, _csv
+
+
+def _make_catalog_serving(pages, header):
+    """Build a real ``ErmrestCatalog`` whose ``_session.get`` serves CSV pages.
+
+    The catalog is constructed via ``__new__`` to bypass ``__init__``/network,
+    then its ``_session.get`` is given the ``@after``-terminating fake from
+    ``test_rid_set_fetch.py``: a request whose URL contains ``@after`` returns
+    an empty CSV page (ending that chunk's cursor loop); otherwise the page body
+    keyed by the matching RID-chunk path is returned. Everything else on the
+    catalog — including ``get_as_file`` and its rid-set chunk-append helpers — is
+    the genuine class implementation.
+
+    Args:
+        pages: Mapping of RID-chunk path (e.g. ``/entity/S:T/RID=any(r1,r2)``)
+            to the CSV body that chunk should return.
+        header: The shared CSV header line (e.g. ``"RID,Name"``).
+
+    Returns:
+        A real ``ErmrestCatalog`` instance ready for ``get_as_file``.
+    """
+    cat = ErmrestCatalog.__new__(ErmrestCatalog)  # bypass __init__/network
+    cat._server_uri = "https://example.org/ermrest/catalog/1"
+
+    def fake_get(url, headers=None, stream=False):
+        if "@after" in url:
+            # Second page of any chunk: no more rows -> terminate the page loop.
+            return _FakeResponse(_csv(header, []))
+        for path, body in pages.items():
+            if path in url:
+                return _FakeResponse(body)
+        raise AssertionError("unexpected URL: %s" % url)
+
+    cat._session = MagicMock()
+    cat._session.get.side_effect = fake_get
+    cat._response_raise_for_status = lambda r: None
+    return cat
+
+
+def _make_format_b_processor(catalog, rid_set, rid_table, output_abspath):
+    """Hand-build a ``BaseQueryProcessor`` shaped like a Format-B emission.
+
+    Mirrors how ``CatalogBagBuilder`` configures the processor: ``rid_set`` and
+    ``rid_table`` come from ``processor_params``, and there is NO ``query_path``
+    (``self.query`` is empty). Built via ``__new__`` + manual attribute setup
+    — the same pattern the forwarding unit test uses — so we exercise
+    ``catalogQuery`` without ``CSVQueryProcessor.__init__``'s path-creation
+    machinery, while still pointing ``self.catalog`` at the REAL catalog so the
+    genuine ``get_as_file`` runs.
+
+    Args:
+        catalog: The real ``ErmrestCatalog`` whose ``get_as_file`` will run.
+        rid_set: The RIDs the processor should fetch.
+        rid_table: ``"schema:table"`` the RIDs belong to.
+        output_abspath: Real on-disk path the CSV is written to.
+
+    Returns:
+        A ready-to-run ``BaseQueryProcessor``.
+    """
+    proc = BaseQueryProcessor.__new__(BaseQueryProcessor)
+    proc.parameters = {"rid_set": rid_set, "rid_table": rid_table}
+    proc.envars = {}
+    proc.rid_set = proc.parameters.get("rid_set")
+    proc.rid_table = proc.parameters.get("rid_table")
+    proc.query = ""  # Format B: no query_path at all.
+    proc.output_abspath = output_abspath
+    proc.paged_query = False
+    proc.paged_query_size = 100000
+    proc.paged_query_sort_columns = ["RID"]
+    proc.HEADERS = {}
+    proc.callback = None
+    proc.catalog = catalog
+    # __init__ sets ``sessions`` (used by __del__); the __new__ build skips it,
+    # so set it here to keep teardown clean.
+    proc.sessions = {}
+    return proc
+
+
+def test_format_b_processor_writes_one_clean_csv_end_to_end():
+    """spec(rid_set) -> processor -> REAL get_as_file -> ONE clean CSV on disk.
+
+    Drives the full Format-B chain end-to-end with only ``_session.get`` mocked:
+
+    1. ``proc.catalogQuery()`` runs (FIX 2: the empty-query guard does NOT
+       short-circuit because ``self.rid_set`` is populated).
+    2. It calls the REAL ``ErmrestCatalog.get_as_file`` with the rid_set, which
+       chunk-appends across 2 chunks (3 RIDs, ``RID_SET_CHUNK_SIZE`` patched to
+       2) into one CSV.
+    3. The resulting file has the header exactly once and all three rows.
+
+    This is the test that would have caught FIX 2: ``get_as_file`` is the
+    genuine implementation, so a real CSV is produced — not a captured-kwargs
+    mock.
+    """
+    header = "RID,Name"
+    pages = {
+        "/entity/S:T/RID=any(r1,r2)": _csv(header, ["r1,Alice", "r2,Bob"]),
+        "/entity/S:T/RID=any(r3)": _csv(header, ["r3,Carol"]),
+    }
+    catalog = _make_catalog_serving(pages, header)
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        out = f.name
+    try:
+        proc = _make_format_b_processor(
+            catalog, ["r1", "r2", "r3"], "S:T", out
+        )
+
+        # Sanity-check the wiring: the processor calls the genuine bound method,
+        # NOT a MagicMock. (A mocked get_as_file would write nothing.)
+        assert proc.catalog.get_as_file.__func__ is ErmrestCatalog.get_as_file
+
+        # chunk size 2 -> 2 chunks: [r1,r2], [r3]. Patch the module constant so
+        # the chain spans multiple chunks without needing 500+ RIDs, proving the
+        # multi-chunk append fires through the processor path.
+        orig = ec.RID_SET_CHUNK_SIZE
+        ec.RID_SET_CHUNK_SIZE = 2
+        # Patch make_dirs (as the forwarding unit test does) so catalogQuery's
+        # mkdir-for-output-dir is a no-op for the temp file.
+        try:
+            with patch(
+                "deriva.transfer.download.processors.query."
+                "base_query_processor.make_dirs"
+            ):
+                proc.catalogQuery()
+        finally:
+            ec.RID_SET_CHUNK_SIZE = orig
+
+        # The REAL get_as_file wrote a real file: header once + all 3 rows.
+        assert os.path.exists(out)
+        with open(out, encoding="utf-8") as fh:
+            content = fh.read()
+        assert content.count("RID,Name") == 1  # header exactly once
+        for rid in ("r1", "r2", "r3"):
+            assert rid in content  # every chunk's row landed
+        nonblank = [ln for ln in content.splitlines() if ln.strip()]
+        assert len(nonblank) == 4  # 1 header + 3 rows, chunk-appended
+        # The mocked session was actually exercised (chain ran, not skipped).
+        assert catalog._session.get.called
+    finally:
+        if os.path.exists(out):
+            os.unlink(out)


### PR DESCRIPTION
Brings `2.0-dev` up to date with the current `master` (tip `ebd3400`).

`2.0-dev` was last at `77fb43f` (2026-03-30) and is fully contained in `master`, so this is a clean fast-forward catch-up — it adds the 8 commits `master` has gained since the branch point and drops/duplicates nothing. No 2.0 PRs have been accepted into `master` yet, so there is no 2.0-specific work on this branch to conflict.

This keeps `2.0-dev` = `master` + (future) selective 2.0 features, per the intended branch topology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)