### PR TITLE
Add type hints to deriva.core.datapath (annotations only)

### DIFF
--- a/deriva/core/datapath.py
+++ b/deriva/core/datapath.py
@@ -9,6 +9,8 @@ import time
 import re
 from requests import HTTPError
 import warnings
+from typing import Any, Callable, Iterable, Iterator, Optional
+from typing import Any as _Any  # alias preserved for use after the `Any` quantifier class shadows the name
 from . import DEFAULT_HEADERS, ermrest_model as _erm
 
 __all__ = ['DataPathException', 'Min', 'Max', 'Sum', 'Avg', 'Cnt', 'CntD', 'Array', 'ArrayD', 'Bin', 'All', 'Any',
@@ -21,15 +23,15 @@ _system_defaults = {'RID', 'RCT', 'RCB', 'RMT', 'RMB'}
 """Set of system default column names"""
 
 
-def deprecated(f):
+def deprecated(f: Callable) -> Callable:
     """A simple 'deprecated' function decorator."""
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
         warnings.warn("'%s' has been deprecated" % f.__name__, DeprecationWarning, stacklevel=2)
         return f(*args, **kwargs)
     return wrapper
 
 
-def from_catalog(catalog):
+def from_catalog(catalog: Any) -> "_CatalogWrapper":
     """Wraps an ErmrestCatalog object for use in datapath expressions.
 
     :param catalog: an ErmrestCatalog object
@@ -38,7 +40,7 @@ def from_catalog(catalog):
     return _CatalogWrapper(catalog)
 
 
-def _isidentifier(a):
+def _isidentifier(a: Any) -> bool:
     """Tests if string is a valid python identifier.
 
     This function is intended for internal usage within this module.
@@ -51,7 +53,7 @@ def _isidentifier(a):
         return re.match("[_A-Za-z][_a-zA-Z0-9]*$", a) is not None
 
 
-def _identifier_for_name(name, *reserveds):
+def _identifier_for_name(name: str, *reserveds: Iterable[str]) -> str:
     """Makes an identifier from a given name and disambiguates if it is reserved.
 
     1. replace invalid identifier characters with '_'
@@ -81,7 +83,7 @@ def _identifier_for_name(name, *reserveds):
     return identifier
 
 
-def _make_identifier_to_name_mapping(names, reserved):
+def _make_identifier_to_name_mapping(names: Iterable[str], reserved: Iterable[str]) -> dict[str, str]:
     """Makes a dictionary of (valid) identifiers to (original) names.
 
     Try to favor the names that require the least modification:
@@ -113,7 +115,7 @@ def _make_identifier_to_name_mapping(names, reserved):
     return mappings
 
 
-def _http_error_message(e):
+def _http_error_message(e: HTTPError) -> str:
     """Returns a formatted error message from the raw HTTPError.
     """
     return '\n'.join(e.response.text.splitlines()[1:]) + '\n' + str(e)
@@ -122,19 +124,19 @@ def _http_error_message(e):
 class DataPathException (Exception):
     """Exception in a datapath expression.
     """
-    def __init__(self, message, reason=None):
+    def __init__(self, message: str, reason: Any = None) -> None:
         super(DataPathException, self).__init__(message, reason)
         self.message = message
         self.reason = reason
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.message
 
 
 class _CatalogWrapper (object):
     """Wraps a Catalog for datapath expressions.
     """
-    def __init__(self, catalog):
+    def __init__(self, catalog: Any) -> None:
         """Creates the _CatalogWrapper.
 
         :param catalog: ErmrestCatalog object
@@ -150,13 +152,13 @@ class _CatalogWrapper (object):
             self.schemas.keys(),
             super(_CatalogWrapper, self).__dir__())
 
-    def __dir__(self):
+    def __dir__(self) -> Iterator[str]:
         return itertools.chain(
             super(_CatalogWrapper, self).__dir__(),
             self._identifiers.keys()
         )
 
-    def __getattr__(self, a):
+    def __getattr__(self, a: str) -> Any:
         if a in self._identifiers:
             return self.schemas[self._identifiers[a]]
         elif hasattr(super(_CatalogWrapper, self), a):
@@ -165,7 +167,7 @@ class _CatalogWrapper (object):
             raise AttributeError("'%s' object for catalog '%s' has no attribute or schema '%s'" % (type(self).__name__, self._wrapped_catalog.catalog_id, a))
 
     @classmethod
-    def compose(cls, *paths):
+    def compose(cls, *paths: "DataPath") -> "DataPath":
         """Compose path fragments into a path.
 
         The root of any path fragment must be found in the table instances of the currently composed path from left
@@ -192,7 +194,7 @@ class _CatalogWrapper (object):
 class _SchemaWrapper (object):
     """Wraps a Schema for datapath expressions.
     """
-    def __init__(self, catalog, schema):
+    def __init__(self, catalog: "_CatalogWrapper", schema: Any) -> None:
         """Creates the _SchemaWrapper.
 
         :param catalog: the catalog wrapper to which this schema wrapper belongs
@@ -210,13 +212,13 @@ class _SchemaWrapper (object):
             self.tables.keys(),
             super(_SchemaWrapper, self).__dir__())
 
-    def __dir__(self):
+    def __dir__(self) -> Iterator[str]:
         return itertools.chain(
             super(_SchemaWrapper, self).__dir__(),
             self._identifiers.keys()
         )
 
-    def __getattr__(self, a):
+    def __getattr__(self, a: str) -> Any:
         if a in self._identifiers:
             return self.tables[self._identifiers[a]]
         elif hasattr(super(_SchemaWrapper, self), a):
@@ -225,7 +227,7 @@ class _SchemaWrapper (object):
             raise AttributeError("'%s' object for schema '%s' has no attribute or table '%s'" % (type(self).__name__, self._name, a))
 
     @deprecated
-    def describe(self):
+    def describe(self) -> str:
         """Provides a description of the model element.
 
         :return: a user-friendly string representation of the model element.
@@ -238,14 +240,14 @@ class _SchemaWrapper (object):
         return s
 
     @deprecated
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         return self.describe()
 
 
 class DataPath (object):
     """Represents a datapath expression.
     """
-    def __init__(self, root):
+    def __init__(self, root: "_TableAlias") -> None:
         assert isinstance(root, _TableAlias)
         self._path_expression = _Root(root)
         self._root = root
@@ -255,13 +257,13 @@ class DataPath (object):
         self._identifiers = {}
         self._bind_table_instance(root)
 
-    def __dir__(self):
+    def __dir__(self) -> Iterator[str]:
         return itertools.chain(
             super(DataPath, self).__dir__(),
             self._identifiers.keys()
         )
 
-    def __getattr__(self, a):
+    def __getattr__(self, a: str) -> Any:
         if a in self._identifiers:
             return self._table_instances[self._identifiers[a]]
         elif hasattr(super(DataPath, self), a):
@@ -269,7 +271,7 @@ class DataPath (object):
         else:
             raise AttributeError("'%s' object has no attribute or table instance '%s'" % (type(self).__name__, a))
 
-    def __deepcopy__(self, memodict={}):
+    def __deepcopy__(self, memodict: dict = {}) -> "DataPath":
         cp = DataPath(copy.deepcopy(self._root, memo=memodict))
         for alias in copy.deepcopy(self._table_instances, memo=memodict).values():
             if alias != cp._root:
@@ -290,17 +292,17 @@ class DataPath (object):
         return cp
 
     @property
-    def table_instances(self):
+    def table_instances(self) -> dict[str, "_TableAlias"]:
         """Collection of the table instances in this datapath expression."""
         return self._table_instances
 
     @property
-    def context(self):
+    def context(self) -> "_TableAlias":
         """Context (i.e., last bound table instance) of this datapath expression."""
         return self._context
 
     @context.setter
-    def context(self, value):
+    def context(self, value: "_TableAlias") -> None:
         """Updates the context of this datapath expression (must be a table instance bound to this expression)."""
         if not isinstance(value, _TableAlias):
             raise TypeError('context must be a table alias object')
@@ -311,11 +313,11 @@ class DataPath (object):
             self._context = value
 
     @property
-    def uri(self):
+    def uri(self) -> str:
         """The current URI serialization of this datapath expression."""
         return self._base_uri + str(self._path_expression)
 
-    def _contextualized_uri(self, context):
+    def _contextualized_uri(self, context: "_TableAlias") -> str:
         """Returns a path uri for the specified context.
 
         :param context: a table instance that is bound to this path
@@ -328,7 +330,7 @@ class DataPath (object):
         else:
             return self.uri
 
-    def _bind_table_instance(self, alias):
+    def _bind_table_instance(self, alias: "_TableAlias") -> None:
         """Binds a new table instance into this path.
         """
         assert isinstance(alias, _TableAlias)
@@ -336,7 +338,7 @@ class DataPath (object):
         self._table_instances[alias._name] = self._context = alias
         self._identifiers[_identifier_for_name(alias._name, self._identifiers.keys(), super(DataPath, self).__dir__())] = alias._name
 
-    def delete(self):
+    def delete(self) -> None:
         """Deletes the entity set referenced by the data path.
         """
         try:
@@ -350,7 +352,7 @@ class DataPath (object):
             else:
                 raise e
 
-    def filter(self, filter_expression):
+    def filter(self, filter_expression: "_Predicate") -> "DataPath":
         """Filters the path based on the specified formula.
 
         :param filter_expression: should be a valid _Predicate object
@@ -360,7 +362,7 @@ class DataPath (object):
         self._path_expression = _Filter(self._path_expression, filter_expression)
         return self
 
-    def link(self, right, on=None, join_type=''):
+    def link(self, right: "_TableWrapper", on: Any = None, join_type: str = '') -> "DataPath":
         """Links this path with another table.
 
         To link a table with an unambigious relationship where table A is related to table B via a single foreign key
@@ -461,7 +463,7 @@ class DataPath (object):
 
         return self
 
-    def entities(self):
+    def entities(self) -> "_ResultSet":
         """Returns a results set of whole entities from this data path's current context.
 
         ```
@@ -472,7 +474,7 @@ class DataPath (object):
         """
         return self._query()
 
-    def aggregates(self, *functions):
+    def aggregates(self, *functions: "_AggregateFunctionAlias") -> "_ResultSet":
         """Returns a results set of computed aggregates from this data path.
 
         By using the built-in subclasses of the `AggregateFunction` class, including `Min`, `Max`, `Sum`, `Avg`, `Cnt`,
@@ -490,7 +492,7 @@ class DataPath (object):
         """
         return self._query(mode=_Project.AGGREGATE, projection=list(functions))
 
-    def attributes(self, *attributes):
+    def attributes(self, *attributes: Any) -> "_ResultSet":
         """Returns a results set of attributes projected and optionally renamed from this data path.
 
         ```
@@ -504,7 +506,7 @@ class DataPath (object):
         """
         return self._query(mode=_Project.ATTRIBUTE, projection=list(attributes))
 
-    def groupby(self, *keys):
+    def groupby(self, *keys: Any) -> "_AttributeGroup":
         """Returns an attribute group object.
 
         The attribute group object returned by this method can be used to get a results set of computed aggregates for
@@ -538,7 +540,7 @@ class DataPath (object):
         """
         return _AttributeGroup(self, self._query, keys)
 
-    def _query(self, mode='entity', projection=[], group_key=[], context=None):
+    def _query(self, mode: str = 'entity', projection: list = [], group_key: list = [], context: Optional["_TableAlias"] = None) -> "_ResultSet":
         """Internal method for querying the data path from the perspective of the given 'context'.
 
         :param mode: a valid mode in Project.MODES
@@ -557,7 +559,7 @@ class DataPath (object):
             expression = _Project(expression, mode, projection, group_key)
         base_path = str(expression)
 
-        def fetcher(limit=None, sort=None, headers=DEFAULT_HEADERS):
+        def fetcher(limit: Optional[int] = None, sort: Any = None, headers: Any = DEFAULT_HEADERS) -> Any:
             assert limit is None or isinstance(limit, int)
             assert sort is None or hasattr(sort, '__iter__')
             limiting = '?limit=%d' % limit if limit else ''
@@ -576,7 +578,7 @@ class DataPath (object):
 
         return _ResultSet(self._base_uri + base_path, fetcher)
 
-    def merge(self, path):
+    def merge(self, path: "DataPath") -> "DataPath":
         """Merges the current path with the given path.
 
         The right-hand 'path' must be rooted on a `_TableAlias` object that exists (by alias name) within this path
@@ -609,7 +611,7 @@ class DataPath (object):
 
         return self
 
-    def denormalize(self, context_name=None, heuristic=None, groupkey_name='RID'):
+    def denormalize(self, context_name: Optional[str] = None, heuristic: Optional[Callable] = None, groupkey_name: str = 'RID') -> "_ResultSet":
         """Denormalizes a path based on a visible-columns annotation 'context' or a heuristic approach.
 
         This method does not mutate this object. It returns a result set representing the denormalization of the path.
@@ -629,7 +631,7 @@ class _ResultSet (object):
     container. If the result set has not been fetched explicitly, on first use of container operations, it will
     be implicitly fetched from the catalog.
     """
-    def __init__(self, uri, fetcher_fn):
+    def __init__(self, uri: str, fetcher_fn: Callable) -> None:
         """Initializes the _ResultSet.
         :param uri: the uri for the entity set in the catalog.
         :param fetcher_fn: a function that fetches the entities from the catalog.
@@ -642,21 +644,21 @@ class _ResultSet (object):
         self.uri = uri
 
     @property
-    def _results(self):
+    def _results(self) -> Any:
         if self._results_doc is None:
             self.fetch()
         return self._results_doc
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._results)
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: Any) -> Any:
         return self._results[item]
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator:
         return iter(self._results)
 
-    def sort(self, *attributes):
+    def sort(self, *attributes: Any) -> "_ResultSet":
         """Orders the results set by the given attributes.
 
         :param keys: Columns, column aliases, or aggregate function aliases. The sort attributes must be projected by
@@ -672,7 +674,7 @@ class _ResultSet (object):
         self._results_doc = None
         return self
 
-    def limit(self, n):
+    def limit(self, n: Optional[int]) -> "_ResultSet":
         """Set a limit on the number of results to be returned.
 
         :param n: integer or None.
@@ -685,7 +687,7 @@ class _ResultSet (object):
         except ValueError:
             raise ValueError('limit argument "n" must be an integer or None')
 
-    def fetch(self, limit=None, headers=DEFAULT_HEADERS):
+    def fetch(self, limit: Optional[int] = None, headers: Any = DEFAULT_HEADERS) -> "_ResultSet":
         """Fetches the results from the catalog.
 
         :param limit: maximum number of results to fetch from the catalog.
@@ -697,7 +699,7 @@ class _ResultSet (object):
         logger.debug("Fetched %d entities" % len(self._results_doc))
         return self
 
-def _json_size_approx(data):
+def _json_size_approx(data: Any) -> int:
     """Return approximate byte count for minimal JSON encoding of data
 
     Minimal encoding has no optional whitespace/indentation.
@@ -719,7 +721,7 @@ def _json_size_approx(data):
 
     return nbytes
 
-def _generate_batches(entities, max_batch_rows=1000, max_batch_bytes=250*1024):
+def _generate_batches(entities: Any, max_batch_rows: int = 1000, max_batch_bytes: int = 250*1024) -> Any:
     """Generate a series of entity batches as slices of the input entities
 
     """
@@ -752,7 +754,7 @@ def _generate_batches(entities, max_batch_rows=1000, max_batch_bytes=250*1024):
         yield entities[lower:upper]
         lower = upper
 
-def _request_with_retry(request_func, retry_codes={408, 429, 500, 502, 503, 504}, backoff_factor=4, max_attempts=5):
+def _request_with_retry(request_func: Callable, retry_codes: set = {408, 429, 500, 502, 503, 504}, backoff_factor: int = 4, max_attempts: int = 5) -> Any:
     """Perform request func with exponential backoff and retry.
 
     :param request_func: A function returning a requests.Response object or raising HTTPError
@@ -797,7 +799,7 @@ def _request_with_retry(request_func, retry_codes={408, 429, 500, 502, 503, 504}
 class _TableWrapper (object):
     """Wraps a Table for datapath expressions.
     """
-    def __init__(self, schema, table):
+    def __init__(self, schema: "_SchemaWrapper", table: Any) -> None:
         """Creates a _TableWrapper object.
 
         :param schema: the schema objec to which this table belongs
@@ -819,13 +821,13 @@ class _TableWrapper (object):
             self.column_definitions.keys(),
             super(_TableWrapper, self).__dir__())
 
-    def __dir__(self):
+    def __dir__(self) -> Iterator[str]:
         return itertools.chain(
             super(_TableWrapper, self).__dir__(),
             self._identifiers.keys()
         )
 
-    def __getattr__(self, a):
+    def __getattr__(self, a: str) -> Any:
         if a in self._identifiers:
             return self.column_definitions[self._identifiers[a]]
         elif hasattr(super(_TableWrapper, self), a):
@@ -834,7 +836,7 @@ class _TableWrapper (object):
             raise AttributeError("'%s' object for table '%s' has no attribute or column '%s'" % (type(self).__name__, self._wrapped_table.name, a))
 
     @deprecated
-    def describe(self):
+    def describe(self) -> str:
         """Provides a description of the model element.
 
         :return: a user-friendly string representation of the model element.
@@ -847,16 +849,16 @@ class _TableWrapper (object):
         return s
 
     @deprecated
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         return self.describe()
 
     @property
-    def columns(self):
+    def columns(self) -> dict[str, "_ColumnWrapper"]:
         """Sugared access to self.column_definitions"""
         return self.column_definitions
 
     @property
-    def path(self):
+    def path(self) -> "DataPath":
         """Always a new DataPath instance that is rooted at this table.
 
         Note that this table will be automatically aliased using its own table name.
@@ -864,7 +866,7 @@ class _TableWrapper (object):
         return DataPath(self.alias(self._name))
 
     @property
-    def _contextualized_path(self):
+    def _contextualized_path(self) -> "DataPath":
         """Returns the path as contextualized for this table instance.
 
         Conditionally updates the context of the path to which this table instance is bound.
@@ -873,56 +875,56 @@ class _TableWrapper (object):
 
     @property
     @deprecated
-    def uri(self):
+    def uri(self) -> str:
         return self.path.uri
 
-    def alias(self, alias_name):
+    def alias(self, alias_name: str) -> "_TableAlias":
         """Returns a table alias object.
         :param alias_name: a string to use as the alias name
         """
         return _TableAlias(self, alias_name)
 
-    def filter(self, filter_expression):
+    def filter(self, filter_expression: "_Predicate") -> "DataPath":
         """See the docs for this method in `DataPath` for more information."""
         return self._contextualized_path.filter(filter_expression)
 
-    def link(self, right, on=None, join_type=''):
+    def link(self, right: "_TableWrapper", on: Any = None, join_type: str = '') -> "DataPath":
         """See the docs for this method in `DataPath` for more information."""
         return self._contextualized_path.link(right, on, join_type)
 
-    def _query(self, mode='entity', projection=[], group_key=[], context=None):
+    def _query(self, mode: str = 'entity', projection: list = [], group_key: list = [], context: Optional["_TableAlias"] = None) -> "_ResultSet":
         """Invokes query on the path for this table."""
         return self.path._query(mode, projection, group_key=group_key, context=context)
 
-    def entities(self):
+    def entities(self) -> "_ResultSet":
         """Returns a results set of whole entities from this data path's current context.
 
         See the docs for this method in `DataPath` for more information.
         """
         return self._query()
 
-    def aggregates(self, *functions):
+    def aggregates(self, *functions: "_AggregateFunctionAlias") -> "_ResultSet":
         """Returns a results set of computed aggregates from this data path.
 
         See the docs for this method in `DataPath` for more information.
         """
         return self._query(mode=_Project.AGGREGATE, projection=list(functions))
 
-    def attributes(self, *attributes):
+    def attributes(self, *attributes: Any) -> "_ResultSet":
         """Returns a results set of attributes projected and optionally renamed from this data path.
 
         See the docs for this method in `DataPath` for more information.
         """
         return self._query(mode=_Project.ATTRIBUTE, projection=list(attributes))
 
-    def groupby(self, *keys):
+    def groupby(self, *keys: Any) -> "_AttributeGroup":
         """Returns an attribute group object.
 
         See the docs for this method in `DataPath` for more information.
         """
         return _AttributeGroup(self, self._query, keys)
 
-    def denormalize(self, context_name=None, heuristic=None, groupkey_name='RID'):
+    def denormalize(self, context_name: Optional[str] = None, heuristic: Optional[Callable] = None, groupkey_name: str = 'RID') -> "_ResultSet":
         """Denormalizes a path based on a visible-columns annotation 'context' or a heuristic approach.
 
         This method does not mutate this object. It returns a result set representing the denormalization of the path.
@@ -934,7 +936,7 @@ class _TableWrapper (object):
         """
         return self.path.denormalize(context_name=context_name, heuristic=heuristic, groupkey_name=groupkey_name)
 
-    def insert(self, entities, defaults=set(), nondefaults=set(), add_system_defaults=True, on_conflict_skip=False, retry_codes={408, 429, 500, 502, 503, 504}, backoff_factor=4, max_attempts=5, max_batch_rows=1000, max_batch_bytes=250*1024):
+    def insert(self, entities: Iterable, defaults: set = set(), nondefaults: set = set(), add_system_defaults: bool = True, on_conflict_skip: bool = False, retry_codes: set = {408, 429, 500, 502, 503, 504}, backoff_factor: int = 4, max_attempts: int = 5, max_batch_rows: int = 1000, max_batch_bytes: int = 250*1024) -> "_ResultSet":
         """Inserts entities into the table.
 
         :param entities: an iterable collection of entities (i.e., rows) to be inserted into the table.
@@ -994,10 +996,10 @@ class _TableWrapper (object):
             raise TypeError('entities[0] does not look like a dictionary -- does not have a "keys()" method')
 
         # perform one batch request in a helper we can hand to retry helper
-        def request_func(batch):
+        def request_func(batch: Any) -> Any:
             return self._schema._catalog._wrapped_catalog.post(path, json=batch, headers={'Content-Type': 'application/json'})
 
-        def _has_user_pkey(table):
+        def _has_user_pkey(table: Any) -> bool:
             """Return True if table has at least one primary key other than the system RID key"""
             for key in table.keys:
                 if { c.name for c in key.unique_columns } != {'RID'}:
@@ -1038,7 +1040,7 @@ class _TableWrapper (object):
         return result
 
 
-    def update(self, entities, correlation={'RID'}, targets=None, retry_codes={408, 429, 500, 502, 503, 504}, backoff_factor=4, max_attempts=5, max_batch_rows=1000, max_batch_bytes=250*1024):
+    def update(self, entities: Iterable, correlation: Iterable = {'RID'}, targets: Optional[Iterable] = None, retry_codes: set = {408, 429, 500, 502, 503, 504}, backoff_factor: int = 4, max_attempts: int = 5, max_batch_rows: int = 1000, max_batch_bytes: int = 250*1024) -> "_ResultSet":
         """Update entities of a table.
 
         For more information see the ERMrest protocol for the `attributegroup` interface. By default, this method will
@@ -1096,7 +1098,7 @@ class _TableWrapper (object):
         )
 
         # perform one batch request in a helper we can hand to retry helper
-        def request_func(batch):
+        def request_func(batch: Any) -> Any:
             return self._schema._catalog._wrapped_catalog.put(path, json=batch, headers={'Content-Type': 'application/json'})
 
         # perform all requests synchronously so the caller can get exceptions
@@ -1124,7 +1126,7 @@ class _TableWrapper (object):
         result = _ResultSet(self.path.uri, lambda ignore1, ignore2, ignore3: results)
         return result
 
-    def delete(self):
+    def delete(self) -> None:
         """Deletes the entity set referenced by the Table.
         """
         self.path.delete()
@@ -1133,7 +1135,7 @@ class _TableWrapper (object):
 class _TableAlias (_TableWrapper):
     """Represents a table alias in datapath expressions.
     """
-    def __init__(self, base_table, alias_name):
+    def __init__(self, base_table: "_TableWrapper", alias_name: str) -> None:
         """Initializes the table alias.
 
         :param base_table: the base table to be given an alias name
@@ -1150,11 +1152,11 @@ class _TableAlias (_TableWrapper):
         self._projection_name = self._instancename
         self._fromname = "%s:=%s" % (self._uname, self._base_table._fqname)
 
-    def __deepcopy__(self, memodict={}):
+    def __deepcopy__(self, memodict: dict = {}) -> "_TableAlias":
         # deep copy implementation of a table alias should not make copies of model objects (ie, the base table)
         return _TableAlias(self._base_table, self._name)
 
-    def _equivalent(self, alias):
+    def _equivalent(self, alias: "_TableAlias") -> bool:
         """Equivalence comparison between table aliases.
 
         :param alias: another table alias
@@ -1165,14 +1167,14 @@ class _TableAlias (_TableWrapper):
         return self._name == alias._name and self._base_table == alias._base_table
 
     @property
-    def path(self):
+    def path(self) -> "DataPath":
         """Returns the parent path for this alias.
         """
         if not self._parent:
             self._parent = DataPath(self)
         return self._parent
 
-    def _bind(self, parent_path):
+    def _bind(self, parent_path: "DataPath") -> None:
         """Binds this table instance to the given parent path."""
         if self._parent:
             raise ValueError("Cannot bind a table instance that has already been bound.")
@@ -1181,7 +1183,7 @@ class _TableAlias (_TableWrapper):
         self._parent = parent_path
 
     @property
-    def _contextualized_path(self):
+    def _contextualized_path(self) -> "DataPath":
         """Returns the path as contextualized for this table instance.
 
         Conditionally updates the context of the path to which this table instance is bound.
@@ -1193,10 +1195,10 @@ class _TableAlias (_TableWrapper):
 
     @property
     @deprecated
-    def uri(self):
+    def uri(self) -> str:
         return self.path._contextualized_uri(self)
 
-    def _query(self, mode='entity', projection=[], group_key=[], context=None):
+    def _query(self, mode: str = 'entity', projection: list = [], group_key: list = [], context: Optional["_TableAlias"] = None) -> "_ResultSet":
         """Overridden method to set context of query to this table instance."""
         return self.path._query(mode, projection, group_key=group_key, context=self)
 
@@ -1205,7 +1207,7 @@ class _ColumnWrapper (object):
     """Wraps a Column for datapath expressions.
     """
 
-    def __init__(self, table, column):
+    def __init__(self, table: "_TableWrapper", column: Any) -> None:
         """Creates a _ColumnWrapper object.
 
         :param table: the table to which this column belongs
@@ -1218,22 +1220,22 @@ class _ColumnWrapper (object):
         self._uname = urlquote(self._name)
 
     @property
-    def _fqname(self):
+    def _fqname(self) -> str:
         """Late binding needed for table alias instances."""
         return "%s:%s" % (self._table._fqname, self._uname)
 
     @property
-    def _instancename(self):
+    def _instancename(self) -> str:
         """Late binding needed for table alias instances."""
         return "%s:%s" % (self._table._uname, self._uname) if isinstance(self._table, _TableAlias) else self._uname
 
     @property
-    def _projection_name(self):
+    def _projection_name(self) -> str:
         """Late binding needed for table alias instances."""
         return self._instancename
 
     @deprecated
-    def describe(self):
+    def describe(self) -> str:
         """Provides a description of the model element.
 
         :return: a user-friendly string representation of the model element.
@@ -1242,18 +1244,18 @@ class _ColumnWrapper (object):
                (self._name, self._wrapped_column.type.typename, self._wrapped_column.comment)
 
     @deprecated
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         return self.describe()
 
     @property
-    def desc(self):
+    def desc(self) -> "_SortDescending":
         """A descending sort modifier based on this column."""
         return _SortDescending(self)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self._name
 
-    def eq(self, other):
+    def eq(self, other: Any) -> "_ComparisonPredicate":
         """Returns an 'equality' comparison predicate.
 
         :param other: `None` or any other literal value.
@@ -1266,7 +1268,7 @@ class _ColumnWrapper (object):
 
     __eq__ = eq
 
-    def ne(self, other):
+    def ne(self, other: Any) -> "_NegationPredicate":
         """Returns a 'not equal' comparison predicate.
 
         :param other: `None` or any other literal value.
@@ -1279,7 +1281,7 @@ class _ColumnWrapper (object):
 
     __ne__ = ne
 
-    def lt(self, other):
+    def lt(self, other: Any) -> "_ComparisonPredicate":
         """Returns a 'less than' comparison predicate.
 
         :param other: a literal value.
@@ -1289,7 +1291,7 @@ class _ColumnWrapper (object):
 
     __lt__ = lt
 
-    def le(self, other):
+    def le(self, other: Any) -> "_ComparisonPredicate":
         """Returns a 'less than or equal' comparison predicate.
 
         :param other: a literal value.
@@ -1299,7 +1301,7 @@ class _ColumnWrapper (object):
 
     __le__ = le
 
-    def gt(self, other):
+    def gt(self, other: Any) -> "_ComparisonPredicate":
         """Returns a 'greater than' comparison predicate.
 
         :param other: a literal value.
@@ -1309,7 +1311,7 @@ class _ColumnWrapper (object):
 
     __gt__ = gt
 
-    def ge(self, other):
+    def ge(self, other: Any) -> "_ComparisonPredicate":
         """Returns a 'greater than or equal' comparison predicate.
 
         :param other: a literal value.
@@ -1319,7 +1321,7 @@ class _ColumnWrapper (object):
 
     __ge__ = ge
 
-    def regexp(self, other):
+    def regexp(self, other: Any) -> "_ComparisonPredicate":
         """Returns a 'regular expression' comparison predicate.
 
         :param other: a _string_ literal value.
@@ -1327,7 +1329,7 @@ class _ColumnWrapper (object):
         """
         return _ComparisonPredicate(self, "::regexp::", other)
 
-    def ciregexp(self, other):
+    def ciregexp(self, other: Any) -> "_ComparisonPredicate":
         """Returns a 'case-insensitive regular expression' comparison predicate.
 
         :param other: a _string_ literal value.
@@ -1335,7 +1337,7 @@ class _ColumnWrapper (object):
         """
         return _ComparisonPredicate(self, "::ciregexp::", other)
 
-    def ts(self, other):
+    def ts(self, other: Any) -> "_ComparisonPredicate":
         """Returns a 'text search' comparison predicate.
 
         :param other: a _string_ literal value.
@@ -1343,7 +1345,7 @@ class _ColumnWrapper (object):
         """
         return _ComparisonPredicate(self, "::ts::", other)
 
-    def alias(self, name):
+    def alias(self, name: str) -> "_ColumnAlias":
         """Returns an alias for this column."""
         return _ColumnAlias(self, name)
 
@@ -1351,7 +1353,7 @@ class _ColumnWrapper (object):
 class _ColumnAlias (object):
     """Represents an (output) alias for a column instance in a datapath expression.
     """
-    def __init__(self, base_column, alias_name):
+    def __init__(self, base_column: "_ColumnWrapper", alias_name: str) -> None:
         """Initializes the column alias.
 
         :param base_column: the base column to be given an alias name
@@ -1364,16 +1366,16 @@ class _ColumnAlias (object):
         self._uname = urlquote(self._name)
 
     @property
-    def _projection_name(self):
+    def _projection_name(self) -> str:
         """Late binding needed for table alias instances."""
         return "%s:=%s" % (self._uname, self._base_column._instancename)
 
-    def __deepcopy__(self, memodict={}):
+    def __deepcopy__(self, memodict: dict = {}) -> "_ColumnAlias":
         # deep copy implementation of a column alias should not make copies of model objects (ie, the base column)
         return _ColumnAlias(self._base_column, self._name)
 
     @deprecated
-    def describe(self):
+    def describe(self) -> str:
         """Provides a description of the model element.
 
         :return: a user-friendly string representation of the model element.
@@ -1382,18 +1384,18 @@ class _ColumnAlias (object):
                (self._name, self._base_column.describe())
 
     @deprecated
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         return self.describe()
 
     @property
-    def desc(self):
+    def desc(self) -> "_SortDescending":
         """A descending sort modifier based on this column."""
         return _SortDescending(self)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self._name
 
-    def eq(self, other):
+    def eq(self, other: Any) -> "_ComparisonPredicate":
         """Returns an 'equality' comparison predicate.
 
         :param other: `None` or any other literal value.
@@ -1403,7 +1405,7 @@ class _ColumnAlias (object):
 
     __eq__ = eq
 
-    def ne(self, other):
+    def ne(self, other: Any) -> "_NegationPredicate":
         """Returns a 'not equal' comparison predicate.
 
         :param other: `None` or any other literal value.
@@ -1413,7 +1415,7 @@ class _ColumnAlias (object):
 
     __ne__ = ne
 
-    def lt(self, other):
+    def lt(self, other: Any) -> "_ComparisonPredicate":
         """Returns a 'less than' comparison predicate.
 
         :param other: a literal value.
@@ -1423,7 +1425,7 @@ class _ColumnAlias (object):
 
     __lt__ = lt
 
-    def le(self, other):
+    def le(self, other: Any) -> "_ComparisonPredicate":
         """Returns a 'less than or equal' comparison predicate.
 
         :param other: a literal value.
@@ -1433,7 +1435,7 @@ class _ColumnAlias (object):
 
     __le__ = le
 
-    def gt(self, other):
+    def gt(self, other: Any) -> "_ComparisonPredicate":
         """Returns a 'greater than' comparison predicate.
 
         :param other: a literal value.
@@ -1443,7 +1445,7 @@ class _ColumnAlias (object):
 
     __gt__ = gt
 
-    def ge(self, other):
+    def ge(self, other: Any) -> "_ComparisonPredicate":
         """Returns a 'greater than or equal' comparison predicate.
 
         :param other: a literal value.
@@ -1453,7 +1455,7 @@ class _ColumnAlias (object):
 
     __ge__ = ge
 
-    def regexp(self, other):
+    def regexp(self, other: Any) -> "_ComparisonPredicate":
         """Returns a 'regular expression' comparison predicate.
 
         :param other: a _string_ literal value.
@@ -1461,7 +1463,7 @@ class _ColumnAlias (object):
         """
         return self._base_column.regexp(other)
 
-    def ciregexp(self, other):
+    def ciregexp(self, other: Any) -> "_ComparisonPredicate":
         """Returns a 'case-insensitive regular expression' comparison predicate.
 
         :param other: a _string_ literal value.
@@ -1469,7 +1471,7 @@ class _ColumnAlias (object):
         """
         return self._base_column.ciregexp(other)
 
-    def ts(self, other):
+    def ts(self, other: Any) -> "_ComparisonPredicate":
         """Returns a 'text search' comparison predicate.
 
         :param other: a _string_ literal value.
@@ -1481,7 +1483,7 @@ class _ColumnAlias (object):
 class _SortDescending (object):
     """A descending sort condition."""
 
-    def __init__(self, attr):
+    def __init__(self, attr: Any) -> None:
         """Creates sort descending object.
 
         :param attr: a column, column alias, or aggrfn alias object
@@ -1492,29 +1494,29 @@ class _SortDescending (object):
 
 
 class _PathOperator (object):
-    def __init__(self, r):
+    def __init__(self, r: Any) -> None:
         assert isinstance(r, _PathOperator) or isinstance(r, _TableAlias)
         if isinstance(r, _Project):
             raise Exception("Cannot extend a path after an attribute projection")
         self._r = r
 
-    def __deepcopy__(self, memodict={}):
+    def __deepcopy__(self, memodict: dict = {}) -> "_PathOperator":
         return type(self)(copy.deepcopy(self._r, memo=memodict))
 
     @property
-    def _path(self):
+    def _path(self) -> str:
         assert isinstance(self._r, _PathOperator)
         return self._r._path
 
     @property
-    def _mode(self):
+    def _mode(self) -> str:
         assert isinstance(self._r, _PathOperator)
         return self._r._mode
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "/%s/%s" % (self._mode, self._path)
 
-    def rebase(self, base, root_context):
+    def rebase(self, base: "_PathOperator", root_context: "_TableAlias") -> "_PathOperator":
         """Rebases the current path expression to begin as a reset context following 'base'.
 
         :param base: a valid path expresion
@@ -1535,48 +1537,48 @@ class _PathOperator (object):
 
 
 class _Root (_PathOperator):
-    def __init__(self, r):
+    def __init__(self, r: "_TableAlias") -> None:
         super(_Root, self).__init__(r)
         assert isinstance(r, _TableAlias)
         self._table = r
 
     @property
-    def _path(self):
+    def _path(self) -> str:
         return self._table._fromname
 
     @property
-    def _mode(self):
+    def _mode(self) -> str:
         return 'entity'
 
 
 class _ResetContext (_PathOperator):
-    def __init__(self, r, alias):
+    def __init__(self, r: Any, alias: "_TableAlias") -> None:
         if isinstance(r, _ResetContext):
             r = r._r  # discard the previous context reset operator
         super(_ResetContext, self).__init__(r)
         assert isinstance(alias, _TableAlias)
         self._alias = alias
 
-    def __deepcopy__(self, memodict={}):
+    def __deepcopy__(self, memodict: dict = {}) -> "_ResetContext":
         return _ResetContext(copy.deepcopy(self._r, memo=memodict), copy.deepcopy(self._alias, memo=memodict))
 
     @property
-    def _path(self):
+    def _path(self) -> str:
         assert isinstance(self._r, _PathOperator)
         return "%s/$%s" % (self._r._path, self._alias._uname)
 
 
 class _Filter(_PathOperator):
-    def __init__(self, r, formula):
+    def __init__(self, r: Any, formula: "_Predicate") -> None:
         super(_Filter, self).__init__(r)
         assert isinstance(formula, _Predicate)
         self._formula = formula
 
-    def __deepcopy__(self, memodict={}):
+    def __deepcopy__(self, memodict: dict = {}) -> "_Filter":
         return _Filter(copy.deepcopy(self._r, memo=memodict), copy.deepcopy(self._formula, memo=memodict))
 
     @property
-    def _path(self):
+    def _path(self) -> str:
         assert isinstance(self._r, _PathOperator)
         return "%s/%s" % (self._r._path, str(self._formula))
 
@@ -1590,7 +1592,7 @@ class _Project (_PathOperator):
     ATTRGROUP = 'attributegroup'
     MODES = (ENTITY, ATTRIBUTE, AGGREGATE, ATTRGROUP)
 
-    def __init__(self, r, mode=ENTITY, projection=[], group_key=[]):
+    def __init__(self, r: Any, mode: str = ENTITY, projection: list = [], group_key: list = []) -> None:
         """Initializes the projection component.
 
         :param r: the parent path component.
@@ -1621,7 +1623,7 @@ class _Project (_PathOperator):
 
         self._projection = [obj._projection_name for obj in projection]
 
-    def __deepcopy__(self, memodict={}):
+    def __deepcopy__(self, memodict: dict = {}) -> "_Project":
         cp = super(_Project, self).__deepcopy__(memodict=memodict)
         cp._projection_mode = self._projection_mode
         cp._projection = copy.deepcopy(self._projection, memo=memodict)
@@ -1629,7 +1631,7 @@ class _Project (_PathOperator):
         return cp
 
     @property
-    def _path(self):
+    def _path(self) -> str:
         assert isinstance(self._r, _PathOperator)
         projection = ','.join(self._projection)
         if self._projection_mode == self.ATTRGROUP:
@@ -1640,12 +1642,12 @@ class _Project (_PathOperator):
             return "%s/%s" % (self._r._path, projection)
 
     @property
-    def _mode(self):
+    def _mode(self) -> str:
         return self._projection_mode
 
 
 class _Link (_PathOperator):
-    def __init__(self, r, on, as_=None, join_type=''):
+    def __init__(self, r: Any, on: Any, as_: Optional["_TableAlias"] = None, join_type: str = '') -> None:
         """Initialize the _Link operator
 
         :param r: parent path operator
@@ -1662,7 +1664,7 @@ class _Link (_PathOperator):
         self._as = as_
         self._join_type = join_type
 
-    def __deepcopy__(self, memodict={}):
+    def __deepcopy__(self, memodict: dict = {}) -> "_Link":
         return _Link(
             copy.deepcopy(self._r, memo=memodict),
             copy.deepcopy(self._on, memo=memodict),
@@ -1671,7 +1673,7 @@ class _Link (_PathOperator):
         )
 
     @property
-    def _path(self):
+    def _path(self) -> str:
         assert isinstance(self._r, _PathOperator)
         assign = '' if self._as is None else "%s:=" % self._as._uname
         if isinstance(self._on, _TableWrapper):
@@ -1688,7 +1690,7 @@ class _Link (_PathOperator):
 class _Predicate (object):
     """Common base class for all predicate types."""
 
-    def and_(self, other):
+    def and_(self, other: "_Predicate") -> "_ConjunctionPredicate":
         """Returns a conjunction predicate.
 
         :param other: a predicate object.
@@ -1700,7 +1702,7 @@ class _Predicate (object):
 
     __and__ = and_
 
-    def or_(self, other):
+    def or_(self, other: "_Predicate") -> "_DisjunctionPredicate":
         """Returns a disjunction predicate.
 
         :param other: a predicate object.
@@ -1712,7 +1714,7 @@ class _Predicate (object):
 
     __or__ = or_
 
-    def negate(self):
+    def negate(self) -> "_NegationPredicate":
         """Returns a negation predicate.
 
         This predicate is wrapped in a negation predicate which is returned to the caller.
@@ -1726,7 +1728,7 @@ class _Predicate (object):
 
 class _ComparisonPredicate (_Predicate):
     """Comparison (left-operand operator right-operand) predicate"""
-    def __init__(self, lop, op, rop):
+    def __init__(self, lop: "_ColumnWrapper", op: str, rop: Any) -> None:
         super(_ComparisonPredicate, self).__init__()
         assert isinstance(lop, _ColumnWrapper)
         assert isinstance(rop, _ColumnWrapper) or isinstance(rop, int) or \
@@ -1737,23 +1739,23 @@ class _ComparisonPredicate (_Predicate):
         self._op = op
         self._rop = rop
 
-    def __deepcopy__(self, memodict={}):
+    def __deepcopy__(self, memodict: dict = {}) -> "_ComparisonPredicate":
         # deep copy of predicate should not deep copy the model object references (i.e., _ColumnWrapper objects)
         return _ComparisonPredicate(self._lop, self._op, self._rop)
 
     @property
-    def is_equality(self):
+    def is_equality(self) -> bool:
         return self._op == '='
 
     @property
-    def left(self):
+    def left(self) -> "_ColumnWrapper":
         return self._lop
 
     @property
-    def right(self):
+    def right(self) -> Any:
         return self._rop
 
-    def __str__(self):
+    def __str__(self) -> str:
         if isinstance(self._rop, _ColumnWrapper):
             # The only valid circumstance for a _ColumnWrapper rop is in a link 'on' predicate for simple key/fkey joins
             return "(%s)=(%s)" % (self._lop._instancename, self._rop._fqname)
@@ -1767,7 +1769,7 @@ class _ComparisonPredicate (_Predicate):
 
 class _JunctionPredicate (_Predicate):
     """Junction (and/or) of child predicates."""
-    def __init__(self, op, operands):
+    def __init__(self, op: str, operands: list) -> None:
         super(_JunctionPredicate, self).__init__()
         assert operands and hasattr(operands, '__iter__') and len(operands) > 1
         assert all(isinstance(operand, _Predicate) for operand in operands)
@@ -1775,25 +1777,25 @@ class _JunctionPredicate (_Predicate):
         self._operands = operands
         self._op = op
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self._op.join(["(%s)" % operand for operand in self._operands])
 
 
 class _ConjunctionPredicate (_JunctionPredicate):
     """Conjunction (and) or child predicates."""
-    def __init__(self, operands):
+    def __init__(self, operands: list) -> None:
         super(_ConjunctionPredicate, self).__init__('&', operands)
 
-    def and_(self, other):
+    def and_(self, other: "_Predicate") -> "_ConjunctionPredicate":
         return _ConjunctionPredicate(self._operands + [other])
 
     @property
-    def is_valid_join_condition(self):
+    def is_valid_join_condition(self) -> bool:
         """Tests if this conjunction is a valid join condition."""
         return all(isinstance(o, _ComparisonPredicate) and o.is_equality for o in self._operands)
 
     @property
-    def as_join_condition(self):
+    def as_join_condition(self) -> str:
         """Returns the conjunction in the 'join condition' serialized format."""
         lhs = []
         rhs = []
@@ -1813,27 +1815,27 @@ class _ConjunctionPredicate (_JunctionPredicate):
 
 class _DisjunctionPredicate (_JunctionPredicate):
     """Disjunction (or) of child predicates."""
-    def __init__(self, operands):
+    def __init__(self, operands: list) -> None:
         super(_DisjunctionPredicate, self).__init__(';', operands)
 
-    def or_(self, other):
+    def or_(self, other: "_Predicate") -> "_DisjunctionPredicate":
         return _DisjunctionPredicate(self._operands + [other])
 
 
 class _NegationPredicate (_Predicate):
     """Negates the child predicate."""
-    def __init__(self, child):
+    def __init__(self, child: "_Predicate") -> None:
         super(_NegationPredicate, self).__init__()
         assert isinstance(child, _Predicate)
         self._child = child
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "!(%s)" % self._child
 
 
 class _Quantifier (object):
     """Base class of quantifiers."""
-    def __init__(self, quantifier_name, *args):
+    def __init__(self, quantifier_name: str, *args: Any) -> None:
         """Initializes the quantifier object.
 
         :param quantifier_name: name of the quantifier per ERMrest specification.
@@ -1843,25 +1845,25 @@ class _Quantifier (object):
         self._quantifier_name = quantifier_name
         self._args = args
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "%s(%s)" % (self._quantifier_name, ','.join([urlquote(str(arg)) for arg in self._args]))
 
 
 class All (_Quantifier):
     """Universal quantifier."""
-    def __init__(self, *args):
+    def __init__(self, *args: Any) -> None:
         super(All, self).__init__('all', *args)
 
 
 class Any (_Quantifier):
     """Existential quantifier."""
-    def __init__(self, *args):
+    def __init__(self, *args: Any) -> None:
         super(Any, self).__init__('any', *args)
 
 
 class AggregateFunction (object):
     """Base class of all aggregate functions."""
-    def __init__(self, fn_name, arg):
+    def __init__(self, fn_name: str, arg: _Any) -> None:
         """Initializes the aggregate function.
 
         :param fn_name: name of the function per ERMrest specification.
@@ -1871,69 +1873,69 @@ class AggregateFunction (object):
         self._fn_name = fn_name
         self._arg = arg
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "%s(%s)" % (self._fn_name, self._arg)
 
     @property
-    def _instancename(self):
+    def _instancename(self) -> str:
         return "%s(%s)" % (self._fn_name, self._arg._instancename)
 
-    def alias(self, alias_name):
+    def alias(self, alias_name: str) -> "_AggregateFunctionAlias":
         """Returns an (output) alias for this aggregate function instance."""
         return _AggregateFunctionAlias(self, alias_name)
 
 
 class Min (AggregateFunction):
     """Aggregate function for minimum non-NULL value."""
-    def __init__(self, arg):
+    def __init__(self, arg: _Any) -> None:
         super(Min, self).__init__('min', arg)
 
 
 class Max (AggregateFunction):
     """Aggregate function for maximum non-NULL value."""
-    def __init__(self, arg):
+    def __init__(self, arg: _Any) -> None:
         super(Max, self).__init__('max', arg)
 
 
 class Sum (AggregateFunction):
     """Aggregate function for sum of non-NULL values."""
-    def __init__(self, arg):
+    def __init__(self, arg: _Any) -> None:
         super(Sum, self).__init__('sum', arg)
 
 
 class Avg (AggregateFunction):
     """Aggregate function for average of non-NULL values."""
-    def __init__(self, arg):
+    def __init__(self, arg: _Any) -> None:
         super(Avg, self).__init__('avg', arg)
 
 
 class Cnt (AggregateFunction):
     """Aggregate function for count of non-NULL values."""
-    def __init__(self, arg):
+    def __init__(self, arg: _Any) -> None:
         super(Cnt, self).__init__('cnt', arg)
 
 
 class CntD (AggregateFunction):
     """Aggregate function for count of distinct non-NULL values."""
-    def __init__(self, arg):
+    def __init__(self, arg: _Any) -> None:
         super(CntD, self).__init__('cnt_d', arg)
 
 
 class Array (AggregateFunction):
     """Aggregate function for an array containing all values (including NULL)."""
-    def __init__(self, arg):
+    def __init__(self, arg: _Any) -> None:
         super(Array, self).__init__('array', arg)
 
 
 class ArrayD (AggregateFunction):
     """Aggregate function for an array containing distinct values (including NULL)."""
-    def __init__(self, arg):
+    def __init__(self, arg: _Any) -> None:
         super(ArrayD, self).__init__('array_d', arg)
 
 
 class Bin (AggregateFunction):
     """Binning function."""
-    def __init__(self, arg, nbins, minval=None, maxval=None):
+    def __init__(self, arg: _Any, nbins: int, minval: _Any = None, maxval: _Any = None) -> None:
         """Initialize the bin function.
 
         If `minval` or `maxval` are not given, they will be set based on the min and/or max values for the column
@@ -1951,17 +1953,17 @@ class Bin (AggregateFunction):
         self.minval = minval
         self.maxval = maxval
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "%s(%s;%s;%s;%s)" % (self._fn_name, self._arg, self.nbins, self.minval, self.maxval)
 
     @property
-    def _instancename(self):
+    def _instancename(self) -> str:
         return "%s(%s;%s;%s;%s)" % (self._fn_name, self._arg._instancename, self.nbins, self.minval, self.maxval)
 
 
 class _AggregateFunctionAlias (object):
     """Alias for aggregate functions."""
-    def __init__(self, fn, alias_name):
+    def __init__(self, fn: "AggregateFunction", alias_name: str) -> None:
         """Initializes the aggregate function alias.
 
         :param fn: aggregate function instance
@@ -1973,23 +1975,23 @@ class _AggregateFunctionAlias (object):
         self._name = alias_name
         self._uname = urlquote(self._name)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self._fn)
 
     @property
-    def _projection_name(self):
+    def _projection_name(self) -> str:
         """In a projection, the object uses this name."""
         return "%s:=%s" % (self._uname, self._fn._instancename)
 
     @property
-    def desc(self):
+    def desc(self) -> "_SortDescending":
         """A descending sort modifier based on this alias."""
         return _SortDescending(self)
 
 
 class _AttributeGroup (object):
     """A computed attribute group."""
-    def __init__(self, source, queryfn, keys):
+    def __init__(self, source: _Any, queryfn: Callable, keys: tuple) -> None:
         """Initializes an attribute group instance.
 
         :param source: the source object for the group (DataPath, _TableWrapper, _TableAlias)
@@ -2005,7 +2007,7 @@ class _AttributeGroup (object):
         self._queryfn = queryfn
         self._grouping_keys = list(keys)
 
-    def attributes(self, *attributes):
+    def attributes(self, *attributes: _Any) -> "_ResultSet":
         """Returns a results set of attributes projected and optionally renamed from this group.
 
         :param attributes: the columns, aliased columns, and/or aliased aggregate functions to be retrieved for this group.
@@ -2014,7 +2016,7 @@ class _AttributeGroup (object):
         self._resolve_binning_ranges()
         return self._queryfn(mode=_Project.ATTRGROUP, projection=list(attributes), group_key=self._grouping_keys)
 
-    def _resolve_binning_ranges(self):
+    def _resolve_binning_ranges(self) -> None:
         """Helper method to resolve any unspecified binning ranges."""
         for key in self._grouping_keys:
             if isinstance(key, _AggregateFunctionAlias) and isinstance(key._fn, Bin):
@@ -2035,7 +2037,7 @@ class _AttributeGroup (object):
 ## UTILITIES FOR DENORMALIZATION ##############################################
 ##
 
-def _datapath_left_outer_join_by_fkey(path, fk, alias_name=None):
+def _datapath_left_outer_join_by_fkey(path: "DataPath", fk: _Any, alias_name: Optional[str] = None) -> None:
     """Link a table to the path based on a foreign key reference.
 
     :param path: a DataPath object
@@ -2071,7 +2073,7 @@ def _datapath_left_outer_join_by_fkey(path, fk, alias_name=None):
     path.link(right.alias(alias_name) if alias_name else right, on=on, join_type='left')
 
 
-def _datapath_deserialize_vizcolumn(path, vizcol, sources=None):
+def _datapath_deserialize_vizcolumn(path: "DataPath", vizcol: _Any, sources: Optional[dict] = None) -> _Any:
     """Deserializes a visual column specification.
 
     If the visible column specifies a foreign key path, the datapath object
@@ -2161,7 +2163,7 @@ def _datapath_deserialize_vizcolumn(path, vizcol, sources=None):
         raise ValueError('Malformed visible column: %s' % str(vizcol))
 
 
-def _datapath_contextualize(path, context_name='*', context_body=None, groupkey_name='RID'):
+def _datapath_contextualize(path: "DataPath", context_name: str = '*', context_body: Optional[list] = None, groupkey_name: str = 'RID') -> _Any:
     """Contextualizes a data path to a named visible columns context.
 
     :param path: a datapath object
@@ -2188,7 +2190,7 @@ def _datapath_contextualize(path, context_name='*', context_body=None, groupkey_
         except ValueError as e:
             logger.warning(str(e))
 
-    def not_same_as_group_key(x):
+    def not_same_as_group_key(x: _Any) -> bool:
         assert isinstance(groupkey, _ColumnWrapper)
         if not isinstance(x, _ColumnWrapper):
             return True
@@ -2199,7 +2201,7 @@ def _datapath_contextualize(path, context_name='*', context_body=None, groupkey_
     return query
 
 
-def _datapath_generate_simple_denormalization(path, include_whole_entities=False):
+def _datapath_generate_simple_denormalization(path: "DataPath", include_whole_entities: bool = False) -> list:
     """Generates a denormalized form of the table expressed in a visible columns specification.
 
     :param path: a datapath object
@@ -2216,7 +2218,7 @@ def _datapath_generate_simple_denormalization(path, include_whole_entities=False
         for fkey in table.foreign_keys if len(fkey.foreign_key_columns) == 1
     }
 
-    def _fkey_to_vizcol(name, fk, inbound=None):
+    def _fkey_to_vizcol(name: _Any, fk: _Any, inbound: _Any = None) -> dict:
         # name columns to look for in related tables
         name_candidates = [
             'displayname',
@@ -2275,15 +2277,15 @@ def _datapath_generate_simple_denormalization(path, include_whole_entities=False
 
     return vizcols
 
-def simple_denormalization(path):
+def simple_denormalization(path: "DataPath") -> list:
     """A simple heuristic denormalization."""
     return _datapath_generate_simple_denormalization(path)
 
-def simple_denormalization_with_whole_entities(path):
+def simple_denormalization_with_whole_entities(path: "DataPath") -> list:
     """A simple heuristic denormalization with related and associated entities."""
     return _datapath_generate_simple_denormalization(path, include_whole_entities=True)
 
-def _datapath_denormalize(path, context_name=None, heuristic=None, groupkey_name='RID'):
+def _datapath_denormalize(path: "DataPath", context_name: Optional[str] = None, heuristic: Optional[Callable] = None, groupkey_name: str = 'RID') -> _Any:
     """Denormalizes a path based on annotations or heuristics.
 
     :param path: a DataPath object


### PR DESCRIPTION
## Summary

Adds type annotations to `deriva/core/datapath.py` — the query-building API (DataPath, table/column/schema wrappers, predicates, aggregates, link/join builders, result-set and fetch helpers) — plus supporting `typing` imports.

**Annotations only. No behavior change.** Verified mechanically: after stripping all annotations and docstrings, the module's executable code is byte-identical to the base (`2.0-dev`); the sole residuals are the new `typing` imports.

Implementation note: the module defines a class named `Any` (a query quantifier) that shadows `typing.Any`. For functions defined after that class, annotations use an aliased `typing.Any` import so they still refer to the typing construct, not the quantifier class. Many builder/wrapper methods that accept heterogeneous operands (column refs, scalars, predicates, model objects) are annotated `Any` rather than over-narrowing — behavior preservation took priority over annotation precision.

Part of a per-module type-hint series into `2.0-dev` (follows #278 ermrest_model, #279 deriva_binding, #280 ermrest_catalog).

## Test plan
- [x] `tests/deriva/core` (datapath tests skip without a live ERMrest host, as on baseline).
- [x] Module imports cleanly.
- [x] AST comparison vs base confirms annotations-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)