### PR TITLE
fix(bag): mirror conflicts fail loudly except legitimate PK dedup

### DIFF
--- a/deriva/bag/loader.py
+++ b/deriva/bag/loader.py
@@ -483,9 +483,10 @@ class Sink(Protocol):
         """Write a batch of rows for ``table``. Return how many landed.
 
         The sink may legitimately drop rows (e.g., SQLiteSink with
-        ``on_conflict="ignore"`` drops PK collisions). The return
-        value is the number of rows the sink wrote, not the number
-        it was given.
+        ``on_conflict="ignore"`` dedups primary-key collisions from
+        multi-path emission). The return value is the number of rows
+        the sink wrote, not the number it was given. Anything that
+        would lose *distinct* data must raise rather than drop.
         """
         ...
 
@@ -501,10 +502,15 @@ class SQLiteSink:
     Args:
         orm: A :class:`SchemaORM` from
             :class:`~deriva.bag.schema.SchemaBuilder`.
-        on_conflict: How to handle PK collisions during insert.
-            One of ``"ignore"`` (skip the conflicting row),
-            ``"replace"`` (upsert non-PK columns), or ``"error"``
-            (raise).
+        on_conflict: How to handle **primary-key** collisions during
+            insert. One of ``"ignore"`` (skip the conflicting row —
+            the multi-path-emission dedup), ``"replace"`` (upsert
+            non-PK columns), or ``"error"`` (raise). Collisions on
+            any *other* unique constraint, and FK violations, always
+            raise ``IntegrityError`` regardless of this setting —
+            those mean the mirror would silently end up thinner than
+            the bag (issue #285's failure mode), so they abort the
+            load loudly rather than dropping data.
     """
 
     def __init__(
@@ -563,7 +569,25 @@ class SQLiteSink:
 
         try:
             if self.on_conflict == "ignore":
-                stmt = sqlite_insert(sql_table).on_conflict_do_nothing()
+                # Scope the DO NOTHING to the *primary key* only. The
+                # legitimate dedup case is the same row arriving twice
+                # via multi-path emission (identical RID); dropping
+                # those is by design. A collision on any OTHER unique
+                # constraint is data loss — before this was scoped, a
+                # non-PK unique collision was silently absorbed and the
+                # mirror shipped fewer rows than the bag carried
+                # (issue #285's failure mode). Non-PK collisions now
+                # raise IntegrityError and abort the load loudly.
+                pk_cols = [c.name for c in sql_table.primary_key.columns]
+                if pk_cols:
+                    stmt = sqlite_insert(sql_table).on_conflict_do_nothing(
+                        index_elements=pk_cols
+                    )
+                else:
+                    # No PK on the mirror table → there is no
+                    # legitimate dedup; insert plainly so any
+                    # conflict raises.
+                    stmt = sql_table.insert()
             elif self.on_conflict == "replace":
                 # Derive the conflict-key column set from the actual
                 # primary-key definition rather than hard-coding
@@ -600,11 +624,15 @@ class SQLiteSink:
                 else len(rows)
             )
             if inserted < len(rows):
-                logger.warning(
-                    "Sink: %d of %d rows for %s.%s were dropped by the "
-                    "mirror's ON CONFLICT policy (duplicate primary/unique "
-                    "key values). Child rows referencing the dropped rows "
-                    "will fail at load time.",
+                # With the ON CONFLICT clause scoped to the primary
+                # key, a dropped row means the same RID arrived more
+                # than once (multi-path emission) — the row already
+                # landed, so child FK references still resolve. This
+                # is expected dedup, not data loss; anything that IS
+                # data loss raises IntegrityError below instead.
+                logger.info(
+                    "Sink: deduplicated %d of %d rows for %s.%s by "
+                    "primary key (same row emitted via multiple paths).",
                     len(rows) - inserted,
                     len(rows),
                     table.schema.name,
@@ -612,19 +640,21 @@ class SQLiteSink:
                 )
             return inserted
         except IntegrityError as e:
-            # FK / unique constraint violations are the conflict
-            # case the ``on_conflict`` knob is supposed to handle.
-            # For ``ignore`` and ``replace`` the SQLite-side ON
-            # CONFLICT clause already absorbs them, so reaching this
-            # branch means the conflict was something the clause
-            # didn't catch (e.g. an FK violation, which ON CONFLICT
-            # doesn't suppress). Log and surface per the policy.
+            # Reaching this branch means the conflict was something
+            # the PK-scoped ON CONFLICT clause didn't absorb: a
+            # non-PK unique-constraint collision (duplicate business
+            # key in the bag) or an FK violation. Either way the
+            # mirror would end up thinner than the bag — silently
+            # returning 0 here is exactly the failure mode that made
+            # issue #285 so hard to localize (the loss only surfaced
+            # much later as an FK 409 at the destination). Data loss
+            # aborts the load, loudly, for every on_conflict mode.
             logger.error(
-                f"Sink: integrity error inserting into {sql_table.name}: {e}"
+                f"Sink: integrity error inserting into {sql_table.name} "
+                f"— the bag's rows conflict with the mirror's "
+                f"constraints and would be lost: {e}"
             )
-            if self.on_conflict == "error":
-                raise
-            return 0
+            raise
 
 
 class CSVSink:

--- a/tests/deriva/bag/test_catalog_loader.py
+++ b/tests/deriva/bag/test_catalog_loader.py
@@ -2555,3 +2555,121 @@ def test_mirror_keeps_rows_with_all_null_unique_column(tmp_path: Path) -> None:
     by_rid = {r["RID"]: r for r in widget_rows}
     assert by_rid["W1"]["Image"] == "I-DST-A"
     assert by_rid["W2"]["Image"] == "I-SRC-B"
+
+
+def _build_dup_url_bag(tmp_path: Path) -> Path:
+    """Bag whose Image table has TWO rows with the same (uniquely-keyed)
+    ``URL`` — genuinely duplicate business keys, i.e. real data loss if
+    the mirror deduped them silently."""
+    bag = tmp_path / "dup_url_bag" / "bag"
+    (bag / "data" / "demo").mkdir(parents=True)
+    doc = {
+        "snaptime": "2026-01-01T00:00:00",
+        "schemas": {
+            "demo": {
+                "schema_name": "demo",
+                "tables": {
+                    "Image": {
+                        "schema_name": "demo",
+                        "table_name": "Image",
+                        "kind": "table",
+                        "column_definitions": [
+                            {
+                                "name": "RID",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                            {
+                                "name": "URL",
+                                "type": {"typename": "text"},
+                                "nullok": False,
+                                "default": None,
+                                "comment": None,
+                            },
+                        ],
+                        "keys": [
+                            {
+                                "names": [["demo", "Image_RID_key"]],
+                                "unique_columns": ["RID"],
+                            },
+                            {
+                                "names": [["demo", "Image_URL_key"]],
+                                "unique_columns": ["URL"],
+                            },
+                        ],
+                        "foreign_keys": [],
+                    },
+                },
+            }
+        },
+    }
+    (bag / "data" / "schema.json").write_text(json.dumps(doc))
+    with (bag / "data" / "demo" / "Image.csv").open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["RID", "URL"])
+        w.writerow(["I-SRC-A", "/hatrac/demo/same.png"])
+        w.writerow(["I-SRC-B", "/hatrac/demo/same.png"])  # duplicate URL
+    return bag
+
+
+def test_mirror_raises_on_non_pk_unique_collision(tmp_path: Path) -> None:
+    """A collision on a NON-PK unique constraint (duplicate business key)
+    must abort the load loudly, not silently thin the mirror.
+
+    Before the ON CONFLICT clause was scoped to the primary key, the
+    ``ignore`` policy absorbed this collision and shipped one row fewer
+    than the bag carried — the silent-loss failure mode behind #285.
+    """
+    bag = _build_dup_url_bag(tmp_path)
+    catalog = _mock_catalog()
+
+    with pytest.raises(Exception) as excinfo:
+        loader = BagCatalogLoader(
+            catalog=catalog,
+            bag=bag,
+            policy=FKTraversalPolicy(asset_mode=AssetMode.ROWS_ONLY),
+            database_dir=tmp_path / "db",
+        )
+        try:
+            loader.run()
+        finally:
+            loader.dispose()
+    assert "IntegrityError" in type(excinfo.value).__name__ or "unique" in str(
+        excinfo.value
+    ).lower(), f"expected a unique-constraint failure, got: {excinfo.value!r}"
+
+
+def test_mirror_still_dedups_pk_duplicates_silently(tmp_path: Path) -> None:
+    """The legitimate multi-path-emission dedup (same RID arriving twice)
+    still works: no raise, row counted once, loader proceeds."""
+    bag = _build_dup_url_bag(tmp_path)
+    # Rewrite the CSV: same RID twice (identical row) with DISTINCT URLs
+    # is impossible for one RID — the multi-path case is the *same row*
+    # twice, so duplicate the whole row verbatim.
+    with (bag / "data" / "demo" / "Image.csv").open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["RID", "URL"])
+        w.writerow(["I-SRC-A", "/hatrac/demo/a.png"])
+        w.writerow(["I-SRC-A", "/hatrac/demo/a.png"])  # same row, twice
+
+    catalog = _mock_catalog()
+    image_tw = _pb_table(catalog, "demo", "Image")
+    image_tw.attributes.return_value.fetch.return_value = []
+    _stub_insert_result(image_tw, [{"RID": "I-SRC-A"}])
+
+    loader = BagCatalogLoader(
+        catalog=catalog,
+        bag=bag,
+        policy=FKTraversalPolicy(asset_mode=AssetMode.ROWS_ONLY),
+        database_dir=tmp_path / "db",
+    )
+    try:
+        report = loader.run()
+    finally:
+        loader.dispose()
+
+    # One logical row made it through the mirror and to the destination.
+    image_stats = report.table_stats["demo.Image"]
+    assert image_stats.rows_inserted == 1


### PR DESCRIPTION
## Summary

Follow-up to #286 (issue #285), per review feedback: **silent failure is not acceptable** — a WARNING in a log is still effectively silent. This makes every data-losing mirror conflict abort the load loudly, while preserving the one legitimate drop.

## Changes (`SQLiteSink.write_rows`)

1. **`ON CONFLICT DO NOTHING` is now scoped to the primary key.** The only legitimate drop is multi-path-emission dedup — the *same row* (same RID) arriving via two FK routes. A collision on any **other** unique constraint (a genuinely duplicate business key) now raises `IntegrityError` and aborts the load, instead of silently shipping a mirror thinner than the bag (#285's failure mode).
2. **The `IntegrityError` handler always raises.** Previously it logged and returned 0 for `ignore`/`replace` modes — swallowing entire failed batches. Data loss now aborts for every `on_conflict` mode.
3. The drop log is downgraded to INFO and reworded: with the PK-scoped clause, a dropped row means that RID already landed — child FK references still resolve. Expected dedup, not loss.

## Why the PK carve-out is safe

The multi-path dedup is load-bearing (CatalogBagBuilder emits one query processor per FK route; the same row can arrive twice). Scoping the ignore to the PK keeps that working; everything else fails fast. A duplicate business key would 409 at the destination anyway — failing at the mirror with a clear message is strictly earlier and clearer.

## Tests

- `test_mirror_raises_on_non_pk_unique_collision` — duplicate `URL` (unique key) across two rows aborts the load.
- `test_mirror_still_dedups_pk_duplicates_silently` — the same row emitted twice dedups to one insert, no raise.
- Full suite: 509 passed, 190 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)