### PR TITLE
fix(bag): mirror drops N>=2 asset rows when a nullable unique column is all-NULL (#285)

### DIFF
--- a/deriva/bag/loader.py
+++ b/deriva/bag/loader.py
@@ -538,6 +538,29 @@ class SQLiteSink:
             )
             return 0
 
+        # Coerce empty strings on nullable columns to real NULLs
+        # before the mirror insert — the write-side twin of
+        # ``BagCatalogLoader._coerce_empty_to_null``. Bag CSVs
+        # serialize NULL as ``""`` (CSV has no NULL sentinel), and
+        # SQLite — unlike ERMrest/Postgres — treats ``""`` as a
+        # comparable value in unique indexes. A unique key over a
+        # column that is NULL in every source row (e.g. an optional
+        # ``Image_ID`` on an asset table) would otherwise collide on
+        # ``""`` from the second row on, and the ``ignore``
+        # conflict policy would silently drop those rows — the
+        # loader then never sees them, and child rows that FK-
+        # reference the dropped rows fail at the destination with
+        # an FK violation (issue #285).
+        nullable_cols = {c.name for c in table.columns if c.nullok}
+        if nullable_cols:
+            rows = [
+                {
+                    k: (None if k in nullable_cols and v == "" else v)
+                    for k, v in row.items()
+                }
+                for row in rows
+            ]
+
         try:
             if self.on_conflict == "ignore":
                 stmt = sqlite_insert(sql_table).on_conflict_do_nothing()
@@ -562,8 +585,32 @@ class SQLiteSink:
                 stmt = sql_table.insert()
 
             with self.orm.engine.begin() as conn:
-                conn.execute(stmt, rows)
-            return len(rows)
+                result = conn.execute(stmt, rows)
+            # Report the number of rows that actually landed, per the
+            # ``Sink`` protocol contract. With ``on_conflict="ignore"``
+            # SQLite silently skips conflicting rows; returning
+            # ``len(rows)`` here would hide the drop from every
+            # downstream count. A drop is legal but must be LOUD —
+            # a silently thinner mirror is exactly how issue #285
+            # stayed invisible (child tables kept FK-referencing rows
+            # the mirror had dropped).
+            rowcount = result.rowcount
+            inserted = (
+                rowcount if rowcount is not None and rowcount >= 0
+                else len(rows)
+            )
+            if inserted < len(rows):
+                logger.warning(
+                    "Sink: %d of %d rows for %s.%s were dropped by the "
+                    "mirror's ON CONFLICT policy (duplicate primary/unique "
+                    "key values). Child rows referencing the dropped rows "
+                    "will fail at load time.",
+                    len(rows) - inserted,
+                    len(rows),
+                    table.schema.name,
+                    table.name,
+                )
+            return inserted
         except IntegrityError as e:
             # FK / unique constraint violations are the conflict
             # case the ``on_conflict`` knob is supposed to handle.

--- a/tests/deriva/bag/test_catalog_loader.py
+++ b/tests/deriva/bag/test_catalog_loader.py
@@ -2364,3 +2364,194 @@ def test_rewrite_fks_returns_row_unchanged_for_composite_fk(
         assert out is not row
     finally:
         loader.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Issue #285 — mirror must not drop rows whose nullable unique-keyed column
+# is NULL ('' in the bag CSV)
+# ---------------------------------------------------------------------------
+
+
+def _build_null_unique_asset_bag(tmp_path: Path) -> Path:
+    """Bag whose asset table carries a nullable, uniquely-keyed column
+    (``Image_ID``) that is NULL (serialized ``""``) in every row.
+
+    Mirrors the eye-ai ``Image`` shape from issue #285: SQLite treats
+    ``""`` as a comparable value in unique indexes (unlike
+    ERMrest/Postgres, where NULLs never collide), so without the
+    sink-side empty-string coercion the mirror silently drops every
+    Image row after the first and child rows FK-reference rows the
+    loader never saw.
+    """
+    bag = tmp_path / "null_unique_bag" / "bag"
+    (bag / "data" / "demo").mkdir(parents=True)
+
+    doc = {
+        "snaptime": "2026-01-01T00:00:00",
+        "schemas": {
+            "demo": {
+                "schema_name": "demo",
+                "tables": {
+                    "Image": {
+                        "schema_name": "demo",
+                        "table_name": "Image",
+                        "kind": "table",
+                        "column_definitions": [
+                            {
+                                "name": "RID",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "URL",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "Image_ID",
+                                "type": {"typename": "text"},
+                                "nullok": True,
+                                "default": None,
+                                "comment": None,
+                            },
+                        ],
+                        "keys": [
+                            {
+                                "names": [["demo", "Image_RID_key"]],
+                                "unique_columns": ["RID"],
+                            },
+                            {
+                                "names": [["demo", "Image_URL_key"]],
+                                "unique_columns": ["URL"],
+                            },
+                            {
+                                "names": [["demo", "Image_Image_ID_key"]],
+                                "unique_columns": ["Image_ID"],
+                            },
+                        ],
+                        "foreign_keys": [],
+                    },
+                    "Widget": {
+                        "schema_name": "demo",
+                        "table_name": "Widget",
+                        "kind": "table",
+                        "column_definitions": [
+                            {
+                                "name": "RID",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "Image",
+                                "type": {"typename": "text"},
+                                "nullok": True,
+                                "default": None,
+                                "comment": None,
+                            },
+                        ],
+                        "keys": [
+                            {
+                                "names": [["demo", "Widget_RID_key"]],
+                                "unique_columns": ["RID"],
+                            }
+                        ],
+                        "foreign_keys": [
+                            {
+                                "names": [["demo", "Widget_Image_fkey"]],
+                                "foreign_key_columns": [
+                                    {
+                                        "schema_name": "demo",
+                                        "table_name": "Widget",
+                                        "column_name": "Image",
+                                    }
+                                ],
+                                "referenced_columns": [
+                                    {
+                                        "schema_name": "demo",
+                                        "table_name": "Image",
+                                        "column_name": "RID",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                },
+            }
+        },
+    }
+    (bag / "data" / "schema.json").write_text(json.dumps(doc))
+    with (bag / "data" / "demo" / "Image.csv").open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["RID", "URL", "Image_ID"])
+        # Image_ID is NULL ('') in BOTH rows — the #285 trigger.
+        w.writerow(["I-SRC-A", "/hatrac/demo/abc.a.png", ""])
+        w.writerow(["I-SRC-B", "/hatrac/demo/def.b.png", ""])
+    with (bag / "data" / "demo" / "Widget.csv").open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["RID", "Image"])
+        w.writerow(["W1", "I-SRC-A"])
+        w.writerow(["W2", "I-SRC-B"])
+    return bag
+
+
+def test_mirror_keeps_rows_with_all_null_unique_column(tmp_path: Path) -> None:
+    """REGRESSION (#285): N>=2 rows whose uniquely-keyed nullable column is
+    NULL in every row must all survive the mirror, populate the remap, and
+    have child FK references rewritten.
+
+    Before the sink-side empty-string coercion, the mirror's unique index
+    on ``Image_ID`` collided on ``""`` and ``ON CONFLICT DO NOTHING``
+    silently dropped every Image row after the first: the loader loaded 1
+    of N images, the remap had a single entry, and child rows referencing
+    the dropped images failed at the destination with an FK violation.
+    """
+    bag = _build_null_unique_asset_bag(tmp_path)
+    catalog = _mock_catalog()
+
+    image_tw = _pb_table(catalog, "demo", "Image")
+    # One image already exists at the destination by URL — the exact
+    # remap-required shape from the issue's bisect (a re-run after a
+    # prior partially-failed commit).
+    image_tw.attributes.return_value.fetch.return_value = [
+        {"URL": "/hatrac/demo/abc.a.png", "RID": "I-DST-A"},
+    ]
+    _stub_insert_result(image_tw, [{"RID": "I-SRC-B"}])
+
+    widget_tw = _pb_table(catalog, "demo", "Widget")
+    _stub_insert_result(widget_tw, [{"RID": "W1"}, {"RID": "W2"}])
+
+    loader = BagCatalogLoader(
+        catalog=catalog,
+        bag=bag,
+        policy=FKTraversalPolicy(
+            asset_mode=AssetMode.ROWS_ONLY,
+            match_by_columns={("demo", "Image"): ["URL"]},
+        ),
+        database_dir=tmp_path / "db",
+    )
+    try:
+        report = loader.run()
+    finally:
+        loader.dispose()
+
+    # BOTH images made it through the mirror: one matched, one inserted.
+    image_stats = report.table_stats["demo.Image"]
+    assert image_stats.rows_matched_by_columns == 1
+    assert image_stats.rows_inserted == 1
+
+    # The remap is complete — this is what breaks under #285 (only the
+    # first row survived, so the second entry was missing).
+    remap = loader._rid_remap[("demo", "Image")]
+    assert remap == {"I-SRC-A": "I-DST-A", "I-SRC-B": "I-SRC-B"}
+
+    # Child FK references rewritten through the complete remap.
+    widget_rows = widget_tw.insert.call_args.args[0]
+    by_rid = {r["RID"]: r for r in widget_rows}
+    assert by_rid["W1"]["Image"] == "I-DST-A"
+    assert by_rid["W2"]["Image"] == "I-SRC-B"


### PR DESCRIPTION
## Summary

Fixes #285 — the multi-asset commit failure (`409 ... Key (Image)=(7-B6VT) is not present in table "Image"` on the association insert).

## Root cause (not where the issue guessed)

The issue hypothesized a gap in the loader's RID-remap bookkeeping. The remap logic is actually correct — the defect is **upstream, in the bag's SQLite mirror**:

1. Bag CSVs serialize NULL as `""` (CSV has no NULL sentinel).
2. SQLite — unlike ERMrest/Postgres — treats `""` as a comparable value in **unique indexes**.
3. `eye-ai.Image` has a unique key on `Image_ID`, which is NULL in every committed row. In the mirror, row 2..N collide with row 1 on `""`.
4. `SQLiteSink`'s `on_conflict="ignore"` (`ON CONFLICT DO NOTHING`) **silently dropped** every Image row after the first — and `write_rows` returned `len(rows)` regardless, so no count anywhere showed the loss.
5. The loader then saw 1 of N images (remap had one entry); the association tables (whose composite keys don't collide) loaded fully and FK-referenced images the destination never received → the FK violation. **N=1 can never collide — exactly the issue's bisect.**

Diagnosed by running the loader against the *actual failing bag* from the repro (execution `7-B6V0`, 5 images): `bag_db.get_table_contents("Image")` returned **1 row of 5**.

## Fix (`SQLiteSink.write_rows`)

- **Coerce `""` → NULL on nullable columns before the mirror insert** — the write-side twin of `BagCatalogLoader._coerce_empty_to_null`. NULLs are distinct in SQLite unique indexes (matching ERMrest semantics), so all-NULL unique columns no longer collide. The unique constraints themselves stay: they're load-bearing for the schema.json round-trip.
- **Return the true inserted count** (`result.rowcount`) per the `Sink` protocol contract, and **log a WARNING when the ON CONFLICT policy drops rows** — the silent thinning of the mirror is what made this failure so hard to localize.

## Verification

- **Real failing bag** (`7-B6V0`): pre-fix → mirror returns 1/5 Image rows, associations carry the un-remapped lease RID (`7-B6VT`). Post-fix → all 5 rows load, the URL-matched row remaps (`7-B6VT → <dest RID>`), both `Image_Asset_Type` and `Image_Execution` payloads reference valid destination RIDs.
- **New regression test** (`test_mirror_keeps_rows_with_all_null_unique_column`): N=2 assets with an all-NULL uniquely-keyed column + child FK rows, one asset URL-matched at the destination (the re-run shape from the bisect). Fails with the exact #285 signature on unfixed code; passes with the fix.
- Full suite: 507 passed, 190 skipped, 0 failed.

## Note for deriva-ml#357

The deriva-ml build side is confirmed clean (the built bag is internally consistent) — this loader fix resolves the whole failure chain, so deriva-ml#357 can close as a duplicate of #285 once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)